### PR TITLE
Isolate staging KV namespaces and fix invalid IDs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,11 +13,11 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
   schedule:
-    - cron: '16 22 * * 0'
+    - cron: "16 22 * * 0"
 
 jobs:
   analyze:
@@ -43,10 +43,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - language: actions
-          build-mode: none
-        - language: javascript-typescript
-          build-mode: none
+          - language: actions
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
@@ -56,46 +56,46 @@ jobs:
         # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    # Add any setup steps before running the `github/codeql-action/init` action.
-    # This includes steps like installing compilers or runtimes (`actions/setup-node`
-    # or others). This is typically only required for manual builds.
-    # - name: Setup runtime (example)
-    #   uses: actions/setup-example@v1
+      # Add any setup steps before running the `github/codeql-action/init` action.
+      # This includes steps like installing compilers or runtimes (`actions/setup-node`
+      # or others). This is typically only required for manual builds.
+      # - name: Setup runtime (example)
+      #   uses: actions/setup-example@v1
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
-      with:
-        languages: ${{ matrix.language }}
-        build-mode: ${{ matrix.build-mode }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
 
-        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+          # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          # queries: security-extended,security-and-quality
 
-    # If the analyze step fails for one of the languages you are analyzing with
-    # "We were unable to automatically build your code", modify the matrix above
-    # to set the build mode to "manual" for that language. Then modify this step
-    # to build your code.
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-    - name: Run manual build steps
-      if: matrix.build-mode == 'manual'
-      shell: bash
-      run: |
-        echo 'If you are using a "manual" build mode for one or more of the' \
-          'languages you are analyzing, replace this with the commands to build' \
-          'your code, for example:'
-        echo '  make bootstrap'
-        echo '  make release'
-        exit 1
+      # If the analyze step fails for one of the languages you are analyzing with
+      # "We were unable to automatically build your code", modify the matrix above
+      # to set the build mode to "manual" for that language. Then modify this step
+      # to build your code.
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+      - name: Run manual build steps
+        if: matrix.build-mode == 'manual'
+        shell: bash
+        run: |
+          echo 'If you are using a "manual" build mode for one or more of the' \
+            'languages you are analyzing, replace this with the commands to build' \
+            'your code, for example:'
+          echo '  make bootstrap'
+          echo '  make release'
+          exit 1
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{matrix.language}}"

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -187,6 +187,8 @@ Each command returns a JSON object with the namespace ID:
 
 Copy the returned IDs into `wrangler.jsonc` under the appropriate environment block. The current production IDs are:
 
+#### Production Environment
+
 | Binding        | ID                               |
 | -------------- | -------------------------------- |
 | DEALS_PROD     | `23ee9b8c9e2748e5880f476b8b57a524` |
@@ -194,6 +196,16 @@ Copy the returned IDs into `wrangler.jsonc` under the appropriate environment bl
 | DEALS_LOG      | `1f1a901fd6fb4dffbdcc86aa4a914ba8` |
 | DEALS_LOCK     | `e3ab520eafd5430ab72978e78bdd257e` |
 | DEALS_SOURCES  | `be3c0fc148b749b49a59aa7cfa23e3ac` |
+
+#### Staging Environment
+
+| Binding        | ID                               |
+| -------------- | -------------------------------- |
+| DEALS_PROD     | `b0db85b92fae45c1895152737ab72649` |
+| DEALS_STAGING  | `b0db85b92fae45c1895152737ab72649` |
+| DEALS_LOG      | `76296ec3db649ce88fda702b2661ba08` |
+| DEALS_LOCK     | `43fe4464ef6780963114c35e5939f2fc` |
+| DEALS_SOURCES  | `6459eeaa19a573ca72c52e2ba1ad909b` |
 
 ### Automated KV Setup (GitHub Actions)
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -109,15 +109,18 @@
         },
         {
           "binding": "DEALS_LOG",
-          "id": "1f1a901fd6fb4dffbdcc86aa4a914ba8-staging",
+          // Environment-isolated: staging-specific logging
+          "id": "76296ec3db649ce88fda702b2661ba08",
         },
         {
           "binding": "DEALS_LOCK",
-          "id": "e3ab520eafd5430ab72978e78bdd257e",
+          // Environment-isolated: prevents cross-env pipeline lock contention
+          "id": "43fe4464ef6780963114c35e5939f2fc",
         },
         {
           "binding": "DEALS_SOURCES",
-          "id": "be3c0fc148b749b49a59aa7cfa23e3ac",
+          // Environment-isolated: experimental sources shouldn't pollute production
+          "id": "6459eeaa19a573ca72c52e2ba1ad909b",
         },
       ],
       "d1_databases": [


### PR DESCRIPTION
This change isolates the staging environment's KV namespaces from production to prevent resource contention (especially for the distributed lock) and configuration pollution. It also corrects an invalid namespace ID format in the staging environment.

Fixes #197

---
*PR created automatically by Jules for task [16476692442202967601](https://jules.google.com/task/16476692442202967601) started by @do-ops885*