### PR TITLE
Add auto-resolution for outdated DeepSource comments

### DIFF
--- a/.github/workflows/resolve-deepsource.yml
+++ b/.github/workflows/resolve-deepsource.yml
@@ -1,0 +1,22 @@
+---
+name: "Resolve outdated DeepSource comments"
+
+"on":
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  resolve-outdated:
+    name: Resolve Outdated
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve outdated DeepSource threads
+        uses: Ardiannn08/resolve-outdated-comment@v1.3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          filter-user: "deepsource-io[bot]"
+          mode: "resolve"


### PR DESCRIPTION
Adds a new GitHub Action workflow to automatically resolve outdated DeepSource bot comments on pull requests. This helps keep PR conversations clean by closing automated threads that are no longer relevant after new commits are pushed.

Key changes:
- Created .github/workflows/resolve-deepsource.yml
- Configured triggers for PR opened, synchronize, and reopened events
- Set filter to target deepsource-io[bot] only
- Granted pull-requests: write permission to allow thread resolution

Verification:
- Manual inspection of the YAML configuration
- Quality gate check (passed)
- Code review performed and approved

---
*PR created automatically by Jules for task [4239856838353558397](https://jules.google.com/task/4239856838353558397) started by @do-ops885*