### PR TITLE
perf(crypto): optimize jaccard similarity memory and compute

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2026-04-08 - Parallelize referral storage operations
 **Learning:** Referral search and maintenance operations (fetching objects from index keys, deactivating expired entries) were performing sequential KV operations in loops. Using `fetchInBatches` and `executeInBatches` reduces latency from O(N) to O(N/batchSize) while ensuring stability via defensive null checks and `allSettled` handling.
 **Action:** Apply `fetchInBatches` for retrieval and `executeInBatches` for bulk updates. Always include defensive null checks (e.g., `filter(r => r && r.status === status)`) when processing batched results to handle potential KV inconsistencies or race conditions.
+
+## 2026-04-09 - Optimize Jaccard similarity computation
+**Learning:** The `calculateStringSimilarity` function, used in O(N^2) deduplication and search loops, was creating five intermediate collections (3 arrays, 2 sets) per call. This caused high garbage collection pressure and redundant iterations.
+**Action:** Directly calculate intersection size by iterating over the smaller set and use the Inclusion-Exclusion Principle (|A ∪ B| = |A| + |B| - |A ∩ B|) to derive union size. This reduces memory allocation from O(N) to O(1) per similarity check and eliminates redundant passes.

--- a/worker/lib/crypto.ts
+++ b/worker/lib/crypto.ts
@@ -82,10 +82,18 @@ export function calculateStringSimilarity(a: string, b: string): number {
   const setA = getBigrams(strA);
   const setB = getBigrams(strB);
 
-  const intersection = new Set([...setA].filter((x) => setB.has(x)));
-  const union = new Set([...setA, ...setB]);
+  // Performance optimization: Calculate intersection size directly to avoid additional Set/Array allocations
+  // Uses the Inclusion-Exclusion Principle: |A ∪ B| = |A| + |B| - |A ∩ B|
+  let intersectionSize = 0;
+  const [smaller, larger] = setA.size < setB.size ? [setA, setB] : [setB, setA];
+  for (const item of smaller) {
+    if (larger.has(item)) {
+      intersectionSize++;
+    }
+  }
 
-  return intersection.size / union.size;
+  const unionSize = setA.size + setB.size - intersectionSize;
+  return intersectionSize / unionSize;
 }
 
 /**


### PR DESCRIPTION
What: Refactored calculateStringSimilarity in worker/lib/crypto.ts to compute set intersection size directly and derive union size via the Inclusion-Exclusion Principle.
Why: The original implementation created three intermediate arrays and two additional sets per call, causing excessive garbage collection pressure and redundant iterations in O(N^2) loops used for deduplication and similarity search.
Impact: Reduces memory allocation from O(N) to O(1) additional collections per check and eliminates two full passes over the data.

---
*PR created automatically by Jules for task [14103224884778431589](https://jules.google.com/task/14103224884778431589) started by @do-ops885*