### PR TITLE
perf: add benchmark suite for ranking and similarity hot paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,35 @@ jobs:
           kill $WRANGLER_PID
           exit $EXIT_CODE
 
+  benchmark:
+    name: Run Benchmarks
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Run benchmarks
+        run: npm run bench -- --run | tee benchmark-results.txt
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results
+          path: benchmark-results.txt
+
   summary:
     name: CI Summary
     runs-on: ubuntu-latest
@@ -256,6 +285,7 @@ jobs:
         lint,
         build-check,
         smoke-test,
+        benchmark,
       ]
     if: always()
 
@@ -269,6 +299,7 @@ jobs:
           LINT_RESULT="${{ needs.lint.result }}"
           BUILD_CHECK_RESULT="${{ needs.build-check.result }}"
           SMOKE_TEST_RESULT="${{ needs.smoke-test.result }}"
+          BENCHMARK_RESULT="${{ needs.benchmark.result }}"
           {
             echo "## CI Results"
             echo "| Job | Status |"
@@ -280,6 +311,7 @@ jobs:
             echo "| Lint & Format | ${LINT_RESULT} |"
             echo "| Build Check | ${BUILD_CHECK_RESULT} |"
             echo "| Smoke Tests | ${SMOKE_TEST_RESULT} |"
+            echo "| Benchmarks | ${BENCHMARK_RESULT} |"
           } >> "$GITHUB_STEP_SUMMARY"
 
           # Check if any required job failed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,6 +206,9 @@ See [`AGENTS.md`](../../AGENTS.md) for complete style guide. Key points:
 SKIP_CLIPPY=true ./scripts/quality_gate.sh  # Skip Rust clippy
 SKIP_TESTS=true ./scripts/quality_gate.sh   # Skip tests
 
+# Run benchmarks
+npm run bench
+
 # Validate skills only
 ./scripts/validate-skills.sh
 ```

--- a/benchmarks/bench-utils.ts
+++ b/benchmarks/bench-utils.ts
@@ -1,0 +1,41 @@
+import type { Deal } from "../worker/types";
+
+export function generateTestDeals(count: number): Deal[] {
+  const deals: Deal[] = [];
+  const now = new Date().toISOString();
+
+  for (let i = 0; i < count; i++) {
+    deals.push({
+      id: `deal-${i}`,
+      source: {
+        url: `https://example.com/source/${i}`,
+        domain: "example.com",
+        discovered_at: now,
+        trust_score: 0.5 + Math.random() * 0.5,
+      },
+      title: `Test Deal ${i}`,
+      description: `Description for test deal ${i}`,
+      code: `CODE${i}`,
+      url: `https://example.com/deal/${i}`,
+      reward: {
+        type: "cash",
+        value: 10 + i,
+        currency: "USD",
+      },
+      expiry: {
+        date: new Date(Date.now() + 86400000 * 30).toISOString(),
+        confidence: 0.9,
+        type: "hard",
+      },
+      metadata: {
+        category: ["tech"],
+        tags: ["test"],
+        normalized_at: now,
+        confidence_score: 0.5 + Math.random() * 0.5,
+        status: "active",
+      },
+    });
+  }
+
+  return deals;
+}

--- a/benchmarks/ranking.bench.ts
+++ b/benchmarks/ranking.bench.ts
@@ -1,0 +1,22 @@
+import { bench, describe } from "vitest";
+import { rankDeals } from "../worker/lib/ranking";
+import { generateTestDeals } from "./bench-utils";
+
+describe("rankDeals", () => {
+  const deals100 = generateTestDeals(100);
+  const deals1000 = generateTestDeals(1000);
+
+  bench("rank 100 deals", () => {
+    rankDeals(deals100, {
+      sortBy: "confidence",
+      order: "desc",
+    });
+  });
+
+  bench("rank 1000 deals", () => {
+    rankDeals(deals1000, {
+      sortBy: "confidence",
+      order: "desc",
+    });
+  });
+});

--- a/benchmarks/similarity.bench.ts
+++ b/benchmarks/similarity.bench.ts
@@ -1,0 +1,26 @@
+import { bench, describe } from "vitest";
+import {
+  calculateStringSimilarity,
+  calculateUrlSimilarity,
+} from "../worker/lib/crypto";
+
+describe("similarity scoring", () => {
+  const strA = "The quick brown fox jumps over the lazy dog";
+  const strB = "The quick brown fox jumps over the lazy dog!";
+  const strC = "Pack my box with five dozen liquor jugs";
+
+  const urlA = "https://example.com/path/to/deal?id=123&ref=abc";
+  const urlB = "https://example.com/path/to/deal?id=456&ref=def";
+
+  bench("string similarity (similar)", () => {
+    calculateStringSimilarity(strA, strB);
+  });
+
+  bench("string similarity (different)", () => {
+    calculateStringSimilarity(strA, strC);
+  });
+
+  bench("url similarity", () => {
+    calculateUrlSimilarity(urlA, urlB);
+  });
+});

--- a/benchmarks/validation.bench.ts
+++ b/benchmarks/validation.bench.ts
@@ -1,0 +1,39 @@
+import { bench, describe } from "vitest";
+import { validate } from "../worker/pipeline/validate";
+import { generateTestDeals } from "./bench-utils";
+import type { Env, PipelineContext } from "../worker/types";
+
+describe("validation pipeline", () => {
+  const deals100 = generateTestDeals(100);
+
+  const mockEnv: Env = {
+    DEALS_PROD: { get: async () => null } as any,
+    DEALS_STAGING: {} as any,
+    DEALS_LOG: {} as any,
+    DEALS_LOCK: {} as any,
+    DEALS_SOURCES: {} as any,
+    AI_GATEWAY_URL: "http://mock-ai",
+    ENVIRONMENT: "test",
+    GITHUB_REPO: "test/repo",
+    TRUST_THRESHOLD: "0.3",
+    NOTIFICATION_THRESHOLD: "0.8",
+    ENABLE_VALIDATION_CACHE: "false",
+  };
+
+  const mockCtx: PipelineContext = {
+    run_id: "test-run",
+    trace_id: "test-trace",
+    start_time: Date.now(),
+    candidates: [],
+    normalized: [],
+    deduped: [],
+    validated: [],
+    scored: [],
+    errors: [],
+    retry_count: 0,
+  };
+
+  bench("validate 100 deals", async () => {
+    await validate(deals100, mockCtx, mockEnv);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:load:smoke": "artillery run -t http://localhost:8787 --overrides '{\"config\":{\"phases\":[{\"duration\":10,\"arrivalRate\":1}],\"ensure\":{\"p95\":500,\"maxErrorRate\":5}}}' tests/load/artillery/api-endpoints.yml",
     "test:load:quick": "artillery run -t ${WORKER_URL:-http://localhost:8787} --overrides '{\"config\":{\"phases\":[{\"duration\":30,\"arrivalRate\":5}]}}' tests/load/artillery/api-endpoints.yml",
     "lint": "tsc --noEmit",
+    "bench": "vitest bench",
     "validate": "bash scripts/validate-codes.sh",
     "format": "prettier --write ."
   },


### PR DESCRIPTION
What
Added a comprehensive benchmark suite using Vitest for the deal discovery system's hot paths: ranking logic, similarity scoring, and the validation pipeline.

Why
To establish a performance baseline, catch regressions in future optimization efforts, and provide an objective way to compare alternative implementations.

Impact
The system now has automated performance tracking. Benchmarks can be run locally via `npm run bench` and are automatically executed in CI for every push and pull request, with results available as build artifacts. This ensures that performance remains a first-class citizen in the development process.

Fixes #132

---
*PR created automatically by Jules for task [5848669626816357025](https://jules.google.com/task/5848669626816357025) started by @do-ops885*