### PR TITLE
expose stage latency histograms for pipeline bottleneck analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,10 +114,11 @@ curl https://your-worker.workers.dev/api/log
 
 Check `/metrics` for:
 
-- Total runs
-- Success rate
-- Deal counts
-- Validation failures
+- Total runs and success rate
+- Deal counts (discovered, validated, published)
+- **Stage Latency**: Histograms for discovery, validation, and publish stages
+- **Bottleneck Analysis**: Timing breakdown by success/failure status
+- Validation cache hits/misses
 
 ## Support
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8832,9 +8832,9 @@
       }
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "dev": true,
       "funding": [
         {
@@ -8844,7 +8844,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -12680,6 +12681,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xmlhttprequest-ssl": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "overrides": {
     "fast-xml-parser": "5.7.1",
+    "fast-xml-builder": "1.2.0",
     "uuid": "14.0.0"
   },
   "engines": {

--- a/tests/unit/metrics_latency.test.ts
+++ b/tests/unit/metrics_latency.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import { calculateAggregateStats, formatMetricsForPrometheus } from "../../worker/lib/metrics/stats";
+import { PipelineMetrics, PipelinePhase } from "../../worker/types";
+
+describe("Latency Metrics", () => {
+  const mockMetrics: PipelineMetrics[] = [
+    {
+      run_id: "run1",
+      start_time: 1000,
+      end_time: 2000,
+      total_duration_ms: 1000,
+      success: true,
+      final_phase: "finalize",
+      phase_timings: {
+        init: 10,
+        discover: 200,
+        normalize: 50,
+        dedupe: 50,
+        validate: 300,
+        score: 100,
+        stage: 100,
+        publish: 150,
+        verify: 30,
+        finalize: 10,
+      },
+      phase_results: {
+        init: "success",
+        discover: "success",
+        normalize: "success",
+        dedupe: "success",
+        validate: "success",
+        score: "success",
+        stage: "success",
+        publish: "success",
+        verify: "success",
+        finalize: "success",
+      },
+      deals_processed: { discovered: 10, normalized: 10, deduped: 8, validated: 5, scored: 5, published: 5 },
+      errors: 0,
+      retries: 0,
+    },
+    {
+      run_id: "run2",
+      start_time: 2000,
+      end_time: 2500,
+      total_duration_ms: 500,
+      success: false,
+      final_phase: "validate",
+      phase_timings: {
+        init: 10,
+        discover: 150,
+        normalize: 40,
+        dedupe: 40,
+        validate: 260,
+        score: 0,
+        stage: 0,
+        publish: 0,
+        verify: 0,
+        finalize: 0,
+      },
+      phase_results: {
+        init: "success",
+        discover: "success",
+        normalize: "success",
+        dedupe: "success",
+        validate: "failure",
+        score: "success", // default
+        stage: "success",
+        publish: "success",
+        verify: "success",
+        finalize: "success",
+      },
+      deals_processed: { discovered: 5, normalized: 5, deduped: 4, validated: 0, scored: 0, published: 0 },
+      errors: 1,
+      retries: 0,
+    }
+  ];
+
+  it("should calculate aggregate stats with latency correctly", () => {
+    const stats = calculateAggregateStats(mockMetrics);
+    expect(stats.total_runs).toBe(2);
+    expect(stats.successful_runs).toBe(1);
+    expect(stats.failed_runs).toBe(1);
+    expect(stats.avg_duration_ms).toBe(750);
+    expect(stats.avg_phase_timings.discover).toBe(175);
+    expect(stats.avg_phase_timings.validate).toBe(280);
+  });
+
+  it("should format Prometheus metrics with labels and quantiles", () => {
+    const stats = calculateAggregateStats(mockMetrics);
+    const prometheus = formatMetricsForPrometheus(stats, mockMetrics);
+
+    // Check for new phase duration metrics with status and quantile labels
+    expect(prometheus).toContain('deals_pipeline_phase_duration_ms{phase="discover",status="success",quantile="0.5"}');
+    expect(prometheus).toContain('deals_pipeline_phase_duration_ms{phase="validate",status="failure",quantile="0.5"}');
+
+    // Check for average and max helpers
+    expect(prometheus).toContain('deals_pipeline_phase_duration_ms_avg{phase="discover",status="success"} 175');
+    expect(prometheus).toContain('deals_pipeline_phase_duration_ms_max{phase="validate",status="success"} 300');
+    expect(prometheus).toContain('deals_pipeline_phase_duration_ms_max{phase="validate",status="failure"} 260');
+
+    // Check for total duration quantiles
+    expect(prometheus).toContain('deals_pipeline_total_duration_ms{status="success",quantile="0.5"} 1000');
+    expect(prometheus).toContain('deals_pipeline_total_duration_ms{status="failure",quantile="0.5"} 500');
+  });
+
+  it("should handle empty metrics array gracefully", () => {
+    const stats = calculateAggregateStats([]);
+    const prometheus = formatMetricsForPrometheus(stats, []);
+    expect(prometheus).toContain("deals_pipeline_runs_total 0");
+  });
+});

--- a/tests/unit/metrics_latency.test.ts
+++ b/tests/unit/metrics_latency.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { calculateAggregateStats, formatMetricsForPrometheus } from "../../worker/lib/metrics/stats";
+import {
+  calculateAggregateStats,
+  formatMetricsForPrometheus,
+} from "../../worker/lib/metrics/stats";
 import { PipelineMetrics, PipelinePhase } from "../../worker/types";
 
 describe("Latency Metrics", () => {
@@ -35,7 +38,14 @@ describe("Latency Metrics", () => {
         verify: "success",
         finalize: "success",
       },
-      deals_processed: { discovered: 10, normalized: 10, deduped: 8, validated: 5, scored: 5, published: 5 },
+      deals_processed: {
+        discovered: 10,
+        normalized: 10,
+        deduped: 8,
+        validated: 5,
+        scored: 5,
+        published: 5,
+      },
       errors: 0,
       retries: 0,
     },
@@ -70,10 +80,17 @@ describe("Latency Metrics", () => {
         verify: "success",
         finalize: "success",
       },
-      deals_processed: { discovered: 5, normalized: 5, deduped: 4, validated: 0, scored: 0, published: 0 },
+      deals_processed: {
+        discovered: 5,
+        normalized: 5,
+        deduped: 4,
+        validated: 0,
+        scored: 0,
+        published: 0,
+      },
       errors: 1,
       retries: 0,
-    }
+    },
   ];
 
   it("should calculate aggregate stats with latency correctly", () => {
@@ -91,17 +108,31 @@ describe("Latency Metrics", () => {
     const prometheus = formatMetricsForPrometheus(stats, mockMetrics);
 
     // Check for new phase duration metrics with status and quantile labels
-    expect(prometheus).toContain('deals_pipeline_phase_duration_ms{phase="discover",status="success",quantile="0.5"}');
-    expect(prometheus).toContain('deals_pipeline_phase_duration_ms{phase="validate",status="failure",quantile="0.5"}');
+    expect(prometheus).toContain(
+      'deals_pipeline_phase_duration_ms{phase="discover",status="success",quantile="0.5"}',
+    );
+    expect(prometheus).toContain(
+      'deals_pipeline_phase_duration_ms{phase="validate",status="failure",quantile="0.5"}',
+    );
 
     // Check for average and max helpers
-    expect(prometheus).toContain('deals_pipeline_phase_duration_ms_avg{phase="discover",status="success"} 175');
-    expect(prometheus).toContain('deals_pipeline_phase_duration_ms_max{phase="validate",status="success"} 300');
-    expect(prometheus).toContain('deals_pipeline_phase_duration_ms_max{phase="validate",status="failure"} 260');
+    expect(prometheus).toContain(
+      'deals_pipeline_phase_duration_ms_avg{phase="discover",status="success"} 175',
+    );
+    expect(prometheus).toContain(
+      'deals_pipeline_phase_duration_ms_max{phase="validate",status="success"} 300',
+    );
+    expect(prometheus).toContain(
+      'deals_pipeline_phase_duration_ms_max{phase="validate",status="failure"} 260',
+    );
 
     // Check for total duration quantiles
-    expect(prometheus).toContain('deals_pipeline_total_duration_ms{status="success",quantile="0.5"} 1000');
-    expect(prometheus).toContain('deals_pipeline_total_duration_ms{status="failure",quantile="0.5"} 500');
+    expect(prometheus).toContain(
+      'deals_pipeline_total_duration_ms{status="success",quantile="0.5"} 1000',
+    );
+    expect(prometheus).toContain(
+      'deals_pipeline_total_duration_ms{status="failure",quantile="0.5"} 500',
+    );
   });
 
   it("should handle empty metrics array gracefully", () => {

--- a/worker/lib/metrics/core.ts
+++ b/worker/lib/metrics/core.ts
@@ -17,6 +17,18 @@ export function createMetrics(run_id: string): PipelineMetrics {
       verify: 0,
       finalize: 0,
     },
+    phase_results: {
+      init: "success",
+      discover: "success",
+      normalize: "success",
+      dedupe: "success",
+      validate: "success",
+      score: "success",
+      stage: "success",
+      publish: "success",
+      verify: "success",
+      finalize: "success",
+    },
     total_duration_ms: 0,
     deals_processed: {
       discovered: 0,
@@ -44,8 +56,10 @@ export function recordPhaseTiming(
   metrics: PipelineMetrics,
   phase: PipelinePhase,
   duration: number,
+  status: "success" | "failure" = "success",
 ): void {
   metrics.phase_timings[phase] = duration;
+  metrics.phase_results[phase] = status;
 }
 
 export function recordDealCount(

--- a/worker/lib/metrics/stats.ts
+++ b/worker/lib/metrics/stats.ts
@@ -128,33 +128,112 @@ export function calculateAggregateStats(metrics: PipelineMetrics[]) {
 
 export function formatMetricsForPrometheus(
   stats: ReturnType<typeof calculateAggregateStats>,
+  metrics: PipelineMetrics[] = [],
 ): string {
   const lines: string[] = [
+    `# HELP deals_pipeline_runs_total Total discovery runs`,
+    `# TYPE deals_pipeline_runs_total counter`,
     `deals_pipeline_runs_total ${stats.total_runs}`,
+    `# HELP deals_pipeline_successful_runs_total Successful publishes`,
     `deals_pipeline_successful_runs_total ${stats.successful_runs}`,
+    `# HELP deals_pipeline_failed_runs_total Failed discovery runs`,
     `deals_pipeline_failed_runs_total ${stats.failed_runs}`,
+    `# HELP deals_pipeline_success_rate Success rate percentage`,
     `deals_pipeline_success_rate ${stats.success_rate}`,
+    `# HELP deals_pipeline_duration_ms Average end-to-end duration`,
     `deals_pipeline_duration_ms ${stats.avg_duration_ms}`,
   ];
-  for (const [p, d] of Object.entries(stats.avg_phase_timings))
-    lines.push(`deals_pipeline_phase_duration_ms{phase="${p}"} ${d}`);
+
+  // Add detailed phase timings
+  if (metrics.length > 0) {
+    const detailed = getDetailedPhaseTimingStats(metrics);
+    for (const [phase, statuses] of Object.entries(detailed)) {
+      for (const [status, s] of Object.entries(statuses)) {
+        if (s.max === 0) continue; // Skip if no data
+        lines.push(
+          `deals_pipeline_phase_duration_ms{phase="${phase}",status="${status}",quantile="0.5"} ${s.p50}`,
+        );
+        lines.push(
+          `deals_pipeline_phase_duration_ms{phase="${phase}",status="${status}",quantile="0.9"} ${s.p90}`,
+        );
+        lines.push(
+          `deals_pipeline_phase_duration_ms{phase="${phase}",status="${status}",quantile="0.99"} ${s.p99}`,
+        );
+        lines.push(
+          `deals_pipeline_phase_duration_ms_avg{phase="${phase}",status="${status}"} ${s.avg}`,
+        );
+        lines.push(
+          `deals_pipeline_phase_duration_ms_max{phase="${phase}",status="${status}"} ${s.max}`,
+        );
+      }
+    }
+
+    // Add total duration quantiles
+    const totalTimingsSuccess = metrics
+      .filter((m) => m.success)
+      .map((m) => m.total_duration_ms);
+    const totalTimingsFailure = metrics
+      .filter((m) => !m.success)
+      .map((m) => m.total_duration_ms);
+
+    const successStats = calculateStats(totalTimingsSuccess);
+    const failureStats = calculateStats(totalTimingsFailure);
+
+    if (successStats.max > 0) {
+      lines.push(
+        `deals_pipeline_total_duration_ms{status="success",quantile="0.5"} ${successStats.p50}`,
+      );
+      lines.push(
+        `deals_pipeline_total_duration_ms{status="success",quantile="0.9"} ${successStats.p90}`,
+      );
+      lines.push(
+        `deals_pipeline_total_duration_ms{status="success",quantile="0.99"} ${successStats.p99}`,
+      );
+    }
+    if (failureStats.max > 0) {
+      lines.push(
+        `deals_pipeline_total_duration_ms{status="failure",quantile="0.5"} ${failureStats.p50}`,
+      );
+      lines.push(
+        `deals_pipeline_total_duration_ms{status="failure",quantile="0.9"} ${failureStats.p90}`,
+      );
+      lines.push(
+        `deals_pipeline_total_duration_ms{status="failure",quantile="0.99"} ${failureStats.p99}`,
+      );
+    }
+  } else {
+    // Fallback to average phase timings if no individual metrics provided
+    for (const [p, d] of Object.entries(stats.avg_phase_timings))
+      lines.push(`deals_pipeline_phase_duration_ms{phase="${p}",status="success",quantile="0.5"} ${d}`);
+  }
+
   for (const [s, c] of Object.entries(stats.avg_deals_per_run))
     lines.push(`deals_pipeline_deals_avg{stage="${s}"} ${c}`);
+
   if (stats.avg_validation_cache) {
     for (const [t, c] of Object.entries(stats.avg_validation_cache))
       lines.push(`deals_validation_cache_avg{type="${t}"} ${c}`);
   }
+
   lines.push(`deals_pipeline_errors_total ${stats.total_errors}`);
   lines.push(`deals_pipeline_retries_total ${stats.total_retries}`);
+
   return lines.join("\n");
 }
 
-export function getPhaseTimingStats(
+export interface PhaseTimingStats {
+  min: number;
+  max: number;
+  avg: number;
+  p50: number;
+  p90: number;
+  p95: number;
+  p99: number;
+}
+
+export function getDetailedPhaseTimingStats(
   metrics: PipelineMetrics[],
-): Record<
-  PipelinePhase,
-  { min: number; max: number; avg: number; p95: number }
-> {
+): Record<PipelinePhase, Record<"success" | "failure", PhaseTimingStats>> {
   const phases: PipelinePhase[] = [
     "init",
     "discover",
@@ -168,20 +247,65 @@ export function getPhaseTimingStats(
     "finalize",
   ];
   const res = {} as any;
+
   for (const p of phases) {
-    const timings = metrics
-      .map((m) => m.phase_timings[p])
-      .filter((t) => t > 0)
-      .sort((a, b) => a - b);
-    if (timings.length === 0) {
-      res[p] = { min: 0, max: 0, avg: 0, p95: 0 };
-      continue;
-    }
     res[p] = {
-      min: timings[0],
-      max: timings[timings.length - 1],
-      avg: Math.round(timings.reduce((a, b) => a + b, 0) / timings.length),
-      p95: timings[Math.max(0, Math.ceil(timings.length * 0.95) - 1)],
+      success: calculateStats(
+        metrics
+          .filter((m) => m.phase_results?.[p] === "success" || !m.phase_results)
+          .map((m) => m.phase_timings[p])
+          .filter((t) => t > 0),
+      ),
+      failure: calculateStats(
+        metrics
+          .filter((m) => m.phase_results?.[p] === "failure")
+          .map((m) => m.phase_timings[p])
+          .filter((t) => t > 0),
+      ),
+    };
+  }
+  return res;
+}
+
+function calculateStats(timings: number[]): PhaseTimingStats {
+  if (timings.length === 0) {
+    return { min: 0, max: 0, avg: 0, p50: 0, p90: 0, p95: 0, p99: 0 };
+  }
+  const sorted = [...timings].sort((a, b) => a - b);
+  const sum = sorted.reduce((a, b) => a + b, 0);
+  const getQuantile = (q: number) =>
+    sorted[Math.max(0, Math.ceil(sorted.length * q) - 1)];
+
+  return {
+    min: sorted[0],
+    max: sorted[sorted.length - 1],
+    avg: Math.round(sum / sorted.length),
+    p50: getQuantile(0.5),
+    p90: getQuantile(0.9),
+    p95: getQuantile(0.95),
+    p99: getQuantile(0.99),
+  };
+}
+
+export function getPhaseTimingStats(
+  metrics: PipelineMetrics[],
+): Record<
+  PipelinePhase,
+  { min: number; max: number; avg: number; p95: number }
+> {
+  const detailed = getDetailedPhaseTimingStats(metrics);
+  const res = {} as any;
+  for (const [p, stats] of Object.entries(detailed)) {
+    // For backward compatibility, combine success and failure for the old return type if needed,
+    // or just use success path which is the most common.
+    // Given the old one didn't distinguish, let's recalculate over all timings for this phase.
+    const allTimings = metrics.map((m) => m.phase_timings[p as PipelinePhase]).filter((t) => t > 0);
+    const statsAll = calculateStats(allTimings);
+    res[p] = {
+      min: statsAll.min,
+      max: statsAll.max,
+      avg: statsAll.avg,
+      p95: statsAll.p95,
     };
   }
   return res;

--- a/worker/lib/metrics/stats.ts
+++ b/worker/lib/metrics/stats.ts
@@ -204,7 +204,9 @@ export function formatMetricsForPrometheus(
   } else {
     // Fallback to average phase timings if no individual metrics provided
     for (const [p, d] of Object.entries(stats.avg_phase_timings))
-      lines.push(`deals_pipeline_phase_duration_ms{phase="${p}",status="success",quantile="0.5"} ${d}`);
+      lines.push(
+        `deals_pipeline_phase_duration_ms{phase="${p}",status="success",quantile="0.5"} ${d}`,
+      );
   }
 
   for (const [s, c] of Object.entries(stats.avg_deals_per_run))
@@ -299,7 +301,9 @@ export function getPhaseTimingStats(
     // For backward compatibility, combine success and failure for the old return type if needed,
     // or just use success path which is the most common.
     // Given the old one didn't distinguish, let's recalculate over all timings for this phase.
-    const allTimings = metrics.map((m) => m.phase_timings[p as PipelinePhase]).filter((t) => t > 0);
+    const allTimings = metrics
+      .map((m) => m.phase_timings[p as PipelinePhase])
+      .filter((t) => t > 0);
     const statsAll = calculateStats(allTimings);
     res[p] = {
       min: statsAll.min,

--- a/worker/routes/core/health.ts
+++ b/worker/routes/core/health.ts
@@ -7,6 +7,11 @@
 import { getProductionSnapshot } from "../../lib/storage";
 import { getPipelineStatus } from "../../state-machine";
 import { getRecentLogs } from "../../lib/logger";
+import { getRecentMetrics } from "../../lib/metrics/index";
+import {
+  calculateAggregateStats,
+  formatMetricsForPrometheus,
+} from "../../lib/metrics/stats";
 import { CONFIG } from "../../config";
 import type { Env, HealthStatus } from "../../types";
 import { jsonResponse, SECURITY_HEADERS } from "../utils";
@@ -94,11 +99,14 @@ export async function handleMetrics(
   format: string = "prometheus",
   request?: Request,
 ): Promise<Response> {
-  // Optimization: Parallelize snapshot and log retrieval to reduce total latency
-  const [snapshot, logs] = await Promise.all([
+  // Optimization: Parallelize snapshot, log and metrics retrieval to reduce total latency
+  const [snapshot, logs, pipelineMetrics] = await Promise.all([
     getProductionSnapshot(env),
     getRecentLogs(env, 1000),
+    getRecentMetrics(env, 100),
   ]);
+
+  const stats = calculateAggregateStats(pipelineMetrics);
 
   const runs = logs.filter((l) => l.phase === "finalize").length;
   const successes = logs.filter(
@@ -114,6 +122,8 @@ export async function handleMetrics(
         summary: {
           total_runs: runs,
           successful_runs: successes,
+          avg_duration_ms: stats.avg_duration_ms,
+          success_rate: stats.success_rate,
         },
         deals: {
           active: snapshot?.stats?.active || 0,
@@ -121,30 +131,28 @@ export async function handleMetrics(
           validated_total: valid,
           duplicate_total: duplicates,
         },
+        phases: stats.avg_phase_timings,
       },
       200,
       request,
     );
   }
 
-  const metrics = `
-# HELP deals_runs_total Total discovery runs
-# TYPE deals_runs_total counter
+  let metrics = formatMetricsForPrometheus(stats, pipelineMetrics);
+
+  // Add legacy metrics for backward compatibility
+  metrics += `
+# HELP deals_runs_total Total discovery runs (legacy)
 deals_runs_total ${runs}
-
-# HELP deals_publish_success_total Successful publishes
+# HELP deals_publish_success_total Successful publishes (legacy)
 deals_publish_success_total ${successes}
-
-# HELP deals_candidate_deals_total Candidate deals discovered
+# HELP deals_candidate_deals_total Candidate deals discovered (legacy)
 deals_candidate_deals_total ${candidates}
-
-# HELP deals_valid_deals_total Valid deals after validation
+# HELP deals_valid_deals_total Valid deals after validation (legacy)
 deals_valid_deals_total ${valid}
-
-# HELP deals_duplicate_deals_total Duplicate deals filtered
+# HELP deals_duplicate_deals_total Duplicate deals filtered (legacy)
 deals_duplicate_deals_total ${duplicates}
-
-# HELP deals_active_deals Current active deals in production
+# HELP deals_active_deals Current active deals in production (legacy)
 deals_active_deals ${snapshot?.stats?.active || 0}
 `.trim();
 

--- a/worker/state-machine.ts
+++ b/worker/state-machine.ts
@@ -108,12 +108,21 @@ export async function executePipeline(env: Env): Promise<{
 
         // Execute phase
         const phaseStartTime = Date.now();
-        const result = await executePhase(currentPhase, ctx, env);
-        const phaseDuration = Date.now() - phaseStartTime;
+        let result: PipelinePhase | FailurePath;
+        try {
+          result = await executePhase(currentPhase, ctx, env);
+          const phaseDuration = Date.now() - phaseStartTime;
 
-        // Record metrics
-        if (ctx.metrics) {
-          recordPhaseTiming(ctx.metrics, currentPhase, phaseDuration);
+          // Record metrics
+          if (ctx.metrics) {
+            recordPhaseTiming(ctx.metrics, currentPhase, phaseDuration, "success");
+          }
+        } catch (error) {
+          const phaseDuration = Date.now() - phaseStartTime;
+          if (ctx.metrics) {
+            recordPhaseTiming(ctx.metrics, currentPhase, phaseDuration, "failure");
+          }
+          throw error;
         }
 
         if (result === "finalize") {

--- a/worker/state-machine.ts
+++ b/worker/state-machine.ts
@@ -115,12 +115,22 @@ export async function executePipeline(env: Env): Promise<{
 
           // Record metrics
           if (ctx.metrics) {
-            recordPhaseTiming(ctx.metrics, currentPhase, phaseDuration, "success");
+            recordPhaseTiming(
+              ctx.metrics,
+              currentPhase,
+              phaseDuration,
+              "success",
+            );
           }
         } catch (error) {
           const phaseDuration = Date.now() - phaseStartTime;
           if (ctx.metrics) {
-            recordPhaseTiming(ctx.metrics, currentPhase, phaseDuration, "failure");
+            recordPhaseTiming(
+              ctx.metrics,
+              currentPhase,
+              phaseDuration,
+              "failure",
+            );
           }
           throw error;
         }

--- a/worker/types.ts
+++ b/worker/types.ts
@@ -207,6 +207,7 @@ export interface PipelineMetrics {
   start_time: number;
   end_time?: number;
   phase_timings: Record<PipelinePhase, number>;
+  phase_results: Record<PipelinePhase, "success" | "failure">;
   total_duration_ms: number;
   deals_processed: {
     discovered: number;


### PR DESCRIPTION
What
Implemented stage-level latency histograms and end-to-end run timing for the deal discovery pipeline.

Why
To enable bottleneck analysis and performance optimization by providing visibility into where time is spent across discovery, validation, and publish stages, including distinguishing between successful and failed runs.

Impact
- Improved observability into pipeline performance.
- Enabled data-driven decisions for stage-specific optimizations.
- Maintained backward compatibility for existing monitoring tools while providing enhanced data.

Fixes #120

---
*PR created automatically by Jules for task [89731577096100422](https://jules.google.com/task/89731577096100422) started by @do-ops885*