### PR TITLE
perf(ranking): optimize deal scoring and ranking performance

### DIFF
--- a/tests/unit/ranking.test.ts
+++ b/tests/unit/ranking.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import {
+  calculateDealScore,
+  calculateDetailedScore,
+  rankDeals,
+  sortDeals,
+} from "../../worker/lib/ranking";
+import type { Deal } from "../../worker/types";
+
+const createMockDeal = (id: string, overrides: Partial<Deal> = {}): Deal => ({
+  id,
+  source: {
+    url: "https://example.com/invite",
+    domain: "example.com",
+    discovered_at: overrides.source?.discovered_at || new Date().toISOString(),
+    trust_score: overrides.source?.trust_score ?? 0.7,
+  },
+  title: overrides.title || "Test Deal",
+  description: "Test description",
+  code: overrides.code || "CODE123",
+  url: overrides.url || "https://example.com/invite/CODE123",
+  reward: {
+    type: (overrides.reward?.type as any) || "cash",
+    value: overrides.reward?.value ?? 50,
+    currency: "USD",
+  },
+  expiry: {
+    date: overrides.expiry?.date,
+    confidence: overrides.expiry?.confidence ?? 0.8,
+    type: (overrides.expiry?.type as any) || "soft",
+  },
+  metadata: {
+    category: overrides.metadata?.category || ["test"],
+    tags: ["test"],
+    normalized_at: new Date().toISOString(),
+    confidence_score: overrides.metadata?.confidence_score ?? 0.5,
+    status: (overrides.metadata?.status as any) || "active",
+  },
+});
+
+describe("Ranking Logic", () => {
+  it("should calculate consistent scores between simple and detailed functions", () => {
+    const deal = createMockDeal("1");
+    const simpleScore = calculateDealScore(deal);
+    const { score: detailedScore, breakdown } = calculateDetailedScore(deal);
+
+    expect(simpleScore).toBe(detailedScore);
+    expect(breakdown.confidence).toBe(deal.metadata.confidence_score * 100);
+    expect(breakdown.trust).toBe(deal.source.trust_score * 100);
+  });
+
+  it("should rank deals by composite score", () => {
+    const deal1 = createMockDeal("1", {
+      metadata: { confidence_score: 0.9 } as any,
+      source: { trust_score: 0.9 } as any,
+    });
+    const deal2 = createMockDeal("2", {
+      metadata: { confidence_score: 0.1 } as any,
+      source: { trust_score: 0.1 } as any,
+    });
+
+    const result = rankDeals([deal1, deal2], {
+      sortBy: "confidence", // In sortDeals, default is composite score if field not explicitly handled or for rankDeals composite is used for scores breakdown
+      order: "desc",
+    });
+
+    expect(result.deals[0].id).toBe("1");
+    expect(result.scores![0].score).toBeGreaterThan(result.scores![1].score);
+  });
+
+  it("should filter deals by status", () => {
+    const activeDeal = createMockDeal("active", {
+      metadata: { status: "active" } as any,
+    });
+    const rejectedDeal = createMockDeal("rejected", {
+      metadata: { status: "rejected" } as any,
+    });
+
+    const result = rankDeals([activeDeal, rejectedDeal], {
+      sortBy: "confidence",
+      order: "desc",
+    });
+
+    expect(result.deals).toHaveLength(1);
+    expect(result.deals[0].id).toBe("active");
+  });
+
+  it("should filter by minConfidence", () => {
+    const highConf = createMockDeal("high", {
+      metadata: { confidence_score: 0.8 } as any,
+    });
+    const lowConf = createMockDeal("low", {
+      metadata: { confidence_score: 0.2 } as any,
+    });
+
+    const result = rankDeals([highConf, lowConf], {
+      sortBy: "confidence",
+      order: "desc",
+      minConfidence: 0.5,
+    });
+
+    expect(result.deals).toHaveLength(1);
+    expect(result.deals[0].id).toBe("high");
+  });
+
+  it("should sort by recency", () => {
+    const oldDate = new Date(
+      Date.now() - 30 * 24 * 60 * 60 * 1000,
+    ).toISOString();
+    const newDate = new Date().toISOString();
+
+    const oldDeal = createMockDeal("old", {
+      source: { discovered_at: oldDate } as any,
+    });
+    const newDeal = createMockDeal("new", {
+      source: { discovered_at: newDate } as any,
+    });
+
+    const sorted = sortDeals([oldDeal, newDeal], "recency", "desc");
+    expect(sorted[0].id).toBe("new");
+  });
+});

--- a/worker/lib/ranking.ts
+++ b/worker/lib/ranking.ts
@@ -21,27 +21,49 @@ export interface RankOptions {
  * Composite score based on multiple factors
  */
 export function calculateDealScore(deal: Deal): number {
-  const scores = {
-    confidence: deal.metadata.confidence_score * 100,
-    trust: deal.source.trust_score * 100,
-    recency: calculateRecencyScore(deal.source.discovered_at),
-    value: calculateValueScore(deal.reward),
-    expiry: calculateExpiryScore(deal.expiry.date),
-  };
+  const { score } = calculateDetailedScore(deal);
+  return score;
+}
 
-  // Weighted composite score
-  const weights = {
-    confidence: 0.25,
-    trust: 0.2,
-    recency: 0.2,
-    value: 0.2,
-    expiry: 0.15,
+/**
+ * Calculate detailed score breakdown for ranking
+ * Single-pass calculation to avoid redundant computation
+ */
+export function calculateDetailedScore(deal: Deal): {
+  score: number;
+  breakdown: {
+    confidence: number;
+    trust: number;
+    recency: number;
+    value: number;
+    expiry: number;
   };
+} {
+  const confidence = deal.metadata.confidence_score * 100;
+  const trust = deal.source.trust_score * 100;
+  const recency = calculateRecencyScore(deal.source.discovered_at);
+  const value = calculateValueScore(deal.reward);
+  const expiry = calculateExpiryScore(deal.expiry.date);
 
-  return Object.entries(scores).reduce(
-    (sum, [key, value]) => sum + value * weights[key as keyof typeof weights],
-    0,
-  );
+  // Performance optimization: direct weighted summation avoids intermediate
+  // allocations from Object.entries().reduce()
+  const score =
+    confidence * 0.25 +
+    trust * 0.2 +
+    recency * 0.2 +
+    value * 0.2 +
+    expiry * 0.15;
+
+  return {
+    score,
+    breakdown: {
+      confidence,
+      trust,
+      recency,
+      value,
+      expiry,
+    },
+  };
 }
 
 /**
@@ -221,18 +243,15 @@ export function rankDeals(
   // Sort
   const sorted = sortDeals(filtered, options.sortBy, options.order);
 
-  // Calculate scores with breakdown
-  const scores = sorted.map((deal) => ({
-    dealId: deal.id,
-    score: calculateDealScore(deal),
-    breakdown: {
-      confidence: deal.metadata.confidence_score * 100,
-      trust: deal.source.trust_score * 100,
-      recency: calculateRecencyScore(deal.source.discovered_at),
-      value: calculateValueScore(deal.reward),
-      expiry: calculateExpiryScore(deal.expiry.date),
-    },
-  }));
+  // Calculate scores with breakdown (single-pass optimization)
+  const scores = sorted.map((deal) => {
+    const { score, breakdown } = calculateDetailedScore(deal);
+    return {
+      dealId: deal.id,
+      score,
+      breakdown,
+    };
+  });
 
   // Apply limit
   const limited = options.limit ? sorted.slice(0, options.limit) : sorted;


### PR DESCRIPTION
What: Introduced calculateDetailedScore for single-pass score and breakdown computation. Refactored calculateDealScore to use direct weighted summation instead of Object.entries().reduce().
Why: Redundant computation of recency, value, and expiry scores in rankDeals and high allocation overhead from object/array transformations in hot paths.
Impact: Reduces computational redundancy by 50% in the ranking phase and eliminates multiple intermediate allocations per deal.

---
*PR created automatically by Jules for task [2851014044825694975](https://jules.google.com/task/2851014044825694975) started by @do-ops885*