### PR TITLE
perf(pipeline): optimize score function pipeline

### DIFF
--- a/worker/pipeline/score.ts
+++ b/worker/pipeline/score.ts
@@ -1,6 +1,5 @@
 import { Deal, PipelineContext } from "../types";
 import { CONFIG } from "../config";
-import { getProductionSnapshot } from "../lib/storage";
 import type { Env } from "../types";
 
 // ============================================================================
@@ -43,10 +42,6 @@ export async function score(
   let maxConfidence = -Infinity;
   let highValueCount = 0;
 
-  // Get production deals for diversity calculation
-  const prodSnapshot = await getProductionSnapshot(env);
-  const allDeals = [...(prodSnapshot?.deals || []), ...deals];
-
   // Calculate source diversity
   const diversityScore = calculateSourceDiversity(deals);
 
@@ -58,6 +53,16 @@ export async function score(
     totalCandidates,
   );
 
+  // Pre-calculate frequency map for O(1) duplicate penalty lookup
+  // Frequency of domain:code in the deduped set
+  const duplicateCounts = new Map<string, number>();
+  for (const d of ctx.deduped) {
+    const key = `${d.source.domain}:${d.code}`;
+    duplicateCounts.set(key, (duplicateCounts.get(key) || 0) + 1);
+  }
+
+  const weights = CONFIG.SCORING_WEIGHTS;
+
   for (const deal of deals) {
     // Calculate individual scores
     const validityScore = 1.0; // Already passed validation
@@ -66,10 +71,11 @@ export async function score(
     const expiryScore = deal.expiry.confidence;
 
     // Calculate duplicate penalty
-    const duplicatePenalty = calculateDuplicatePenalty(deal, ctx);
+    // Use the pre-calculated frequency map to avoid O(N^2) inner filter
+    const key = `${deal.source.domain}:${deal.code}`;
+    const duplicatePenalty = (duplicateCounts.get(key) || 0) > 1 ? 0.5 : 0.0;
 
     // Calculate final confidence score
-    const weights = CONFIG.SCORING_WEIGHTS;
     const confidenceScore =
       validityScore * weights.validity_ratio +
       uniquenessScore * weights.uniqueness_score +
@@ -180,25 +186,6 @@ function calculateRewardPlausibility(deal: Deal): number {
   if (reward.type === "item") return 0.8;
 
   return 0.8;
-}
-
-/**
- * Calculate duplicate penalty for a deal
- */
-function calculateDuplicatePenalty(deal: Deal, ctx: PipelineContext): number {
-  // Check if similar deal exists in this batch
-  const similarInBatch = ctx.deduped.filter(
-    (d) =>
-      d.id !== deal.id &&
-      d.source.domain === deal.source.domain &&
-      d.code === deal.code,
-  );
-
-  if (similarInBatch.length > 0) {
-    return 0.5; // Penalty for duplicates
-  }
-
-  return 0.0;
 }
 
 /**


### PR DESCRIPTION
What: Removed an unused getProductionSnapshot call and refactored the duplicate penalty calculation to use a frequency map.
Why: Every score phase execution was performing an unnecessary KV fetch and an O(N^2) inner filter on the deduped set.
Impact: Reduces KV subrequests by 1 per run and improves scoring complexity from O(N^2) to O(N).

---
*PR created automatically by Jules for task [8140839483584700468](https://jules.google.com/task/8140839483584700468) started by @do-ops885*