### PR TITLE
ci(deps): add npm ecosystem to dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -92,3 +92,43 @@ updates:
       - "pre-commit"
     commit-message:
       prefix: "ci"
+
+  # npm Ecosystem
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "deps"
+      - "npm"
+    commit-message:
+      prefix: "chore"
+    groups:
+      cloudflare:
+        patterns:
+          - "@cloudflare/*"
+          - "wrangler"
+          - "miniflare"
+        update-types:
+          - "minor"
+          - "patch"
+      testing:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+          - "playwright"
+          - "@playwright/*"
+          - "artillery"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        versions:
+          - "*-alpha"
+          - "*-beta"
+          - "*-rc*"

--- a/plans/INDEX.md
+++ b/plans/INDEX.md
@@ -13,6 +13,7 @@ This index tracks all implementation plans, roadmaps, and design documents in th
 
 - [GOAP Improvements (2026-05-11)](GOAP_IMPROVEMENTS_2026-05-11.md) - CI/CD hardening, governance alignment, and explainability API.
 - [Multi-Agent Workflow](multi-agent-workflow.md) - Orchestration of parallel agents.
+- [Dependabot npm Integration](dependabot-npm-integration.md) - Adding npm ecosystem to Dependabot.
 
 ## Planned Plans
 

--- a/plans/dependabot-npm-integration.md
+++ b/plans/dependabot-npm-integration.md
@@ -1,0 +1,60 @@
+# ADR: Dependabot npm Integration
+
+**status**: active
+**owner**: jules
+**scope**: .github/dependabot.yml, package.json
+**method**: GOAP (Analyze → Decompose → Strategize → Coordinate → Execute → Synthesize)
+
+---
+
+## 1) Task Analysis
+
+**Primary Goal**: Add the `npm` ecosystem to the Dependabot configuration to automate updates for production and development dependencies.
+
+**Context**:
+Currently, `.github/dependabot.yml` manages `github-actions`, `docker`, `terraform`, `docker-compose`, and `pre-commit`, but lacks `npm`. This results in:
+- Production dependencies (`protobufjs`, `zod`) not receiving automated security patches.
+- Dev dependencies (`vitest`, `wrangler`, `typescript`, etc.) not being updated.
+- Reliance on manual `npm audit`, which only catches known vulnerabilities, not version drift.
+
+**Constraints**:
+- Weekly updates (Mondays at 09:00 UTC).
+- Limit of 5 open PRs to prevent flooding.
+- Grouping for Cloudflare and testing packages to reduce noise.
+- Ignore alpha, beta, and RC versions.
+
+---
+
+## 2) Decomposition (Sub-goals)
+
+1. **Configure npm ecosystem in Dependabot**: Add the `npm` entry with the specified schedule, limits, labels, and groups.
+2. **Verify Configuration**: Ensure the YAML syntax is valid and adheres to the repository's standards.
+3. **Verify Pipeline Integrity**: Run the full test suite and quality gates to ensure no regressions.
+
+---
+
+## 3) Strategy Selection
+
+**Strategy**: Sequential
+- Update configuration, verify, and then run full system checks.
+
+---
+
+## 4) Execution Plan
+
+### Phase 1: Configuration
+- [ ] Add `npm` entry to `.github/dependabot.yml`.
+- [ ] Group `@cloudflare/*`, `wrangler`, `miniflare` into `cloudflare`.
+- [ ] Group `vitest`, `@vitest/*`, `playwright`, `@playwright/*`, `artillery` into `testing`.
+
+### Phase 2: Verification
+- [ ] Run `npm run test:ci`.
+- [ ] Run `./scripts/quality_gate.sh`.
+
+---
+
+## 5) Success Metrics
+
+- Dependabot correctly identifies the `npm` ecosystem (verified by GitHub UI post-merge, though we can only verify the config file here).
+- Quality gate passes (YAML validation).
+- No regressions in the existing test suite.


### PR DESCRIPTION
This PR adds the npm ecosystem to the Dependabot configuration to automate updates for production and development dependencies.

### Changes:
- Added `npm` entry to `.github/dependabot.yml` with:
    - Weekly schedule (Mondays)
    - 5 open PR limit
    - Grouping for `@cloudflare/*`, `wrangler`, `miniflare` (Cloudflare)
    - Grouping for `vitest`, `playwright`, `artillery` (Testing)
    - Labels: `deps`, `npm`
    - Commit prefix: `chore`
    - Version filtering: ignore alpha, beta, rc versions
- Created an Architecture Decision Record (ADR) in `plans/dependabot-npm-integration.md`
- Registered the new plan in `plans/INDEX.md`

### Verification:
- Ran `npm run test:ci` to ensure no regressions.
- Ran `./scripts/quality_gate.sh` to verify YAML syntax and repo integrity.
- Verified that the `npm` ecosystem is correctly configured in `.github/dependabot.yml`.

Fixes #181

---
*PR created automatically by Jules for task [4385642846326658304](https://jules.google.com/task/4385642846326658304) started by @do-ops885*