### PR TITLE
fix(ci): preserve PR body in auto-merge squash commits

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -223,15 +223,15 @@ jobs:
           fi
 
           # Format commit message
-          COMMIT_MESSAGE="${PR_TITLE} (#${PR_NUMBER})"
+          COMMIT_MESSAGE="${COMMIT_MESSAGE_FORMAT//\{title\}/$PR_TITLE}"
+          COMMIT_MESSAGE="${COMMIT_MESSAGE//\{number\}/$PR_NUMBER}"
 
           echo "Enabling auto-merge for PR #${PR_NUMBER} with squash method"
 
           gh pr merge "${PR_NUMBER}" \
             --squash \
             --auto \
-            --subject "${COMMIT_MESSAGE}" \
-            --body ""
+            --subject "${COMMIT_MESSAGE}"
 
           echo "✅ Auto-merge enabled successfully"
         env:


### PR DESCRIPTION
This PR removes the `--body ""` override from the `gh pr merge` command in the auto-merge workflow. By default, GitHub uses the PR description for the squash commit body when this flag is omitted. This ensures that issue-closing keywords (e.g., "Fixes #121") are preserved in the squash commit, allowing GitHub to automatically close the referenced issues.

Additionally, the workflow now correctly uses the `COMMIT_MESSAGE_FORMAT` environment variable to generate the squash commit subject, ensuring consistency across the project.

---
*PR created automatically by Jules for task [10657533562530783560](https://jules.google.com/task/10657533562530783560) started by @do-ops885*