### PR TITLE
docs: write optimization playbook for contributors (PERFORMANCE.md)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,7 @@ git checkout -b fix/issue-123-bug-description
 
 **Before coding:**
 - Read [`AGENTS.md`](../../AGENTS.md) for project standards
+- Review [`docs/PERFORMANCE.md`](../../docs/PERFORMANCE.md) for optimization guidelines
 - Check [`agents-docs/SKILLS.md`](../../agents-docs/SKILLS.md) for skill authoring
 - Review [`agents-docs/HARNESS.md`](../../agents-docs/HARNESS.md) for architecture
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ curl https://your-worker.workers.dev/api/log
 ### Documentation
 
 - [AGENTS.md](AGENTS.md) - System specs and architecture
+- [docs/PERFORMANCE.md](docs/PERFORMANCE.md) - Optimization playbook
 - [docs/API.md](docs/API.md) - API reference
 <!-- - [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) - Deployment guide (Coming Soon) -->
 <!-- - [docs/LEGAL_COMPLIANCE.md](docs/LEGAL_COMPLIANCE.md) - Legal requirements (Coming Soon) -->

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,0 +1,102 @@
+# Performance Optimization Playbook
+
+This document provides a guide for contributors looking to optimize the Deal Discovery System. It covers where to find bottlenecks, how to measure performance, and how to verify improvements.
+
+## 🚀 Known Hot Paths
+
+The following areas are the most computationally or I/O intensive parts of the pipeline:
+
+### 1. Discovery Budgeting & Fetching
+- **File**: `worker/pipeline/discover.ts`
+- **Description**: Managing multi-source discovery within budget constraints.
+- **Bottleneck**: Network I/O when fetching from dozens of sources and payload size validation.
+
+### 2. Semantic Deduplication
+- **File**: `worker/pipeline/dedupe.ts`
+- **Description**: Comparing new deals against existing production deals using string similarity.
+- **Bottleneck**: O(N*M) comparisons, where N is new deals and M is existing deals. Optimized via domain-partitioning.
+
+### 3. Validation Gates
+- **File**: `worker/pipeline/validate.ts`
+- **Description**: Running 9 mandatory validation gates (schema, trust, reward plausibility, etc.).
+- **Bottleneck**: Sequential execution of gates for each deal.
+
+### 4. Ranking & Scoring
+- **File**: `worker/pipeline/score.ts`
+- **Description**: Calculating weighted confidence scores based on 7+ metrics.
+- **Bottleneck**: Frequent metadata updates and floating-point math in hot loops.
+
+---
+
+## 📊 How to Read `/metrics`
+
+The `/metrics` endpoint (accessible via `GET /metrics?format=json` or `GET /metrics` for Prometheus format) is your primary tool for performance analysis.
+
+| Metric | Meaning | Healthy Value |
+|--------|---------|---------------|
+| `stage_latency_ms` | Time spent in discovery, validation, or publish phases. | Discovery < 10s, Validation < 5s |
+| `validation_gate_rejection_ratio` | Percentage of deals failing a specific gate. | High rejections in `source_trust` are normal; high rejections in `schema_validation` suggest parser bugs. |
+| `deals_pipeline_success_rate` | Percentage of cron runs that complete without errors. | > 95% |
+| `deals_active_deals` | Total deals currently in production snapshot. | 100 - 1000 |
+
+### Bad Value Signals
+- **p99 Latency > 30s**: Risk of Worker timeout.
+- **High `idempotency_check` rejections**: Possible duplicate discovery logic bugs.
+- **Success Rate < 80%**: Systemic instability in external dependencies (KV, GitHub, AI Gateway).
+
+---
+
+## 🧪 Funnel Health Check
+
+The discovery funnel tracks how many candidates survive each stage:
+`Discovered` ➔ `Normalized` ➔ `Deduped` ➔ `Validated` ➔ `Published`
+
+**Key Conversions:**
+- **Discovery Yield**: `Normalized / Discovered`. Low yield means parsers are failing to extract data.
+- **Uniqueness Ratio**: `Deduped / Normalized`. Low ratio means we are finding the same deals repeatedly.
+- **Quality Yield**: `Validated / Deduped`. Low yield means discovered deals are failing quality gates.
+
+---
+
+## ⏱️ Running Benchmarks Locally
+
+Before submitting a performance-related PR, run the pipeline benchmark:
+
+```bash
+# Run the local pipeline simulator
+npx tsx scripts/benchmark_pipeline.ts
+```
+
+Compare the `Phase Timings` output before and after your changes. Look for significant reductions in the specific phase you targeted without regressions in others.
+
+---
+
+## 🛠️ Optimization Workflow
+
+1. **Measure Baseline**: Run `scripts/benchmark_pipeline.ts` or check production `/metrics`.
+2. **Isolate**: Use `console.time()` or a profiler to find the exact function causing the delay.
+3. **Change**: Implement your optimization (e.g., better caching, O(N) instead of O(N^2)).
+4. **Benchmark**: Run the local benchmark again to confirm the speedup.
+5. **Verify**: Ensure all tests pass (`npm test`) and that quality metrics (like discovery yield) haven't degraded.
+
+---
+
+## ⚠️ Common Pitfalls
+
+- **AI Gate Costs**: AI-based validation gates are 10-100x slower than rule-based gates. Use rule-based gates first as "fast paths."
+- **KV Read Patterns**: Avoid reading KV keys one-by-one in a loop. Use `Promise.all` or batching logic.
+- **6h Cron Overlap**: If a run takes > 5 minutes, it may overlap with locking logic. Keep the end-to-end duration as low as possible.
+- **Memory Limits**: Cloudflare Workers have a 128MB limit. Avoid loading thousands of deals into memory at once.
+
+---
+
+## ⚙️ Config Tuning Guide
+
+Adjust these in `wrangler.jsonc` or via environment variables to tune the balance between performance and quality:
+
+| Key | Impact | Trade-off |
+|-----|--------|-----------|
+| `TRUST_THRESHOLD` | Minimum trust score to process a source. | Higher = Faster, but fewer deals found. |
+| `CANDIDATE_BUDGET_GLOBAL` | Max deals to discover per run. | Lower = Faster, reduces KV write costs. |
+| `CANDIDATE_BUDGET_PER_SOURCE` | Max deals per individual source. | Prevents a single noisy source from drowning out others. |
+| `SIMILARITY_THRESHOLD` | Threshold for deduplication (0.0 to 1.0). | Higher = More strict, but may miss subtle duplicates. |


### PR DESCRIPTION
This PR introduces a comprehensive performance optimization playbook at `docs/PERFORMANCE.md`. It provides contributors with a structured guide to approaching performance work on the project, including identifying bottlenecks in the pipeline (discovery, deduplication, validation, scoring), interpreting metrics from the `/metrics` endpoint, and running local benchmarks. It also includes a configuration tuning guide to balance performance and quality. Links to the new playbook have been added to `README.md` and `CONTRIBUTING.md`.

Fixes #133

---
*PR created automatically by Jules for task [2984474049557249982](https://jules.google.com/task/2984474049557249982) started by @do-ops885*