### PR TITLE
Optimize scoring pipeline and ranking calculations

### DIFF
--- a/worker/lib/ranking.ts
+++ b/worker/lib/ranking.ts
@@ -29,18 +29,13 @@ export function calculateDealScore(deal: Deal): number {
     expiry: calculateExpiryScore(deal.expiry.date),
   };
 
-  // Weighted composite score
-  const weights = {
-    confidence: 0.25,
-    trust: 0.2,
-    recency: 0.2,
-    value: 0.2,
-    expiry: 0.15,
-  };
-
-  return Object.entries(scores).reduce(
-    (sum, [key, value]) => sum + value * weights[key as keyof typeof weights],
-    0,
+  // Optimization: Direct summation avoids intermediate array and object allocations in hot path
+  return (
+    scores.confidence * 0.25 +
+    scores.trust * 0.2 +
+    scores.recency * 0.2 +
+    scores.value * 0.2 +
+    scores.expiry * 0.15
   );
 }
 

--- a/worker/pipeline/score.ts
+++ b/worker/pipeline/score.ts
@@ -1,6 +1,5 @@
 import { Deal, PipelineContext } from "../types";
 import { CONFIG } from "../config";
-import { getProductionSnapshot } from "../lib/storage";
 import type { Env } from "../types";
 
 // ============================================================================
@@ -43,10 +42,6 @@ export async function score(
   let maxConfidence = -Infinity;
   let highValueCount = 0;
 
-  // Get production deals for diversity calculation
-  const prodSnapshot = await getProductionSnapshot(env);
-  const allDeals = [...(prodSnapshot?.deals || []), ...deals];
-
   // Calculate source diversity
   const diversityScore = calculateSourceDiversity(deals);
 
@@ -58,6 +53,16 @@ export async function score(
     totalCandidates,
   );
 
+  // Optimization: Hoist scoring weights outside the loop
+  const weights = CONFIG.SCORING_WEIGHTS;
+
+  // Optimization: Pre-calculate duplicate counts to avoid O(N^2) penalty check
+  const duplicateCounts = new Map<string, number>();
+  for (const d of ctx.deduped) {
+    const key = `${d.source.domain}:${d.code}`;
+    duplicateCounts.set(key, (duplicateCounts.get(key) || 0) + 1);
+  }
+
   for (const deal of deals) {
     // Calculate individual scores
     const validityScore = 1.0; // Already passed validation
@@ -65,11 +70,13 @@ export async function score(
     const rewardPlausibility = calculateRewardPlausibility(deal);
     const expiryScore = deal.expiry.confidence;
 
-    // Calculate duplicate penalty
-    const duplicatePenalty = calculateDuplicatePenalty(deal, ctx);
+    // Calculate duplicate penalty (O(1) lookup)
+    const duplicatePenalty =
+      (duplicateCounts.get(`${deal.source.domain}:${deal.code}`) || 0) > 1
+        ? 0.5
+        : 0.0;
 
     // Calculate final confidence score
-    const weights = CONFIG.SCORING_WEIGHTS;
     const confidenceScore =
       validityScore * weights.validity_ratio +
       uniquenessScore * weights.uniqueness_score +
@@ -180,25 +187,6 @@ function calculateRewardPlausibility(deal: Deal): number {
   if (reward.type === "item") return 0.8;
 
   return 0.8;
-}
-
-/**
- * Calculate duplicate penalty for a deal
- */
-function calculateDuplicatePenalty(deal: Deal, ctx: PipelineContext): number {
-  // Check if similar deal exists in this batch
-  const similarInBatch = ctx.deduped.filter(
-    (d) =>
-      d.id !== deal.id &&
-      d.source.domain === deal.source.domain &&
-      d.code === deal.code,
-  );
-
-  if (similarInBatch.length > 0) {
-    return 0.5; // Penalty for duplicates
-  }
-
-  return 0.0;
 }
 
 /**


### PR DESCRIPTION
What: Technical description of the code change
The scoring and ranking logic was optimized to reduce algorithmic complexity and memory allocation overhead. In `worker/pipeline/score.ts`, a redundant KV fetch and a large array allocation were removed. The duplicate penalty calculation was refactored from an O(N^2) search to an O(N) lookup using a pre-calculated frequency map. Additionally, configuration weights were hoisted out of the main loop. In `worker/lib/ranking.ts`, the composite score calculation was refactored to use direct summation instead of `Object.entries().reduce()`.

Why: The specific bottleneck resolved
1. Redundant I/O: Every pipeline run performed an unnecessary KV fetch of the production snapshot in the scoring phase.
2. Algorithmic Inefficiency: The duplicate penalty calculation performed a full filter of the deduped set for every deal in the validated set, leading to O(N^2) complexity in the scoring loop.
3. Allocation Overhead: The ranking logic created multiple intermediate objects and arrays (via `Object.entries` and `reduce`) for every deal being scored or ranked, which is a significant overhead in hot paths processing many deals.

Impact: Mathematical/metric improvement
1. I/O Reduction: -1 KV GET request per pipeline run.
2. Time Complexity: Scoring duplicate penalty reduced from O(N*M) to O(N+M), where N is the number of validated deals and M is the number of deduped deals.
3. Memory/CPU: Reduced heap allocations by eliminating O(D) array spreads (D=total deals) and replacing multiple allocations per `calculateDealScore` call with zero-allocation direct summation.

---
*PR created automatically by Jules for task [9802928412355051780](https://jules.google.com/task/9802928412355051780) started by @do-ops885*