### PR TITLE
perf(pipeline): optimize scoring pipeline performance

### DIFF
--- a/worker/pipeline/score.ts
+++ b/worker/pipeline/score.ts
@@ -1,6 +1,5 @@
 import { Deal, PipelineContext } from "../types";
 import { CONFIG } from "../config";
-import { getProductionSnapshot } from "../lib/storage";
 import type { Env } from "../types";
 
 // ============================================================================
@@ -43,12 +42,15 @@ export async function score(
   let maxConfidence = -Infinity;
   let highValueCount = 0;
 
-  // Get production deals for diversity calculation
-  const prodSnapshot = await getProductionSnapshot(env);
-  const allDeals = [...(prodSnapshot?.deals || []), ...deals];
-
   // Calculate source diversity
   const diversityScore = calculateSourceDiversity(deals);
+
+  // Pre-calculate duplicate counts for O(N) penalty calculation
+  const duplicateCounts = new Map<string, number>();
+  for (const d of ctx.deduped) {
+    const key = `${d.source.domain}:${d.code}`;
+    duplicateCounts.set(key, (duplicateCounts.get(key) || 0) + 1);
+  }
 
   // Calculate uniqueness from deduplication phase
   const totalCandidates = ctx.candidates.length;
@@ -58,6 +60,8 @@ export async function score(
     totalCandidates,
   );
 
+  const weights = CONFIG.SCORING_WEIGHTS;
+
   for (const deal of deals) {
     // Calculate individual scores
     const validityScore = 1.0; // Already passed validation
@@ -66,10 +70,9 @@ export async function score(
     const expiryScore = deal.expiry.confidence;
 
     // Calculate duplicate penalty
-    const duplicatePenalty = calculateDuplicatePenalty(deal, ctx);
+    const duplicatePenalty = calculateDuplicatePenalty(deal, duplicateCounts);
 
     // Calculate final confidence score
-    const weights = CONFIG.SCORING_WEIGHTS;
     const confidenceScore =
       validityScore * weights.validity_ratio +
       uniquenessScore * weights.uniqueness_score +
@@ -185,16 +188,14 @@ function calculateRewardPlausibility(deal: Deal): number {
 /**
  * Calculate duplicate penalty for a deal
  */
-function calculateDuplicatePenalty(deal: Deal, ctx: PipelineContext): number {
-  // Check if similar deal exists in this batch
-  const similarInBatch = ctx.deduped.filter(
-    (d) =>
-      d.id !== deal.id &&
-      d.source.domain === deal.source.domain &&
-      d.code === deal.code,
-  );
+function calculateDuplicatePenalty(
+  deal: Deal,
+  duplicateCounts: Map<string, number>,
+): number {
+  const key = `${deal.source.domain}:${deal.code}`;
+  const count = duplicateCounts.get(key) || 0;
 
-  if (similarInBatch.length > 0) {
+  if (count > 1) {
     return 0.5; // Penalty for duplicates
   }
 


### PR DESCRIPTION
What: Removed redundant getProductionSnapshot KV fetch and refactored duplicate penalty calculation to use a pre-calculated frequency map.
Why: Redundant I/O and O(N^2) complexity in the scoring loop were causing unnecessary latency and compute overhead.
Impact: Eliminates one KV read per pipeline run and reduces duplicate penalty calculation complexity from O(N*M) to O(N).
Verification: Verified with unit tests in tests/unit/score.test.ts and successful execution of scripts/quality_gate.sh.

---
*PR created automatically by Jules for task [16403831986536960394](https://jules.google.com/task/16403831986536960394) started by @do-ops885*