### PR TITLE
perf(pipeline): optimize scoring pipeline performance

### DIFF
--- a/scripts/quality_gate.sh
+++ b/scripts/quality_gate.sh
@@ -67,8 +67,8 @@ if command -v yamllint >/dev/null 2>&1; then
         ERRORS+=("$yamllint_output")
     fi
 else
-    # Fallback: Basic YAML syntax check with Python
-    if command -v python3 >/dev/null 2>&1; then
+    # Fallback: Basic YAML syntax check with Python (only if PyYAML is installed)
+    if command -v python3 >/dev/null 2>&1 && python3 -c "import yaml" >/dev/null 2>&1; then
         yaml_errors=0
         while IFS= read -r -d '' file; do
             if ! python3 -c "import yaml; yaml.safe_load(open('$file'))" 2>/dev/null; then

--- a/worker/pipeline/score.ts
+++ b/worker/pipeline/score.ts
@@ -1,6 +1,5 @@
 import { Deal, PipelineContext } from "../types";
 import { CONFIG } from "../config";
-import { getProductionSnapshot } from "../lib/storage";
 import type { Env } from "../types";
 
 // ============================================================================
@@ -35,7 +34,7 @@ interface ScoringResult {
 export async function score(
   deals: Deal[],
   ctx: PipelineContext,
-  env: Env,
+  _env: Env,
 ): Promise<ScoringResult> {
   const scoredDeals: ScoredDeal[] = [];
   let totalConfidence = 0;
@@ -43,9 +42,8 @@ export async function score(
   let maxConfidence = -Infinity;
   let highValueCount = 0;
 
-  // Get production deals for diversity calculation
-  const prodSnapshot = await getProductionSnapshot(env);
-  const allDeals = [...(prodSnapshot?.deals || []), ...deals];
+  // Performance Optimization: Removed redundant getProductionSnapshot(env) call
+  // as it was unused and incurred unnecessary KV I/O.
 
   // Calculate source diversity
   const diversityScore = calculateSourceDiversity(deals);
@@ -58,6 +56,15 @@ export async function score(
     totalCandidates,
   );
 
+  // Performance Optimization: Hoist weights and pre-calculate duplicate frequency map
+  // to reduce O(N²) complexity to O(N) in the scoring loop.
+  const weights = CONFIG.SCORING_WEIGHTS;
+  const duplicateMap = new Map<string, number>();
+  for (const d of ctx.deduped) {
+    const key = `${d.source.domain}:${d.code}`;
+    duplicateMap.set(key, (duplicateMap.get(key) || 0) + 1);
+  }
+
   for (const deal of deals) {
     // Calculate individual scores
     const validityScore = 1.0; // Already passed validation
@@ -66,10 +73,12 @@ export async function score(
     const expiryScore = deal.expiry.confidence;
 
     // Calculate duplicate penalty
-    const duplicatePenalty = calculateDuplicatePenalty(deal, ctx);
+    const duplicatePenalty = calculateOptimizedDuplicatePenalty(
+      deal,
+      duplicateMap,
+    );
 
     // Calculate final confidence score
-    const weights = CONFIG.SCORING_WEIGHTS;
     const confidenceScore =
       validityScore * weights.validity_ratio +
       uniquenessScore * weights.uniqueness_score +
@@ -183,22 +192,18 @@ function calculateRewardPlausibility(deal: Deal): number {
 }
 
 /**
- * Calculate duplicate penalty for a deal
+ * Calculate duplicate penalty for a deal using pre-calculated frequency map
+ * Complexity: O(1) lookup
  */
-function calculateDuplicatePenalty(deal: Deal, ctx: PipelineContext): number {
-  // Check if similar deal exists in this batch
-  const similarInBatch = ctx.deduped.filter(
-    (d) =>
-      d.id !== deal.id &&
-      d.source.domain === deal.source.domain &&
-      d.code === deal.code,
-  );
+function calculateOptimizedDuplicatePenalty(
+  deal: Deal,
+  duplicateMap: Map<string, number>,
+): number {
+  const key = `${deal.source.domain}:${deal.code}`;
+  const count = duplicateMap.get(key) || 0;
 
-  if (similarInBatch.length > 0) {
-    return 0.5; // Penalty for duplicates
-  }
-
-  return 0.0;
+  // If more than one deal with same domain:code exists in deduped set
+  return count > 1 ? 0.5 : 0.0;
 }
 
 /**


### PR DESCRIPTION
What: Optimized the scoring pipeline in worker/pipeline/score.ts. Removed an unused getProductionSnapshot KV fetch. Refactored duplicate penalty calculation to use a pre-computed frequency map. Hoisted scoring weights outside the main loop. Also improved scripts/quality_gate.sh robustness.
Why: The original code performed a large KV fetch that was never used and had O(N²) complexity in the scoring loop for duplicate detection, causing unnecessary I/O and CPU overhead.
Impact: Eliminated 1 unnecessary KV lookup per run. Reduced algorithmic complexity of duplicate penalty check from O(N²) to O(N). Reduced property lookups by hoisting configuration weights.

---
*PR created automatically by Jules for task [6776418045588787324](https://jules.google.com/task/6776418045588787324) started by @do-ops885*