### PR TITLE
feat(metrics): publish per-gate rejection counts and ratios for validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ Every agent MUST follow these rules:
 - **Deals**: `search_deals`, `get_deal`, `add_referral`
 - **Research**: `research_domain`, `list_categories`, `validate_deal`
 - **System**: `get_stats`, `get_pipeline_status`, `trigger_discovery`, `get_logs`
+- `metrics`: `validation_gate_rejections`, `validation_gate_passes`, `validation_gate_rejection_ratio`
 - **User**: `report_deal`, `experience_deal`, `natural_language_query`
 
 Detailed schemas in [agents-docs/SYSTEM_REFERENCE.md](agents-docs/SYSTEM_REFERENCE.md).

--- a/docs/API.md
+++ b/docs/API.md
@@ -289,6 +289,18 @@ deals_runs_total 42
 
 # HELP deals_active_deals Current active deals
 deals_active_deals 45
+
+# HELP validation_gate_rejections Rejections per validation gate
+# TYPE validation_gate_rejections counter
+validation_gate_rejections{gate="source_trust"} 10
+
+# HELP validation_gate_passes Passes per validation gate
+# TYPE validation_gate_passes counter
+validation_gate_passes{gate="source_trust"} 90
+
+# HELP validation_gate_rejection_ratio Ratio of rejections to total attempts per gate
+# TYPE validation_gate_rejection_ratio gauge
+validation_gate_rejection_ratio{gate="source_trust"} 0.1000
 ```
 
 **Content-Type:** `text/plain`

--- a/tests/unit/validation_gates_metrics.test.ts
+++ b/tests/unit/validation_gates_metrics.test.ts
@@ -67,17 +67,35 @@ describe("Validation Gates Metrics", () => {
     expect(result.stats.invalid).toBe(1);
     expect(result.stats.by_gate["source_trust"]).toBe(1);
     expect(ctx.metrics?.validation_gate_rejections?.["source_trust"]).toBe(1);
+    expect(ctx.metrics?.validation_gate_passes?.["schema_validation"]).toBe(1);
 
     // Verify aggregation and prometheus formatting
     const stats = calculateAggregateStats([ctx.metrics!]);
     expect(stats.total_validation_gate_rejections["source_trust"]).toBe(1);
+    expect(stats.total_validation_gate_passes["schema_validation"]).toBe(1);
 
     const prometheus = formatMetricsForPrometheus(stats);
     expect(prometheus).toContain(
       'validation_gate_rejections{gate="source_trust"} 1',
     );
+    expect(prometheus).toContain(
+      'validation_gate_passes{gate="schema_validation"} 1',
+    );
+    expect(prometheus).toContain(
+      'validation_gate_rejection_ratio{gate="schema_validation"} 0.0000',
+    );
+    expect(prometheus).toContain(
+      'validation_gate_rejection_ratio{gate="source_trust"} 1.0000',
+    );
+
     expect(prometheus).toContain("# HELP validation_gate_rejections");
     expect(prometheus).toContain("# TYPE validation_gate_rejections counter");
+    expect(prometheus).toContain("# HELP validation_gate_passes");
+    expect(prometheus).toContain("# TYPE validation_gate_passes counter");
+    expect(prometheus).toContain("# HELP validation_gate_rejection_ratio");
+    expect(prometheus).toContain(
+      "# TYPE validation_gate_rejection_ratio gauge",
+    );
   });
 
   it("should have all 9 gates enumerated in VALIDATION_GATES", async () => {
@@ -97,5 +115,88 @@ describe("Validation Gates Metrics", () => {
       expect(VALIDATION_GATES).toContain(gate);
     }
     expect(VALIDATION_GATES.length).toBe(9);
+  });
+
+  it("should handle multi-gate rejection scenarios", async () => {
+    const mockDeals: Deal[] = [
+      {
+        id: "deal-multi-fail",
+        source: {
+          url: "https://EXAMPLE.COM/ref=test", // Fails normalization (uppercase + tracking param)
+          domain: "EXAMPLE.COM",
+          discovered_at: new Date().toISOString(),
+          trust_score: 0.1, // Fails source_trust
+        },
+        title: "", // Fails schema_validation
+        description: "Test Description",
+        code: "test", // Fails normalization (not uppercase)
+        url: "https://example.com/ref=test",
+        reward: { type: "cash", value: -10 }, // Fails reward_plausibility
+        expiry: {
+          date: "2020-01-01T00:00:00Z", // Fails expiry_validation
+          confidence: 1,
+          type: "hard",
+        },
+        metadata: {
+          category: ["test"],
+          tags: ["test"],
+          normalized_at: "", // Fails normalization
+          confidence_score: 1,
+          status: "active",
+        },
+      },
+    ];
+
+    const ctx: PipelineContext = {
+      run_id: "test-multi-fail-run",
+      trace_id: "test-multi-fail-trace",
+      start_time: Date.now(),
+      candidates: mockDeals,
+      normalized: mockDeals,
+      deduped: mockDeals,
+      validated: [],
+      scored: [],
+      metrics: createMetrics("test-multi-fail-run"),
+      errors: [],
+      retry_count: 0,
+    };
+
+    const env = {
+      ENABLE_VALIDATION_CACHE: "false",
+      TRUST_THRESHOLD: "0.5",
+      DEALS_LOG: {
+        get: async () => null,
+        put: async () => {},
+      },
+      DEALS_PROD: {
+        get: async () => null,
+        put: async () => {},
+      },
+    } as unknown as Env;
+
+    const result = await validate(mockDeals, ctx, env);
+
+    expect(result.stats.invalid).toBe(1);
+
+    // Should have multiple gate failures
+    const failures = ctx.metrics?.validation_gate_rejections;
+    expect(failures!["schema_validation"]).toBe(1);
+    expect(failures!["normalization_verification"]).toBe(1);
+    expect(failures!["source_trust"]).toBe(1);
+    expect(failures!["reward_plausibility"]).toBe(1);
+    expect(failures!["expiry_validation"]).toBe(1);
+
+    // Verify aggregate stats
+    const stats = calculateAggregateStats([ctx.metrics!]);
+    expect(stats.total_validation_gate_rejections["schema_validation"]).toBe(1);
+    expect(stats.total_validation_gate_rejections["source_trust"]).toBe(1);
+
+    const prometheus = formatMetricsForPrometheus(stats);
+    expect(prometheus).toContain(
+      'validation_gate_rejections{gate="schema_validation"} 1',
+    );
+    expect(prometheus).toContain(
+      'validation_gate_rejections{gate="source_trust"} 1',
+    );
   });
 });

--- a/worker/lib/metrics/core.ts
+++ b/worker/lib/metrics/core.ts
@@ -46,6 +46,7 @@ export function createMetrics(run_id: string): PipelineMetrics {
       dedup_hit_total: 0,
     },
     validation_gate_rejections: {},
+    validation_gate_passes: {},
     errors: 0,
     retries: 0,
     success: false,
@@ -94,6 +95,18 @@ export function recordValidationGateRejection(
   }
   metrics.validation_gate_rejections[gate] =
     (metrics.validation_gate_rejections[gate] || 0) + count;
+}
+
+export function recordValidationGatePass(
+  metrics: PipelineMetrics,
+  gate: string,
+  count: number = 1,
+): void {
+  if (!metrics.validation_gate_passes) {
+    metrics.validation_gate_passes = {};
+  }
+  metrics.validation_gate_passes[gate] =
+    (metrics.validation_gate_passes[gate] || 0) + count;
 }
 
 export function recordValidationCacheMetric(
@@ -150,6 +163,25 @@ export async function storeMetrics(
 
     await env.DEALS_LOG.put(cumulativeKey, JSON.stringify(cumulative), {
       // No TTL for cumulative stats, or a long one
+      expirationTtl: 30 * 24 * 60 * 60,
+    });
+  }
+
+  // Persist cumulative gate passes in KV
+  if (metrics.validation_gate_passes) {
+    const cumulativeKey = "metrics:cumulative_gate_passes";
+    const existingRaw = await env.DEALS_LOG.get(cumulativeKey);
+    const cumulative: Record<string, number> = existingRaw
+      ? JSON.parse(existingRaw)
+      : {};
+
+    for (const [gate, count] of Object.entries(
+      metrics.validation_gate_passes,
+    )) {
+      cumulative[gate] = (cumulative[gate] || 0) + count;
+    }
+
+    await env.DEALS_LOG.put(cumulativeKey, JSON.stringify(cumulative), {
       expirationTtl: 30 * 24 * 60 * 60,
     });
   }

--- a/worker/lib/metrics/stats.ts
+++ b/worker/lib/metrics/stats.ts
@@ -11,6 +11,16 @@ export async function getCumulativeGateRejections(
 }
 
 /**
+ * Get cumulative gate passes from KV
+ */
+export async function getCumulativeGatePasses(
+  env: Env,
+): Promise<Record<string, number>> {
+  const raw = await env.DEALS_LOG.get("metrics:cumulative_gate_passes");
+  return raw ? JSON.parse(raw) : {};
+}
+
+/**
  * Calculate aggregate statistics from a list of pipeline metrics
  */
 export function calculateAggregateStats(metrics: PipelineMetrics[]) {
@@ -51,6 +61,7 @@ export function calculateAggregateStats(metrics: PipelineMetrics[]) {
       total_errors: 0,
       total_retries: 0,
       total_validation_gate_rejections: {} as Record<string, number>,
+      total_validation_gate_passes: {} as Record<string, number>,
     };
   const successful = metrics.filter((m) => m.success);
   const phases: PipelinePhase[] = [
@@ -150,6 +161,19 @@ export function calculateAggregateStats(metrics: PipelineMetrics[]) {
       },
       {} as Record<string, number>,
     ),
+    total_validation_gate_passes: metrics.reduce(
+      (acc, m) => {
+        if (m.validation_gate_passes) {
+          for (const [gate, count] of Object.entries(
+            m.validation_gate_passes,
+          )) {
+            acc[gate] = (acc[gate] || 0) + count;
+          }
+        }
+        return acc;
+      },
+      {} as Record<string, number>,
+    ),
   };
 }
 
@@ -160,6 +184,7 @@ export function formatMetricsForPrometheus(
   stats: ReturnType<typeof calculateAggregateStats>,
   metrics: PipelineMetrics[] = [],
   cumulativeRejections: Record<string, number> = {},
+  cumulativePasses: Record<string, number> = {},
 ): string {
   const lines: string[] = [
     `# HELP deals_pipeline_runs_total Total discovery runs`,
@@ -253,15 +278,21 @@ export function formatMetricsForPrometheus(
 
   // Combine and expose validation gate rejections
   const allRejections = { ...cumulativeRejections };
-  // Merge in stats rejections if not already present or to show current batch
   for (const [gate, count] of Object.entries(
     stats.total_validation_gate_rejections,
   )) {
-    // Note: If cumulativeRejections is already comprehensive, we don't want to double count.
-    // However, the requested solution specifically asked for "validation_gate_rejections"
-    // and if we only have one counter, it should be the cumulative one if available.
     if (allRejections[gate] === undefined) {
       allRejections[gate] = count;
+    }
+  }
+
+  // Combine and expose validation gate passes
+  const allPasses = { ...cumulativePasses };
+  for (const [gate, count] of Object.entries(
+    stats.total_validation_gate_passes,
+  )) {
+    if (allPasses[gate] === undefined) {
+      allPasses[gate] = count;
     }
   }
 
@@ -272,6 +303,33 @@ export function formatMetricsForPrometheus(
     lines.push(`# TYPE validation_gate_rejections counter`);
     for (const [gate, count] of Object.entries(allRejections)) {
       lines.push(`validation_gate_rejections{gate="${gate}"} ${count}`);
+    }
+  }
+
+  if (Object.keys(allPasses).length > 0) {
+    lines.push(`# HELP validation_gate_passes Passes per validation gate`);
+    lines.push(`# TYPE validation_gate_passes counter`);
+    for (const [gate, count] of Object.entries(allPasses)) {
+      lines.push(`validation_gate_passes{gate="${gate}"} ${count}`);
+    }
+
+    // Export rejection ratios
+    lines.push(
+      `# HELP validation_gate_rejection_ratio Ratio of rejections to total attempts per gate`,
+    );
+    lines.push(`# TYPE validation_gate_rejection_ratio gauge`);
+    const allGates = new Set([
+      ...Object.keys(allPasses),
+      ...Object.keys(allRejections),
+    ]);
+    for (const gate of allGates) {
+      const passes = allPasses[gate] || 0;
+      const rejections = allRejections[gate] || 0;
+      const total = passes + rejections;
+      const ratio = total > 0 ? rejections / total : 0;
+      lines.push(
+        `validation_gate_rejection_ratio{gate="${gate}"} ${ratio.toFixed(4)}`,
+      );
     }
   }
 

--- a/worker/pipeline/validate.ts
+++ b/worker/pipeline/validate.ts
@@ -7,6 +7,7 @@ import { validateDealFastPath } from "./validate-fast-path";
 import {
   recordValidationCacheMetric,
   recordValidationGateRejection,
+  recordValidationGatePass,
 } from "../lib/metrics";
 import { getProductionSnapshot } from "../lib/storage";
 import { generateSnapshotHash } from "../lib/crypto";
@@ -96,6 +97,7 @@ export async function validate(
       let allPassed = true;
       const failureReasons: string[] = [];
       const gateFailures: string[] = [];
+      const gatePasses: string[] = [];
       let fastPathDecision = null;
       let skipGates = false;
 
@@ -129,6 +131,8 @@ export async function validate(
             allPassed = false;
             failureReasons.push(`${gate}: ${gateResult.reason}`);
             gateFailures.push(gate);
+          } else {
+            gatePasses.push(gate);
           }
         }
       }
@@ -167,7 +171,14 @@ export async function validate(
         deal.metadata.status = "rejected";
       }
 
-      return { deal, allPassed, failureReasons, gateFailures, isQuarantined };
+      return {
+        deal,
+        allPassed,
+        failureReasons,
+        gateFailures,
+        gatePasses,
+        isQuarantined,
+      };
     },
     10, // Max 10 concurrent deals to stay under 50 subrequest limit (each deal does ~3 lookups)
   );
@@ -177,6 +188,12 @@ export async function validate(
       result.stats.by_gate[gate] = (result.stats.by_gate[gate] || 0) + 1;
       if (ctx.metrics) {
         recordValidationGateRejection(ctx.metrics, gate);
+      }
+    });
+
+    r.gatePasses.forEach((gate) => {
+      if (ctx.metrics) {
+        recordValidationGatePass(ctx.metrics, gate);
       }
     });
 

--- a/worker/routes/core/health.ts
+++ b/worker/routes/core/health.ts
@@ -100,15 +100,23 @@ export async function handleMetrics(
   request?: Request,
 ): Promise<Response> {
   // Optimization: Parallelize snapshot, log and metrics retrieval to reduce total latency
-  const [snapshot, logs, pipelineMetrics, cumulativeRejections] =
-    await Promise.all([
-      getProductionSnapshot(env),
-      getRecentLogs(env, 1000),
-      getRecentMetrics(env, 100),
-      import("../../lib/metrics/stats").then((m) =>
-        m.getCumulativeGateRejections(env),
-      ),
-    ]);
+  const [
+    snapshot,
+    logs,
+    pipelineMetrics,
+    cumulativeRejections,
+    cumulativePasses,
+  ] = await Promise.all([
+    getProductionSnapshot(env),
+    getRecentLogs(env, 1000),
+    getRecentMetrics(env, 100),
+    import("../../lib/metrics/stats").then((m) =>
+      m.getCumulativeGateRejections(env),
+    ),
+    import("../../lib/metrics/stats").then((m) =>
+      m.getCumulativeGatePasses(env),
+    ),
+  ]);
 
   const stats = calculateAggregateStats(pipelineMetrics);
 
@@ -146,6 +154,7 @@ export async function handleMetrics(
     stats,
     pipelineMetrics,
     cumulativeRejections,
+    cumulativePasses,
   );
 
   // Add legacy metrics for backward compatibility

--- a/worker/types.ts
+++ b/worker/types.ts
@@ -225,6 +225,7 @@ export interface PipelineMetrics {
     dedup_hit_total: number;
   };
   validation_gate_rejections?: Record<string, number>;
+  validation_gate_passes?: Record<string, number>;
   errors: number;
   retries: number;
   success: boolean;


### PR DESCRIPTION
I have implemented granular per-gate validation metrics to provide better visibility into the deal discovery pipeline.

Changes:
1.  **Metric Tracking:** Updated the `PipelineMetrics` interface and the validation pipeline (`worker/pipeline/validate.ts`) to track both passes and rejections for each of the 9 validation gates.
2.  **Persistence:** Updated the metrics persistence logic (`worker/lib/metrics/core.ts`) to store cumulative gate passes in Cloudflare KV, complementing the existing rejection tracking.
3.  **Exposure:** Enhanced the `/metrics` endpoint (`worker/lib/metrics/stats.ts` and `worker/routes/core/health.ts`) to aggregate these metrics and export them in Prometheus format. This includes a new `validation_gate_rejection_ratio` gauge for each gate.
4.  **Documentation:** Updated `AGENTS.md` and `docs/API.md` to reflect the new metrics and stable gate names.
5.  **Testing:** Expanded `tests/unit/validation_gates_metrics.test.ts` with a multi-gate rejection scenario and verification of the new ratio metrics.

These changes allow for targeted optimization of validation logic and more precise tuning of trust thresholds based on actual gate performance.

Fixes #121

---
*PR created automatically by Jules for task [10953233414855922473](https://jules.google.com/task/10953233414855922473) started by @do-ops885*