### PR TITLE
perf(pipeline): optimize scoring pipeline performance and I/O

### DIFF
--- a/tests/unit/score.test.ts
+++ b/tests/unit/score.test.ts
@@ -89,4 +89,40 @@ describe("Scoring Pipeline", () => {
     expect(result.stats.min_confidence).toBeGreaterThanOrEqual(0);
     expect(result.stats.max_confidence).toBeGreaterThan(0);
   });
+
+  it("should apply duplicate penalty for same domain:code in batch", async () => {
+    const deal1 = createMockDeal("1");
+    const deal2 = createMockDeal("2", { source: { ...deal1.source } });
+    deal2.code = deal1.code; // Same domain and code
+
+    const deals = [deal1, deal2];
+    const context: PipelineContext = {
+      ...ctx,
+      deduped: deals, // Set deduped to the same list for penalty check
+    };
+
+    const result = await score(deals, context, mockEnv);
+
+    // Verify both deals received the duplicate penalty
+    expect(result.deals[0].scores.duplicate_penalty).toBe(0.5);
+    expect(result.deals[1].scores.duplicate_penalty).toBe(0.5);
+  });
+
+  it("should not apply duplicate penalty for unique domain:code in batch", async () => {
+    const deal1 = createMockDeal("1");
+    const deal2 = createMockDeal("2");
+    deal2.source.domain = "other.com";
+    deal2.code = "OTHER";
+
+    const deals = [deal1, deal2];
+    const context: PipelineContext = {
+      ...ctx,
+      deduped: deals,
+    };
+
+    const result = await score(deals, context, mockEnv);
+
+    expect(result.deals[0].scores.duplicate_penalty).toBe(0.0);
+    expect(result.deals[1].scores.duplicate_penalty).toBe(0.0);
+  });
 });

--- a/worker/pipeline/score.ts
+++ b/worker/pipeline/score.ts
@@ -1,6 +1,5 @@
 import { Deal, PipelineContext } from "../types";
 import { CONFIG } from "../config";
-import { getProductionSnapshot } from "../lib/storage";
 import type { Env } from "../types";
 
 // ============================================================================
@@ -35,17 +34,13 @@ interface ScoringResult {
 export async function score(
   deals: Deal[],
   ctx: PipelineContext,
-  env: Env,
+  _env: Env,
 ): Promise<ScoringResult> {
   const scoredDeals: ScoredDeal[] = [];
   let totalConfidence = 0;
   let minConfidence = Infinity;
   let maxConfidence = -Infinity;
   let highValueCount = 0;
-
-  // Get production deals for diversity calculation
-  const prodSnapshot = await getProductionSnapshot(env);
-  const allDeals = [...(prodSnapshot?.deals || []), ...deals];
 
   // Calculate source diversity
   const diversityScore = calculateSourceDiversity(deals);
@@ -58,6 +53,15 @@ export async function score(
     totalCandidates,
   );
 
+  // Optimization: Pre-calculate frequency map for O(1) duplicate penalty lookups
+  const duplicateMap = new Map<string, number>();
+  for (const d of ctx.deduped) {
+    const key = `${d.source.domain}:${d.code}`;
+    duplicateMap.set(key, (duplicateMap.get(key) || 0) + 1);
+  }
+
+  const weights = CONFIG.SCORING_WEIGHTS;
+
   for (const deal of deals) {
     // Calculate individual scores
     const validityScore = 1.0; // Already passed validation
@@ -65,11 +69,10 @@ export async function score(
     const rewardPlausibility = calculateRewardPlausibility(deal);
     const expiryScore = deal.expiry.confidence;
 
-    // Calculate duplicate penalty
-    const duplicatePenalty = calculateDuplicatePenalty(deal, ctx);
+    // Calculate duplicate penalty (O(1) lookup)
+    const duplicatePenalty = calculateDuplicatePenalty(deal, duplicateMap);
 
     // Calculate final confidence score
-    const weights = CONFIG.SCORING_WEIGHTS;
     const confidenceScore =
       validityScore * weights.validity_ratio +
       uniquenessScore * weights.uniqueness_score +
@@ -185,16 +188,16 @@ function calculateRewardPlausibility(deal: Deal): number {
 /**
  * Calculate duplicate penalty for a deal
  */
-function calculateDuplicatePenalty(deal: Deal, ctx: PipelineContext): number {
+function calculateDuplicatePenalty(
+  deal: Deal,
+  duplicateMap: Map<string, number>,
+): number {
   // Check if similar deal exists in this batch
-  const similarInBatch = ctx.deduped.filter(
-    (d) =>
-      d.id !== deal.id &&
-      d.source.domain === deal.source.domain &&
-      d.code === deal.code,
-  );
+  const key = `${deal.source.domain}:${deal.code}`;
+  const count = duplicateMap.get(key) || 0;
 
-  if (similarInBatch.length > 0) {
+  // If count > 1, then there are other deals with the same domain:code
+  if (count > 1) {
     return 0.5; // Penalty for duplicates
   }
 


### PR DESCRIPTION
What: Optimized the scoring pipeline in worker/pipeline/score.ts by removing a redundant KV fetch and refactoring the duplicate penalty calculation.

Why: The getProductionSnapshot fetch was unused, causing unnecessary I/O. The calculateDuplicatePenalty logic was O(N^2) due to nested filtering, which becomes a bottleneck as the deal count grows.

Impact: Reduced I/O overhead by eliminating one KV fetch per run. Improved algorithmic complexity of duplicate detection from O(N^2) to O(N) using a frequency map.

---
*PR created automatically by Jules for task [14323133474373889959](https://jules.google.com/task/14323133474373889959) started by @do-ops885*