### PR TITLE
fix(security): prevent authentication bypass in D1 and core routes

### DIFF
--- a/tests/unit/auth.test.ts
+++ b/tests/unit/auth.test.ts
@@ -593,15 +593,14 @@ describe("Auth", () => {
       });
     };
 
-    it("should allow all requests when no API keys configured", async () => {
+    it("should reject all requests when no API keys configured", async () => {
       mockList.mockResolvedValue({ keys: [] });
 
       const request = createRequest();
       const result = await authenticateRequest(request, mockEnv);
 
-      expect(result.authenticated).toBe(true);
-      expect(result.userId).toBe("anonymous");
-      expect(result.role).toBe("admin");
+      expect(result.authenticated).toBe(false);
+      expect(result.error).toBe("Missing API key");
     });
 
     it("should reject request with missing API key", async () => {

--- a/tests/unit/security-auth.test.ts
+++ b/tests/unit/security-auth.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { authenticateD1Request } from "../../worker/routes/d1/admin";
+import { authenticateRequest } from "../../worker/lib/auth";
+import type { Env } from "../../worker/types";
+
+describe("Security: Authentication Bypasses Fixed", () => {
+  describe("authenticateD1Request", () => {
+    it("should block any API key if WEBHOOK_API_KEYS binding is missing", async () => {
+      const mockEnv = {
+        // WEBHOOK_API_KEYS is missing
+      } as unknown as Env;
+
+      const request = new Request("https://example.com/api/d1/migrations", {
+        headers: { "X-API-Key": "any-arbitrary-key" },
+      });
+
+      const result = await authenticateD1Request(mockEnv, request);
+
+      // FIXED: Should now return false
+      expect(result).toBe(false);
+    });
+
+    it("should block if API key is missing", async () => {
+      const mockEnv = {} as unknown as Env;
+      const request = new Request("https://example.com/api/d1/migrations");
+      const result = await authenticateD1Request(mockEnv, request);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("authenticateRequest", () => {
+    it("should block anonymous access even if no keys exist in KV", async () => {
+      const mockEnv = {
+        DEALS_SOURCES: {
+          // list should not even be called now
+          list: vi.fn(),
+        },
+      } as unknown as Env;
+
+      const request = new Request("https://example.com/api/submit");
+      const result = await authenticateRequest(request, mockEnv);
+
+      // FIXED: Should now return authenticated: false
+      expect(result.authenticated).toBe(false);
+      expect(result.error).toBe("Missing API key");
+    });
+  });
+});

--- a/worker/lib/auth.ts
+++ b/worker/lib/auth.ts
@@ -164,13 +164,6 @@ export async function authenticateRequest(
   request: Request,
   env: Env,
 ): Promise<AuthResult> {
-  // Skip auth if no API keys configured
-  const hasKeys = await env.DEALS_SOURCES.list({ prefix: "apikey:" });
-  if (hasKeys.keys.length === 0) {
-    // No keys configured - allow all (development mode)
-    return { authenticated: true, userId: "anonymous", role: "admin" };
-  }
-
   const apiKey = extractApiKey(request);
   if (!apiKey) {
     return { authenticated: false, error: "Missing API key" };

--- a/worker/routes/d1/admin.ts
+++ b/worker/routes/d1/admin.ts
@@ -27,12 +27,15 @@ export async function authenticateD1Request(
     return false;
   }
 
-  // If WEBHOOK_API_KEYS is configured, validate against it
-  if (env.WEBHOOK_API_KEYS) {
-    const validKey = await env.WEBHOOK_API_KEYS.get(`apikey:${apiKey}`);
-    if (!validKey) {
-      return false;
-    }
+  // Require WEBHOOK_API_KEYS to be configured for all non-health requests
+  if (!env.WEBHOOK_API_KEYS) {
+    return false;
+  }
+
+  // Validate API key against stored keys
+  const validKey = await env.WEBHOOK_API_KEYS.get(`apikey:${apiKey}`);
+  if (!validKey) {
+    return false;
   }
 
   return true;


### PR DESCRIPTION
What: Enforced a "fail-secure" policy in authentication logic by requiring valid configuration and API keys.
Why: Previously, `authenticateD1Request` and `authenticateRequest` allowed unauthorized or anonymous admin access when KV bindings or API keys were missing, creating a significant security risk.
Impact: This change prevents authentication bypasses in D1 management and core pipeline routes, ensuring that protected endpoints always require valid credentials.
Verification: Verified with new unit tests in `tests/unit/security-auth.test.ts` and updated existing tests in `tests/unit/auth.test.ts`.

---
*PR created automatically by Jules for task [851122887264516895](https://jules.google.com/task/851122887264516895) started by @do-ops885*