### PR TITLE
ci(config): add CODEOWNERS file and enforce review rules

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,21 @@
+# Default: all files require review
+* @do-ops885
+
+# Core pipeline logic
+/worker/pipeline/ @do-ops885
+/worker/ @do-ops885
+
+# CI/CD and deployment configs
+/.github/workflows/ @do-ops885
+/.github/dependabot.yml @do-ops885
+
+# Wrangler config (contains KV namespace IDs and env vars)
+/wrangler.jsonc @do-ops885
+
+# Security-sensitive files
+/SECURITY.md @do-ops885
+/.github/SECURITY.md @do-ops885
+
+# Dependency management
+/package.json @do-ops885
+/package-lock.json @do-ops885

--- a/.github/Main Branch Protection.json
+++ b/.github/Main Branch Protection.json
@@ -15,10 +15,10 @@
     {
       "type": "pull_request",
       "parameters": {
-        "required_approving_review_count": 0,
+        "required_approving_review_count": 1,
         "dismiss_stale_reviews_on_push": true,
         "required_reviewers": [],
-        "require_code_owner_review": false,
+        "require_code_owner_review": true,
         "require_last_push_approval": false,
         "required_review_thread_resolution": true,
         "automatic_copilot_code_review_enabled": false,


### PR DESCRIPTION
Created .github/CODEOWNERS to automate PR review routing for sensitive directories and files. Updated .github/Main Branch Protection.json to enforce code owner reviews and require at least one approval for the main branch, aligning with the project's security and CI/CD best practices.

Fixes #182

---
*PR created automatically by Jules for task [7793139135859655290](https://jules.google.com/task/7793139135859655290) started by @do-ops885*