### PR TITLE
validate trufflehog fix with single-commit PR

### DIFF
--- a/plans/sprint-v0.1.5.md
+++ b/plans/sprint-v0.1.5.md
@@ -48,6 +48,7 @@ outcome: ${{ steps.secret-scan.conclusion }}
 Using `conclusion` correctly reflects that `continue-on-error: true` means the failure is expected and handled.
 
 **Validation**: ✅ PR #249 created with single commit, Security workflow passed, PR merged by `github-actions`.
+- Second validation (v2): Triggered via single-commit PR on branch `test/trufflehog-validation-v2` to re-confirm `conclusion` logic.
 
 ### Blocker 3: CodeQL Not Enabled
 

--- a/scripts/test-trufflehog-validate.txt
+++ b/scripts/test-trufflehog-validate.txt
@@ -1,1 +1,2 @@
 // Test commit to validate TruffleHog security fix (single-commit PR)
+// Validation timestamp v2: Sat May 16 15:10:40 UTC 2026


### PR DESCRIPTION
Validating the TruffleHog security fix with a single-commit PR to branch `test/trufflehog-validation-v2`. This re-confirms that the `conclusion` logic correctly handles the single-commit scenario.

Fixes #240

---
*PR created automatically by Jules for task [2750290004861158949](https://jules.google.com/task/2750290004861158949) started by @do-ops885*