### PR TITLE
fix(validation): handle filenames with spaces and fix false positive secrets

### DIFF
--- a/scripts/validate-codes.sh
+++ b/scripts/validate-codes.sh
@@ -49,10 +49,10 @@ echo ""
 # Gate 2: Check for hardcoded secrets
 echo "Gate 2: Secret Detection"
 SECRETS_FOUND=0
-if grep -r "ghp_" --include="*.ts" --include="*.js" --include="*.json" . 2>/dev/null | grep -v "node_modules" | grep -v ".git"; then
+if grep -rE "ghp_[a-zA-Z0-9]{36,}" --include="*.ts" --include="*.js" --include="*.json" . 2>/dev/null | grep -v "node_modules" | grep -v ".git"; then
     SECRETS_FOUND=1
 fi
-if grep -r "sk-" --include="*.ts" --include="*.js" --include="*.json" . 2>/dev/null | grep -v "node_modules" | grep -v ".git" | grep -v ".agents/skills"; then
+if grep -rE "sk-[a-zA-Z0-9]{20,}" --include="*.ts" --include="*.js" --include="*.json" . 2>/dev/null | grep -v "node_modules" | grep -v ".git" | grep -v ".agents/skills"; then
     SECRETS_FOUND=1
 fi
 if [ $SECRETS_FOUND -eq 0 ]; then
@@ -109,12 +109,12 @@ echo ""
 # Gate 5: Validate JSON files
 echo "Gate 5: JSON Validity"
 INVALID_JSON=0
-for file in $(find . -name "*.json" -not -path "./node_modules/*" -not -path "./.git/*"); do
+while IFS= read -r file; do
     if ! jq empty "$file" 2>/dev/null; then
         print_status 1 "Invalid JSON: $file"
         INVALID_JSON=1
     fi
-done
+done < <(find . -name "*.json" -not -path "./node_modules/*" -not -path "./.git/*")
 if [ $INVALID_JSON -eq 0 ]; then
     print_status 0 "All JSON files are valid"
 fi

--- a/temp/state.json
+++ b/temp/state.json
@@ -51,12 +51,13 @@
     ]
   },
   "repository": {
-    "local_head": "b7f012c",
-    "remote_head": "b7f012c",
+    "local_head": "64bb368",
+    "remote_head": "64bb368",
     "synced": true,
     "branch": "main",
     "commits_ahead": 0,
-    "working_tree": "clean"
+    "working_tree": "clean",
+    "note": "Phase 7 changes pushed - validation script fixes deployed"
   },
   "active_agents": [],
   "blockers": [


### PR DESCRIPTION
Fixes two bugs in the validation script:

1. **JSON validation with spaces**: Files with spaces in names (like 'Main Branch Protection.json') were being split incorrectly by the for-loop
   - Changed from \`for file in $(find...)\` to \`while IFS= read -r file\` pattern

2. **False positive secret detection**: 'task-decomposition' was matched as a secret because it contains 'sk-'
   - Changed from generic 'sk-' pattern to 'sk-[a-zA-Z0-9]{20,}' for actual secret keys
   - Same fix applied to 'ghp_' pattern for more precision

Both fixes now allow validation to pass completely.