### PR TITLE
build: use wrangler for correct Worker bundle verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
       - run: npm ci --legacy-peer-deps
       - name: Run wrangler deploy dry-run
-        run: npx wrangler deploy --dry-run
+        run: npm run build
       - name: Run smoke tests
         run: |
           npx wrangler dev --port 8787 &

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Autonomous AI-agent deal discovery system on Cloudflare Workers",
   "type": "module",
   "scripts": {
-    "build": "bash scripts/generate-version.sh && tsc",
+    "build": "bash scripts/generate-version.sh && wrangler deploy --dry-run --env production --outdir dist",
     "build:watch": "bash scripts/generate-version.sh && tsc --watch",
     "deploy": "wrangler deploy",
     "dev": "bash scripts/generate-version.sh && wrangler dev",


### PR DESCRIPTION
I have replaced the `tsc`-only build process with `wrangler deploy --dry-run` to ensure that the Cloudflare Worker bundle is correctly verified during the build step.

Key changes:
- Modified `package.json`: Updated the `build` script to use `wrangler deploy --dry-run --env production --outdir dist`. This ensures that the build process runs through the actual bundler (esbuild) used for deployment, catching bundling-specific errors like size limits or unsupported Node.js APIs.
- Updated `.github/workflows/ci.yml`: Unified the bundling verification by replacing the manual `wrangler deploy --dry-run` in the `smoke-test` job with `npm run build`.

These changes ensure that the `dist/` artifact uploaded by the CI build job is the actual deployable bundle and that any bundling issues are caught early in the pipeline.

Fixes #198

---
*PR created automatically by Jules for task [13153379626639610429](https://jules.google.com/task/13153379626639610429) started by @do-ops885*