### PR TITLE
Add TTL-backed validation cache and D1 dedup index

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,6 @@
       "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
-        "agent-browser": "^0.23.4",
-        "discord.js": "^14.26.0",
-        "telegraf": "^4.16.3",
         "zod": "^3.22.4"
       },
       "devDependencies": {
@@ -2323,176 +2320,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@discordjs/builders": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.14.1.tgz",
-      "integrity": "sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@discordjs/formatters": "^0.6.2",
-        "@discordjs/util": "^1.2.0",
-        "@sapphire/shapeshift": "^4.0.0",
-        "discord-api-types": "^0.38.40",
-        "fast-deep-equal": "^3.1.3",
-        "ts-mixer": "^6.0.4",
-        "tslib": "^2.6.3"
-      },
-      "engines": {
-        "node": ">=16.11.0"
-      },
-      "funding": {
-        "url": "https://github.com/discordjs/discord.js?sponsor"
-      }
-    },
-    "node_modules/@discordjs/collection": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
-      "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=16.11.0"
-      }
-    },
-    "node_modules/@discordjs/formatters": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.2.tgz",
-      "integrity": "sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "discord-api-types": "^0.38.33"
-      },
-      "engines": {
-        "node": ">=16.11.0"
-      },
-      "funding": {
-        "url": "https://github.com/discordjs/discord.js?sponsor"
-      }
-    },
-    "node_modules/@discordjs/rest": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.1.tgz",
-      "integrity": "sha512-wwQdgjeaoYFiaG+atbqx6aJDpqW7JHAo0HrQkBTbYzM3/PJ3GweQIpgElNcGZ26DCUOXMyawYd0YF7vtr+fZXg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@discordjs/collection": "^2.1.1",
-        "@discordjs/util": "^1.2.0",
-        "@sapphire/async-queue": "^1.5.3",
-        "@sapphire/snowflake": "^3.5.5",
-        "@vladfrangu/async_event_emitter": "^2.4.6",
-        "discord-api-types": "^0.38.40",
-        "magic-bytes.js": "^1.13.0",
-        "tslib": "^2.6.3",
-        "undici": "6.24.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/discordjs/discord.js?sponsor"
-      }
-    },
-    "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
-      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/discordjs/discord.js?sponsor"
-      }
-    },
-    "node_modules/@discordjs/rest/node_modules/@sapphire/snowflake": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.5.tgz",
-      "integrity": "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=v14.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@discordjs/rest/node_modules/undici": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
-      }
-    },
-    "node_modules/@discordjs/util": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz",
-      "integrity": "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "discord-api-types": "^0.38.33"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/discordjs/discord.js?sponsor"
-      }
-    },
-    "node_modules/@discordjs/ws": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.3.tgz",
-      "integrity": "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@discordjs/collection": "^2.1.0",
-        "@discordjs/rest": "^2.5.1",
-        "@discordjs/util": "^1.1.0",
-        "@sapphire/async-queue": "^1.5.2",
-        "@types/ws": "^8.5.10",
-        "@vladfrangu/async_event_emitter": "^2.2.4",
-        "discord-api-types": "^0.38.1",
-        "tslib": "^2.6.2",
-        "ws": "^8.17.0"
-      },
-      "engines": {
-        "node": ">=16.11.0"
-      },
-      "funding": {
-        "url": "https://github.com/discordjs/discord.js?sponsor"
-      }
-    },
-    "node_modules/@discordjs/ws/node_modules/@discordjs/collection": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
-      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/discordjs/discord.js?sponsor"
-      }
-    },
-    "node_modules/@discordjs/ws/node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -5616,39 +5443,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@sapphire/async-queue": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
-      "integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=v14.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@sapphire/shapeshift": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
-      "integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "lodash": "^4.17.21"
-      },
-      "engines": {
-        "node": ">=v16"
-      }
-    },
-    "node_modules/@sapphire/snowflake": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
-      "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=v14.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/@sideway/address": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
@@ -6510,12 +6304,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@telegraf/types": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@telegraf/types/-/types-7.1.0.tgz",
-      "integrity": "sha512-kGevOIbpMcIlCDeorKGpwZmdH7kHbqlk/Yj6dEpJMKEQw5lk0KVQY0OLXaCswy8GqlIVLd5625OB+rAntP9xVw==",
-      "license": "MIT"
-    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -6596,6 +6384,7 @@
       "version": "25.5.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
       "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
@@ -6613,15 +6402,6 @@
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
       "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -6901,16 +6681,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@vladfrangu/async_event_emitter": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz",
-      "integrity": "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=v14.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/@vue/compiler-core": {
       "version": "3.5.32",
       "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.32.tgz",
@@ -6985,18 +6755,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "license": "MIT",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -7028,16 +6786,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/agent-browser": {
-      "version": "0.23.4",
-      "resolved": "https://registry.npmjs.org/agent-browser/-/agent-browser-0.23.4.tgz",
-      "integrity": "sha512-FSCjFL+szDz/oWkBv80WnRJyISXD101ePeB8ReuaeGCF5VaiKTrLHccyCeXI8j+DMG6Gt3VU9E0OHvRXKaA+XA==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "agent-browser": "bin/agent-browser.js"
       }
     },
     "node_modules/agentkeepalive": {
@@ -7582,34 +7330,12 @@
         "node": ">=8"
       }
     },
-    "node_modules/buffer-alloc": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-alloc-unsafe": "^1.1.0",
-        "buffer-fill": "^1.0.0"
-      }
-    },
-    "node_modules/buffer-alloc-unsafe": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-      "license": "MIT"
-    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "dev": true,
       "license": "BSD-3-Clause"
-    },
-    "node_modules/buffer-fill": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-      "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
-      "license": "MIT"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -8147,6 +7873,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -8440,51 +8167,6 @@
       },
       "peerDependencies": {
         "typescript": "^5.4.4"
-      }
-    },
-    "node_modules/discord-api-types": {
-      "version": "0.38.44",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.44.tgz",
-      "integrity": "sha512-q91MgBzP/gRaCLIbQTaOrOhbD8uVIaPKxpgX2sfFB2nZ9nSiTYM9P3NFQ7cbO6NCxctI6ODttc67MI+YhIfILg==",
-      "license": "MIT",
-      "workspaces": [
-        "scripts/actions/documentation"
-      ]
-    },
-    "node_modules/discord.js": {
-      "version": "14.26.2",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.26.2.tgz",
-      "integrity": "sha512-feShi+gULJ6R2MAA4/KkCFnkJcuVrROJrKk4czplzq8gE1oqhqgOy9K0Scu44B8oGeWKe04egquzf+ia6VtXAw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@discordjs/builders": "^1.14.1",
-        "@discordjs/collection": "1.5.3",
-        "@discordjs/formatters": "^0.6.2",
-        "@discordjs/rest": "^2.6.1",
-        "@discordjs/util": "^1.2.0",
-        "@discordjs/ws": "^1.2.3",
-        "@sapphire/snowflake": "3.5.3",
-        "discord-api-types": "^0.38.40",
-        "fast-deep-equal": "3.1.3",
-        "lodash.snakecase": "4.1.1",
-        "magic-bytes.js": "^1.13.0",
-        "tslib": "^2.6.3",
-        "undici": "6.24.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/discordjs/discord.js?sponsor"
-      }
-    },
-    "node_modules/discord.js/node_modules/undici": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
       }
     },
     "node_modules/dogapi": {
@@ -8986,15 +8668,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
@@ -9033,6 +8706,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -10335,6 +10009,7 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
@@ -10400,12 +10075,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash.snakecase": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
-      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
-      "license": "MIT"
-    },
     "node_modules/log-symbols": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
@@ -10449,12 +10118,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/magic-bytes.js": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz",
-      "integrity": "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==",
-      "license": "MIT"
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -10727,19 +10390,11 @@
         "node": "*"
       }
     },
-    "node_modules/mri": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
-      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/mute-stream": {
@@ -10790,6 +10445,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -11022,15 +10678,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/p-timeout": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-4.1.0.tgz",
-      "integrity": "sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/pako": {
@@ -11603,30 +11250,12 @@
       ],
       "license": "MIT"
     },
-    "node_modules/safe-compare": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/safe-compare/-/safe-compare-1.1.4.tgz",
-      "integrity": "sha512-b9wZ986HHCo/HbKrRpBJb2kqXMK9CEWIE1egeEvZsYn69ay3kdfl9nG3RyOcR+jInTDf7a86WQ1d4VJX7goSSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-alloc": "^1.2.0"
-      }
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/sandwich-stream": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/sandwich-stream/-/sandwich-stream-2.0.2.tgz",
-      "integrity": "sha512-jLYV0DORrzY3xaz/S9ydJL6Iz7essZeAfnAavsJ+zsJGZ1MOnsS52yRjU3uF3pJa/lla7+wisp//fxOwOH8SKQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 0.10"
-      }
     },
     "node_modules/sass-lookup": {
       "version": "6.1.1",
@@ -11991,28 +11620,6 @@
         "bintrees": "1.0.2"
       }
     },
-    "node_modules/telegraf": {
-      "version": "4.16.3",
-      "resolved": "https://registry.npmjs.org/telegraf/-/telegraf-4.16.3.tgz",
-      "integrity": "sha512-yjEu2NwkHlXu0OARWoNhJlIjX09dRktiMQFsM678BAH/PEPVwctzL67+tvXqLCRQQvm3SDtki2saGO9hLlz68w==",
-      "license": "MIT",
-      "dependencies": {
-        "@telegraf/types": "^7.1.0",
-        "abort-controller": "^3.0.0",
-        "debug": "^4.3.4",
-        "mri": "^1.2.0",
-        "node-fetch": "^2.7.0",
-        "p-timeout": "^4.1.0",
-        "safe-compare": "^1.1.4",
-        "sandwich-stream": "^2.0.2"
-      },
-      "bin": {
-        "telegraf": "lib/cli.mjs"
-      },
-      "engines": {
-        "node": "^12.20.0 || >=14.13.1"
-      }
-    },
     "node_modules/temp-dir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
@@ -12162,6 +11769,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ts-api-utils": {
@@ -12176,12 +11784,6 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
-    },
-    "node_modules/ts-mixer": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
-      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
-      "license": "MIT"
     },
     "node_modules/tsconfig-paths": {
       "version": "4.2.0",
@@ -12202,6 +11804,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-fest": {
@@ -12252,6 +11855,7 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unenv": {
@@ -12531,6 +12135,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-encoding": {
@@ -12574,6 +12179,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",

--- a/tests/integration/validation-fast-path.test.ts
+++ b/tests/integration/validation-fast-path.test.ts
@@ -1,0 +1,109 @@
+// tests/integration/validation-fast-path.test.ts
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { validateDealFastPath } from "../../worker/pipeline/validate-fast-path";
+import { Env } from "../../worker/types";
+
+describe("validateDealFastPath", () => {
+  let mockKv: any;
+  let mockDb: any;
+  let env: Env;
+
+  beforeEach(() => {
+    mockKv = {
+      get: vi.fn(),
+      put: vi.fn().mockResolvedValue(undefined),
+    };
+    mockDb = {
+      prepare: vi.fn().mockReturnValue({
+        bind: vi.fn().mockReturnValue({
+          first: vi.fn(),
+          run: vi.fn().mockResolvedValue({}),
+        }),
+      }),
+    };
+    env = {
+      DEALS_STAGING: mockKv,
+      DEALS_DB: mockDb,
+    } as unknown as Env;
+  });
+
+  it("returns hit: false and persist function on cache miss", async () => {
+    mockKv.get.mockResolvedValue(null);
+    mockDb.prepare().bind().first.mockResolvedValue(null);
+
+    const result = await validateDealFastPath(env, {
+      url: "https://example.com/deal?utm_source=test",
+      fingerprint: "fp1",
+    });
+
+    expect(result.hit).toBe(false);
+    expect(result.source).toBe("none");
+    expect(result.persist).toBeTypeOf("function");
+  });
+
+  it("returns hit: true when URL is cached in KV", async () => {
+    const cachedEntry = {
+      status: "accepted",
+      fingerprint: "fp1",
+      normalizedUrl: "https://example.com/deal",
+      createdAt: new Date().toISOString(),
+    };
+    // Mock URL cache key lookup
+    mockKv.get.mockImplementation((key: string) => {
+      if (key.startsWith("v:url:")) return Promise.resolve(cachedEntry);
+      return Promise.resolve(null);
+    });
+
+    const result = await validateDealFastPath(env, {
+      url: "https://example.com/deal",
+      fingerprint: "fp1",
+    });
+
+    expect(result.hit).toBe(true);
+    expect(result.source).toBe("kv:url");
+    expect(result.decision).toEqual(cachedEntry);
+  });
+
+  it("returns hit: true when fingerprint is cached as duplicate in KV", async () => {
+    const cachedEntry = {
+      status: "duplicate",
+      fingerprint: "fp1",
+      normalizedUrl: "https://example.com/deal",
+      createdAt: new Date().toISOString(),
+    };
+    mockKv.get.mockImplementation((key: string) => {
+      if (key.startsWith("v:fingerprint:")) return Promise.resolve(cachedEntry);
+      return Promise.resolve(null);
+    });
+
+    const result = await validateDealFastPath(env, {
+      url: "https://other.com/deal",
+      fingerprint: "fp1",
+    });
+
+    expect(result.hit).toBe(true);
+    expect(result.source).toBe("kv:fingerprint");
+    expect(result.decision).toEqual(cachedEntry);
+  });
+
+  it("returns hit: true and populates KV when found in D1", async () => {
+    const indexedEntry = {
+      status: "accepted",
+      fingerprint: "fp1",
+      normalized_url: "https://example.com/deal",
+      trust_score: 0.9,
+    };
+    mockKv.get.mockResolvedValue(null);
+    mockDb.prepare().bind().first.mockResolvedValue(indexedEntry);
+
+    const result = await validateDealFastPath(env, {
+      url: "https://example.com/deal",
+      fingerprint: "fp1",
+    });
+
+    expect(result.hit).toBe(true);
+    expect(result.source).toBe("d1");
+    expect(result.decision?.status).toBe("accepted");
+    expect(mockKv.put).toHaveBeenCalledTimes(2); // URL and Fingerprint keys
+  });
+});

--- a/tests/unit/validation-cache.test.ts
+++ b/tests/unit/validation-cache.test.ts
@@ -1,0 +1,45 @@
+// tests/unit/validation-cache.test.ts
+import { describe, expect, it, vi } from "vitest";
+import {
+  ValidationCacheRepository,
+  ttlForStatus,
+} from "../../worker/lib/validation-cache/repository";
+
+describe("ValidationCacheRepository", () => {
+  it("writes TTL-backed entries", async () => {
+    const put = vi.fn().mockResolvedValue(undefined);
+    const repo = new ValidationCacheRepository({
+      get: vi.fn(),
+      put,
+    });
+
+    const entry = {
+      status: "accepted" as const,
+      fingerprint: "fp1",
+      normalizedUrl: "https://example.com/deal",
+      createdAt: new Date().toISOString(),
+    };
+
+    await repo.put("v:url:test", entry, ttlForStatus("accepted"));
+
+    expect(put).toHaveBeenCalledWith(
+      "v:url:test",
+      JSON.stringify(entry),
+      expect.objectContaining({ expirationTtl: 60 * 60 * 24 }),
+    );
+  });
+
+  it("uses shorter TTL for transient errors", () => {
+    expect(ttlForStatus("transient_error")).toBe(60 * 15);
+  });
+
+  it("returns null for cache miss", async () => {
+    const repo = new ValidationCacheRepository({
+      get: vi.fn().mockResolvedValue(null),
+      put: vi.fn(),
+    });
+
+    const result = await repo.get("missing");
+    expect(result).toBeNull();
+  });
+});

--- a/worker/lib/metrics.ts
+++ b/worker/lib/metrics.ts
@@ -1,31 +1,7 @@
-import { PipelinePhase } from "../types";
+import { PipelinePhase, PipelineMetrics } from "../types";
 import type { Env } from "../types";
 import { CONFIG } from "../config";
 import { fetchInBatches } from "./utils";
-
-// ============================================================================
-// Pipeline Metrics Types
-// ============================================================================
-
-export interface PipelineMetrics {
-  run_id: string;
-  start_time: number;
-  end_time?: number;
-  phase_timings: Record<PipelinePhase, number>;
-  total_duration_ms: number;
-  deals_processed: {
-    discovered: number;
-    normalized: number;
-    deduped: number;
-    validated: number;
-    scored: number;
-    published: number;
-  };
-  errors: number;
-  retries: number;
-  success: boolean;
-  final_phase: PipelinePhase;
-}
 
 // ============================================================================
 // Metrics Functions
@@ -58,6 +34,13 @@ export function createMetrics(run_id: string): PipelineMetrics {
       validated: 0,
       scored: 0,
       published: 0,
+    },
+    validation_cache: {
+      hit_total: 0,
+      miss_total: 0,
+      write_total: 0,
+      d1_lookup_total: 0,
+      dedup_hit_total: 0,
     },
     errors: 0,
     retries: 0,
@@ -106,6 +89,26 @@ export function recordError(metrics: PipelineMetrics): void {
  */
 export function recordRetry(metrics: PipelineMetrics): void {
   metrics.retries++;
+}
+
+/**
+ * Update validation cache metrics
+ */
+export function recordValidationCacheMetric(
+  metrics: PipelineMetrics,
+  metric: keyof Required<PipelineMetrics>["validation_cache"],
+  increment: number = 1,
+): void {
+  if (!metrics.validation_cache) {
+    metrics.validation_cache = {
+      hit_total: 0,
+      miss_total: 0,
+      write_total: 0,
+      d1_lookup_total: 0,
+      dedup_hit_total: 0,
+    };
+  }
+  metrics.validation_cache[metric] += increment;
 }
 
 /**
@@ -206,6 +209,13 @@ export function calculateAggregateStats(metrics: PipelineMetrics[]): {
     scored: number;
     published: number;
   };
+  avg_validation_cache?: {
+    hit_total: number;
+    miss_total: number;
+    write_total: number;
+    d1_lookup_total: number;
+    dedup_hit_total: number;
+  };
   total_errors: number;
   total_retries: number;
 } {
@@ -235,6 +245,13 @@ export function calculateAggregateStats(metrics: PipelineMetrics[]): {
         validated: 0,
         scored: 0,
         published: 0,
+      },
+      avg_validation_cache: {
+        hit_total: 0,
+        miss_total: 0,
+        write_total: 0,
+        d1_lookup_total: 0,
+        dedup_hit_total: 0,
       },
       total_errors: 0,
       total_retries: 0,
@@ -292,6 +309,39 @@ export function calculateAggregateStats(metrics: PipelineMetrics[]): {
     ),
   };
 
+  const avgValidationCache = {
+    hit_total: Math.round(
+      metrics.reduce(
+        (sum, m) => sum + (m.validation_cache?.hit_total || 0),
+        0,
+      ) / metrics.length,
+    ),
+    miss_total: Math.round(
+      metrics.reduce(
+        (sum, m) => sum + (m.validation_cache?.miss_total || 0),
+        0,
+      ) / metrics.length,
+    ),
+    write_total: Math.round(
+      metrics.reduce(
+        (sum, m) => sum + (m.validation_cache?.write_total || 0),
+        0,
+      ) / metrics.length,
+    ),
+    d1_lookup_total: Math.round(
+      metrics.reduce(
+        (sum, m) => sum + (m.validation_cache?.d1_lookup_total || 0),
+        0,
+      ) / metrics.length,
+    ),
+    dedup_hit_total: Math.round(
+      metrics.reduce(
+        (sum, m) => sum + (m.validation_cache?.dedup_hit_total || 0),
+        0,
+      ) / metrics.length,
+    ),
+  };
+
   const totalDuration = metrics.reduce(
     (sum, m) => sum + m.total_duration_ms,
     0,
@@ -308,6 +358,7 @@ export function calculateAggregateStats(metrics: PipelineMetrics[]): {
     avg_duration_ms: Math.round(totalDuration / metrics.length),
     avg_phase_timings: avgPhaseTimings,
     avg_deals_per_run: avgDeals,
+    avg_validation_cache: avgValidationCache,
     total_errors: totalErrors,
     total_retries: totalRetries,
   };
@@ -383,6 +434,29 @@ export function formatMetricsForPrometheus(
   lines.push(
     `deals_pipeline_deals_avg{stage="published"} ${stats.avg_deals_per_run.published}`,
   );
+
+  // Validation cache metrics
+  if (stats.avg_validation_cache) {
+    lines.push(
+      "# HELP deals_validation_cache_avg Average validation cache stats per run",
+    );
+    lines.push("# TYPE deals_validation_cache_avg gauge");
+    lines.push(
+      `deals_validation_cache_avg{type="hit"} ${stats.avg_validation_cache.hit_total}`,
+    );
+    lines.push(
+      `deals_validation_cache_avg{type="miss"} ${stats.avg_validation_cache.miss_total}`,
+    );
+    lines.push(
+      `deals_validation_cache_avg{type="write"} ${stats.avg_validation_cache.write_total}`,
+    );
+    lines.push(
+      `deals_validation_cache_avg{type="d1_lookup"} ${stats.avg_validation_cache.d1_lookup_total}`,
+    );
+    lines.push(
+      `deals_validation_cache_avg{type="dedup_hit"} ${stats.avg_validation_cache.dedup_hit_total}`,
+    );
+  }
 
   // Errors and retries
   lines.push("# HELP deals_pipeline_errors_total Total errors encountered");

--- a/worker/lib/validation-cache/index-repository.ts
+++ b/worker/lib/validation-cache/index-repository.ts
@@ -1,0 +1,62 @@
+// worker/lib/validation-cache/index-repository.ts
+import type { ValidationCacheEntry } from "../../types/validation-cache";
+
+type D1Like = {
+  prepare(query: string): {
+    bind(...values: unknown[]): {
+      first<T = Record<string, unknown>>(): Promise<T | null>;
+      run(): Promise<unknown>;
+    };
+  };
+};
+
+export class ValidationIndexRepository {
+  constructor(private readonly db: D1Like) {}
+
+  async findByFingerprint(fingerprint: string): Promise<any | null> {
+    return this.db
+      .prepare(
+        `
+        SELECT fingerprint, normalized_url, status, reason, trust_score,
+               source, trace_id, first_seen_at, last_seen_at
+        FROM validation_index
+        WHERE fingerprint = ?
+        LIMIT 1
+        `,
+      )
+      .bind(fingerprint)
+      .first();
+  }
+
+  async upsert(entry: ValidationCacheEntry): Promise<void> {
+    await this.db
+      .prepare(
+        `
+        INSERT INTO validation_index (
+          fingerprint, normalized_url, status, reason, trust_score,
+          source, trace_id, first_seen_at, last_seen_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(fingerprint) DO UPDATE SET
+          normalized_url = excluded.normalized_url,
+          status = excluded.status,
+          reason = excluded.reason,
+          trust_score = excluded.trust_score,
+          source = excluded.source,
+          trace_id = excluded.trace_id,
+          last_seen_at = excluded.last_seen_at
+        `,
+      )
+      .bind(
+        entry.fingerprint,
+        entry.normalizedUrl,
+        entry.status,
+        entry.reason ?? null,
+        entry.trustScore ?? null,
+        entry.source ?? null,
+        entry.traceId ?? null,
+        entry.createdAt,
+        entry.createdAt,
+      )
+      .run();
+  }
+}

--- a/worker/lib/validation-cache/key.ts
+++ b/worker/lib/validation-cache/key.ts
@@ -1,0 +1,52 @@
+// worker/lib/validation-cache/key.ts
+
+export function normalizeUrl(input: string): string {
+  try {
+    const url = new URL(input);
+    url.hash = "";
+    url.hostname = url.hostname.toLowerCase();
+
+    const trackingParams = [
+      "utm_source",
+      "utm_medium",
+      "utm_campaign",
+      "utm_term",
+      "utm_content",
+      "gclid",
+      "fbclid",
+    ];
+
+    for (const key of trackingParams) {
+      url.searchParams.delete(key);
+    }
+
+    const sorted = new URL(url.toString());
+    const entries = [...sorted.searchParams.entries()].sort(([a], [b]) =>
+      a.localeCompare(b),
+    );
+    sorted.search = "";
+    for (const [k, v] of entries) sorted.searchParams.append(k, v);
+
+    return sorted.toString();
+  } catch {
+    return input.toLowerCase().trim();
+  }
+}
+
+export async function sha256Hex(input: string): Promise<string> {
+  const bytes = new TextEncoder().encode(input);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return [...new Uint8Array(digest)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export async function buildUrlCacheKey(url: string): Promise<string> {
+  return `v:url:${await sha256Hex(normalizeUrl(url))}`;
+}
+
+export async function buildFingerprintKey(
+  fingerprint: string,
+): Promise<string> {
+  return `v:fingerprint:${await sha256Hex(fingerprint)}`;
+}

--- a/worker/lib/validation-cache/repository.ts
+++ b/worker/lib/validation-cache/repository.ts
@@ -1,0 +1,44 @@
+// worker/lib/validation-cache/repository.ts
+import type { ValidationCacheEntry } from "../../types/validation-cache";
+
+type KVNamespaceLike = {
+  get(key: string, options?: { type: "json"; cacheTtl?: number }): Promise<any>;
+  put(
+    key: string,
+    value: string,
+    options?: { expirationTtl?: number },
+  ): Promise<void>;
+};
+
+export class ValidationCacheRepository {
+  constructor(private readonly kv: KVNamespaceLike) {}
+
+  async get(key: string): Promise<ValidationCacheEntry | null> {
+    const result = await this.kv.get(key, { type: "json", cacheTtl: 300 });
+    return result ?? null;
+  }
+
+  async put(
+    key: string,
+    entry: ValidationCacheEntry,
+    ttlSeconds: number,
+  ): Promise<void> {
+    await this.kv.put(key, JSON.stringify(entry), {
+      expirationTtl: ttlSeconds,
+    });
+  }
+}
+
+export function ttlForStatus(status: ValidationCacheEntry["status"]): number {
+  switch (status) {
+    case "accepted":
+    case "duplicate":
+      return 60 * 60 * 24;
+    case "rejected":
+      return 60 * 60 * 6;
+    case "transient_error":
+      return 60 * 15;
+    default:
+      return 60 * 60;
+  }
+}

--- a/worker/pipeline/validate-fast-path.ts
+++ b/worker/pipeline/validate-fast-path.ts
@@ -1,0 +1,129 @@
+// worker/pipeline/validate-fast-path.ts
+import type { Env } from "../types";
+import {
+  buildFingerprintKey,
+  buildUrlCacheKey,
+  normalizeUrl,
+} from "../lib/validation-cache/key";
+import {
+  ValidationCacheRepository,
+  ttlForStatus,
+} from "../lib/validation-cache/repository";
+import { ValidationIndexRepository } from "../lib/validation-cache/index-repository";
+import type { ValidationCacheEntry } from "../types/validation-cache";
+import { recordValidationCacheMetric } from "../lib/metrics";
+
+export interface FastPathResult {
+  hit: boolean;
+  source: "kv:url" | "kv:fingerprint" | "d1" | "none";
+  decision?: ValidationCacheEntry;
+  persist?: (decision: {
+    status: "accepted" | "duplicate" | "rejected" | "transient_error";
+    reason?: string;
+    trustScore?: number;
+  }) => Promise<void>;
+}
+
+export async function validateDealFastPath(
+  env: Env,
+  input: {
+    url: string;
+    fingerprint: string;
+    source?: string;
+    traceId?: string;
+    metrics?: any;
+  },
+): Promise<FastPathResult> {
+  // Use STAGING_KV for validation cache as proposed, or fallback to DEALS_LOG if STAGING_KV is not ideal
+  // Given DEALS_STAGING is available in Env, let's use that.
+  const kv = env.DEALS_STAGING;
+  const db = env.DEALS_DB;
+
+  if (!kv || !db) {
+    return { hit: false, source: "none" };
+  }
+
+  const cacheRepo = new ValidationCacheRepository(kv);
+  const indexRepo = new ValidationIndexRepository(db);
+
+  const normalizedUrl = normalizeUrl(input.url);
+  const urlKey = await buildUrlCacheKey(normalizedUrl);
+  const fpKey = await buildFingerprintKey(input.fingerprint);
+
+  const [cachedByUrl, cachedByFingerprint, indexedByFingerprint] =
+    await Promise.all([
+      cacheRepo.get(urlKey),
+      cacheRepo.get(fpKey),
+      indexRepo.findByFingerprint(input.fingerprint),
+    ]);
+
+  if (cachedByFingerprint?.status === "duplicate") {
+    if (input.metrics)
+      recordValidationCacheMetric(input.metrics, "hit_total", 1);
+    if (input.metrics)
+      recordValidationCacheMetric(input.metrics, "dedup_hit_total", 1);
+    return {
+      hit: true,
+      source: "kv:fingerprint",
+      decision: cachedByFingerprint,
+    };
+  }
+
+  if (
+    cachedByUrl?.status === "accepted" ||
+    cachedByUrl?.status === "rejected"
+  ) {
+    if (input.metrics)
+      recordValidationCacheMetric(input.metrics, "hit_total", 1);
+    return { hit: true, source: "kv:url", decision: cachedByUrl };
+  }
+
+  if (input.metrics)
+    recordValidationCacheMetric(input.metrics, "miss_total", 1);
+
+  if (indexedByFingerprint) {
+    if (input.metrics)
+      recordValidationCacheMetric(input.metrics, "d1_lookup_total", 1);
+    const entry: ValidationCacheEntry = {
+      status: indexedByFingerprint.status,
+      reason: indexedByFingerprint.reason ?? undefined,
+      trustScore: indexedByFingerprint.trust_score ?? undefined,
+      fingerprint: indexedByFingerprint.fingerprint,
+      normalizedUrl: indexedByFingerprint.normalized_url,
+      source: indexedByFingerprint.source ?? undefined,
+      traceId: indexedByFingerprint.trace_id ?? undefined,
+      createdAt: new Date().toISOString(),
+    };
+
+    // Re-populate KV cache from D1
+    await Promise.all([
+      cacheRepo.put(fpKey, entry, ttlForStatus(entry.status)),
+      cacheRepo.put(urlKey, entry, ttlForStatus(entry.status)),
+    ]);
+
+    return { hit: true, source: "d1", decision: entry };
+  }
+
+  return {
+    hit: false,
+    source: "none",
+    persist: async (decision) => {
+      if (input.metrics)
+        recordValidationCacheMetric(input.metrics, "write_total", 1);
+      const entry: ValidationCacheEntry = {
+        ...decision,
+        fingerprint: input.fingerprint,
+        normalizedUrl,
+        source: input.source,
+        traceId: input.traceId,
+        createdAt: new Date().toISOString(),
+      };
+
+      await Promise.all([
+        cacheRepo.put(fpKey, entry, ttlForStatus(entry.status)),
+        cacheRepo.put(urlKey, entry, ttlForStatus(entry.status)),
+        indexRepo.upsert(entry),
+      ]);
+    },
+  };
+}

--- a/worker/pipeline/validate.ts
+++ b/worker/pipeline/validate.ts
@@ -2,6 +2,8 @@ import { Deal, PipelineContext, PipelineError, ErrorClass } from "../types";
 import { DealSchema } from "../types";
 import { CONFIG, VALIDATION_GATES, type ValidationGate } from "../config";
 import { verifyNormalization } from "./normalize";
+import { validateDealFastPath } from "./validate-fast-path";
+import { recordValidationCacheMetric } from "../lib/metrics";
 import { getProductionSnapshot } from "../lib/storage";
 import { generateSnapshotHash } from "../lib/crypto";
 import type { Env } from "../types";
@@ -78,6 +80,7 @@ export async function validate(
 
   // Load production snapshot for idempotency check
   const productionSnapshot = await getProductionSnapshot(env);
+  const useCache = env.ENABLE_VALIDATION_CACHE === "true";
   const existingDealIds = new Set(
     productionSnapshot?.deals.map((d) => d.id) || [],
   );
@@ -87,19 +90,62 @@ export async function validate(
     let allPassed = true;
     const failureReasons: string[] = [];
 
-    // Run each gate
-    for (const gate of VALIDATION_GATES) {
-      const gateResult = await runGate(gate, deal, ctx, existingDealIds);
-      gateResults[gate] = gateResult;
+    // Run fast-path check if enabled
+    let fastPathDecision = null;
+    let skipGates = false;
 
-      if (!gateResult.passed) {
-        allPassed = false;
-        failureReasons.push(`${gate}: ${gateResult.reason}`);
-        result.stats.by_gate[gate] = (result.stats.by_gate[gate] || 0) + 1;
+    if (useCache) {
+      const fastPath = await validateDealFastPath(env, {
+        url: deal.url,
+        fingerprint: deal.id,
+        source: deal.source.domain,
+        traceId: ctx.trace_id,
+        metrics: ctx.metrics,
+      });
+
+      if (fastPath.hit && fastPath.decision) {
+        skipGates = true;
+        fastPathDecision = fastPath.decision;
+      } else {
+        fastPathDecision = fastPath; // contains persist function
+      }
+    }
+
+    // Run each gate
+    if (!skipGates) {
+      for (const gate of VALIDATION_GATES) {
+        const gateResult = await runGate(gate, deal, ctx, existingDealIds);
+        gateResults[gate] = gateResult;
+
+        if (!gateResult.passed) {
+          allPassed = false;
+          failureReasons.push(`${gate}: ${gateResult.reason}`);
+          result.stats.by_gate[gate] = (result.stats.by_gate[gate] || 0) + 1;
+        }
+      }
+    }
+
+    if (skipGates && fastPathDecision && "status" in fastPathDecision) {
+      allPassed = fastPathDecision.status === "accepted";
+      if (!allPassed) {
+        failureReasons.push(`cached_rejection: ${fastPathDecision.reason}`);
       }
     }
 
     if (allPassed) {
+      // Persist to cache if it was a miss
+      if (
+        useCache &&
+        fastPathDecision &&
+        "persist" in fastPathDecision &&
+        fastPathDecision.persist
+      ) {
+        await fastPathDecision.persist({
+          status: "accepted",
+          trustScore: deal.source.trust_score,
+        });
+      }
+
       // Check for quarantine conditions
       if (shouldQuarantine(deal)) {
         deal.metadata.status = "quarantined";
@@ -111,6 +157,23 @@ export async function validate(
         result.stats.valid++;
       }
     } else {
+      // Persist to cache if it was a miss
+      if (
+        useCache &&
+        fastPathDecision &&
+        "persist" in fastPathDecision &&
+        fastPathDecision.persist
+      ) {
+        const isDuplicate = failureReasons.some(
+          (r) => r.includes("Deduplication Check") || r.includes("duplicate"),
+        );
+        await fastPathDecision.persist({
+          status: isDuplicate ? "duplicate" : "rejected",
+          reason: failureReasons.join("; "),
+          trustScore: deal.source.trust_score,
+        });
+      }
+
       deal.metadata.status = "rejected";
       result.invalid.push({ deal, reasons: failureReasons });
       result.stats.invalid++;

--- a/worker/state-machine.ts
+++ b/worker/state-machine.ts
@@ -212,7 +212,8 @@ async function executePhase(
     case "discover":
       const discovery = await discover(env, ctx);
       ctx.candidates = discovery.deals;
-      if (ctx.metrics) recordDealCount(ctx.metrics, "discovered", ctx.candidates.length);
+      if (ctx.metrics)
+        recordDealCount(ctx.metrics, "discovered", ctx.candidates.length);
 
       // Guard rail: Check input resources
       if (ctx.candidates.length > 0) {
@@ -236,13 +237,15 @@ async function executePhase(
 
     case "normalize":
       ctx.normalized = normalize(ctx.candidates, ctx);
-      if (ctx.metrics) recordDealCount(ctx.metrics, "normalized", ctx.normalized.length);
+      if (ctx.metrics)
+        recordDealCount(ctx.metrics, "normalized", ctx.normalized.length);
       return "dedupe";
 
     case "dedupe":
       const dedupeResult = deduplicate(ctx.normalized, ctx);
       ctx.deduped = dedupeResult.unique;
-      if (ctx.metrics) recordDealCount(ctx.metrics, "deduped", ctx.deduped.length);
+      if (ctx.metrics)
+        recordDealCount(ctx.metrics, "deduped", ctx.deduped.length);
       if (ctx.deduped.length === 0) {
         return "finalize"; // No unique deals
       }
@@ -251,7 +254,8 @@ async function executePhase(
     case "validate":
       const validation = await validate(ctx.deduped, ctx, env);
       ctx.validated = validation.valid;
-      if (ctx.metrics) recordDealCount(ctx.metrics, "validated", ctx.validated.length);
+      if (ctx.metrics)
+        recordDealCount(ctx.metrics, "validated", ctx.validated.length);
 
       // Log validation stats
       await appendLog(
@@ -276,7 +280,8 @@ async function executePhase(
     case "score":
       const scoring = await score(ctx.validated, ctx, env);
       ctx.scored = scoring.deals;
-      if (ctx.metrics) recordDealCount(ctx.metrics, "scored", ctx.scored.length);
+      if (ctx.metrics)
+        recordDealCount(ctx.metrics, "scored", ctx.scored.length);
 
       // Log scoring stats
       await appendLog(
@@ -334,7 +339,8 @@ async function executePhase(
         }
 
         await publishSnapshot(env, ctx.snapshot!, ctx);
-        if (ctx.metrics) recordDealCount(ctx.metrics, "published", ctx.scored.length);
+        if (ctx.metrics)
+          recordDealCount(ctx.metrics, "published", ctx.scored.length);
         return "verify";
       } catch (error) {
         return "revert";

--- a/worker/state-machine.ts
+++ b/worker/state-machine.ts
@@ -48,6 +48,16 @@ const PHASES: PipelinePhase[] = [
   "finalize",
 ];
 
+import {
+  createMetrics,
+  recordPhaseTiming,
+  recordDealCount,
+  recordError,
+  recordRetry,
+  finalizeMetrics,
+  storeMetrics,
+} from "./lib/metrics";
+
 /**
  * Execute full pipeline
  */
@@ -69,6 +79,7 @@ export async function executePipeline(env: Env): Promise<{
     deduped: [],
     validated: [],
     scored: [],
+    metrics: createMetrics(run_id),
     errors: [],
     retry_count: 0,
   };
@@ -96,7 +107,14 @@ export async function executePipeline(env: Env): Promise<{
         }
 
         // Execute phase
+        const phaseStartTime = Date.now();
         const result = await executePhase(currentPhase, ctx, env);
+        const phaseDuration = Date.now() - phaseStartTime;
+
+        // Record metrics
+        if (ctx.metrics) {
+          recordPhaseTiming(ctx.metrics, currentPhase, phaseDuration);
+        }
 
         if (result === "finalize") {
           // Success path
@@ -122,6 +140,7 @@ export async function executePipeline(env: Env): Promise<{
         // Continue to next phase
         phaseIndex++;
       } catch (error) {
+        if (ctx.metrics) recordError(ctx.metrics);
         const errorMessage = (error as Error).message;
         ctx.errors.push({ phase: currentPhase, error: error as Error });
 
@@ -145,15 +164,26 @@ export async function executePipeline(env: Env): Promise<{
           ctx.retry_count < CONFIG.MAX_RETRIES
         ) {
           ctx.retry_count++;
+          if (ctx.metrics) recordRetry(ctx.metrics);
           // Retry same phase with backoff
           await new Promise((r) => setTimeout(r, 1000 * ctx.retry_count));
           continue;
         }
 
         // Non-retryable or max retries reached
+        if (ctx.metrics) {
+          finalizeMetrics(ctx.metrics, false, currentPhase);
+          await storeMetrics(env, ctx.metrics);
+        }
         await handleFailure("revert", ctx, env);
         return { success: false, phase: currentPhase, error: errorMessage };
       }
+    }
+
+    // Finalize metrics
+    if (ctx.metrics) {
+      finalizeMetrics(ctx.metrics, true, "finalize");
+      await storeMetrics(env, ctx.metrics);
     }
 
     // Success
@@ -182,6 +212,7 @@ async function executePhase(
     case "discover":
       const discovery = await discover(env, ctx);
       ctx.candidates = discovery.deals;
+      if (ctx.metrics) recordDealCount(ctx.metrics, "discovered", ctx.candidates.length);
 
       // Guard rail: Check input resources
       if (ctx.candidates.length > 0) {
@@ -205,11 +236,13 @@ async function executePhase(
 
     case "normalize":
       ctx.normalized = normalize(ctx.candidates, ctx);
+      if (ctx.metrics) recordDealCount(ctx.metrics, "normalized", ctx.normalized.length);
       return "dedupe";
 
     case "dedupe":
       const dedupeResult = deduplicate(ctx.normalized, ctx);
       ctx.deduped = dedupeResult.unique;
+      if (ctx.metrics) recordDealCount(ctx.metrics, "deduped", ctx.deduped.length);
       if (ctx.deduped.length === 0) {
         return "finalize"; // No unique deals
       }
@@ -218,6 +251,7 @@ async function executePhase(
     case "validate":
       const validation = await validate(ctx.deduped, ctx, env);
       ctx.validated = validation.valid;
+      if (ctx.metrics) recordDealCount(ctx.metrics, "validated", ctx.validated.length);
 
       // Log validation stats
       await appendLog(
@@ -242,6 +276,7 @@ async function executePhase(
     case "score":
       const scoring = await score(ctx.validated, ctx, env);
       ctx.scored = scoring.deals;
+      if (ctx.metrics) recordDealCount(ctx.metrics, "scored", ctx.scored.length);
 
       // Log scoring stats
       await appendLog(
@@ -299,6 +334,7 @@ async function executePhase(
         }
 
         await publishSnapshot(env, ctx.snapshot!, ctx);
+        if (ctx.metrics) recordDealCount(ctx.metrics, "published", ctx.scored.length);
         return "verify";
       } catch (error) {
         return "revert";

--- a/worker/types.ts
+++ b/worker/types.ts
@@ -191,10 +191,42 @@ export interface PipelineContext {
   deduped: Deal[];
   validated: Deal[];
   scored: Deal[];
+  metrics?: PipelineMetrics;
   snapshot?: Snapshot;
   previous_snapshot?: Snapshot;
   errors: Array<{ phase: string; error: Error }>;
   retry_count: number;
+}
+
+// ============================================================================
+// Pipeline Metrics Types
+// ============================================================================
+
+export interface PipelineMetrics {
+  run_id: string;
+  start_time: number;
+  end_time?: number;
+  phase_timings: Record<PipelinePhase, number>;
+  total_duration_ms: number;
+  deals_processed: {
+    discovered: number;
+    normalized: number;
+    deduped: number;
+    validated: number;
+    scored: number;
+    published: number;
+  };
+  validation_cache?: {
+    hit_total: number;
+    miss_total: number;
+    write_total: number;
+    d1_lookup_total: number;
+    dedup_hit_total: number;
+  };
+  errors: number;
+  retries: number;
+  success: boolean;
+  final_phase: PipelinePhase;
 }
 
 // ============================================================================
@@ -287,6 +319,7 @@ export interface Env {
   // D1 Migration Feature Flags
   USE_D1_READS?: string;
   DISABLE_DUAL_WRITE?: string;
+  ENABLE_VALIDATION_CACHE?: string;
 }
 
 // ============================================================================

--- a/worker/types/validation-cache.ts
+++ b/worker/types/validation-cache.ts
@@ -1,0 +1,17 @@
+// worker/types/validation-cache.ts
+export type ValidationCacheStatus =
+  | "accepted"
+  | "duplicate"
+  | "rejected"
+  | "transient_error";
+
+export interface ValidationCacheEntry {
+  status: ValidationCacheStatus;
+  reason?: string;
+  trustScore?: number;
+  fingerprint: string;
+  normalizedUrl: string;
+  source?: string;
+  traceId?: string;
+  createdAt: string;
+}


### PR DESCRIPTION
Implemented a two-layer validation cache (KV for performance, D1 for durability) to reduce redundant work in the deal validation pipeline. Added metrics instrumentation and comprehensive tests.

Fixes #67

---
*PR created automatically by Jules for task [93909309453941194](https://jules.google.com/task/93909309453941194) started by @do-ops885*