### PR TITLE
Enable real fetching for research agent by default in production

### DIFF
--- a/tests/integration/research-api.test.ts
+++ b/tests/integration/research-api.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import worker from "../../worker/index";
+import type { Env } from "../../worker/types";
+
+describe("Research API Integration", () => {
+  const authHeader = { "X-API-Key": "ddr_admin_test_key_123" };
+  let mockKvStorage: Map<string, unknown>;
+  let mockEnv: Env;
+
+  function mockKvFactory(prefix: string) {
+    return {
+      get: vi.fn(async (key: string, type?: string) => {
+        const fullKey = `${prefix}:${key}`;
+        const value = mockKvStorage.get(fullKey);
+        if (value === undefined) return null;
+        if (type === "json" && typeof value === "string") {
+          return JSON.parse(value);
+        }
+        return value;
+      }),
+      put: vi.fn(async (key: string, value: string) => {
+        const fullKey = `${prefix}:${key}`;
+        mockKvStorage.set(fullKey, value);
+      }),
+    };
+  }
+
+  beforeEach(async () => {
+    mockKvStorage = new Map();
+    // Set up auth
+    const encoder = new TextEncoder();
+    const hashBuffer = await crypto.subtle.digest(
+      "SHA-256",
+      encoder.encode("ddr_admin_test_key_123"),
+    );
+    const hash = Array.from(new Uint8Array(hashBuffer))
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+    mockKvStorage.set(
+      "sources:apikey:" + hash,
+      JSON.stringify({ role: "admin", userId: "test-user" }),
+    );
+
+    mockEnv = {
+      DEALS_SOURCES: mockKvFactory("sources"),
+      DEALS_PROD: mockKvFactory("prod"),
+      DEALS_LOG: mockKvFactory("log"),
+      DEALS_LOCK: mockKvFactory("lock"),
+      ENVIRONMENT: "test",
+      GITHUB_REPO: "test/repo",
+      TRUST_THRESHOLD: "0.5",
+      AI_GATEWAY_URL: "https://gateway.test",
+      NOTIFICATION_THRESHOLD: "100",
+    } as unknown as Env;
+
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("should use simulated mode by default in test environment", async () => {
+    const request = new Request("http://localhost/api/research", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...authHeader,
+      },
+      body: JSON.stringify({
+        query: "test query",
+        domain: "example.com",
+      }),
+    });
+
+    const response = await worker.fetch(request, mockEnv);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.research_metadata.used_real_fetching).toBe(false);
+    // Simulated sources usually have "(simulated)" in their name in some places,
+    // but here we check used_real_fetching flag in metadata.
+  });
+
+  it("should use real fetching when ENVIRONMENT is production", async () => {
+    mockEnv.ENVIRONMENT = "production";
+
+    // Mock fetch for real fetching attempt
+    global.fetch = vi.fn().mockRejectedValue(new Error("Network error"));
+
+    const request = new Request("http://localhost/api/research", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...authHeader,
+      },
+      body: JSON.stringify({
+        query: "test query",
+        domain: "example.com",
+      }),
+    });
+
+    const response = await worker.fetch(request, mockEnv);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.research_metadata.used_real_fetching).toBe(true);
+  });
+
+  it("should use real fetching when RESEARCH_USE_REAL_FETCHING is true", async () => {
+    mockEnv.RESEARCH_USE_REAL_FETCHING = "true";
+
+    // Mock fetch for real fetching attempt
+    global.fetch = vi.fn().mockRejectedValue(new Error("Network error"));
+
+    const request = new Request("http://localhost/api/research", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...authHeader,
+      },
+      body: JSON.stringify({
+        query: "test query",
+        domain: "example.com",
+      }),
+    });
+
+    const response = await worker.fetch(request, mockEnv);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.research_metadata.used_real_fetching).toBe(true);
+  });
+
+  it("should respect explicit use_real_fetching option in request body", async () => {
+    const request = new Request("http://localhost/api/research", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...authHeader,
+      },
+      body: JSON.stringify({
+        query: "test query",
+        domain: "example.com",
+        options: {
+          use_real_fetching: true,
+        },
+      }),
+    });
+
+    // Mock fetch for real fetching attempt
+    global.fetch = vi.fn().mockRejectedValue(new Error("Network error"));
+
+    const response = await worker.fetch(request, mockEnv);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.research_metadata.used_real_fetching).toBe(true);
+  });
+
+  it("should handle rate limiting for real requests", async () => {
+    mockEnv.RESEARCH_USE_REAL_FETCHING = "true";
+
+    // We need to trigger rate limit.
+    // The researchRateLimiter is global in the module, so we might need to reset it or fill it.
+    // In orchestrator.ts it uses researchRateLimiter from fetcher.ts.
+
+    const { researchRateLimiter } =
+      await import("../../worker/lib/research-agent/fetcher");
+    // Fill the rate limiter for a source
+    for (let i = 0; i < 11; i++) {
+      researchRateLimiter.recordRequest("producthunt");
+    }
+
+    const request = new Request("http://localhost/api/research", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...authHeader,
+      },
+      body: JSON.stringify({
+        query: "test query",
+        domain: "example.com",
+        sources: ["producthunt"],
+      }),
+    });
+
+    const response = await worker.fetch(request, mockEnv);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.research_metadata.errors).toBeDefined();
+    expect(
+      body.research_metadata.errors.some((e) => e.includes("Rate limited")),
+    ).toBe(true);
+  });
+});

--- a/tests/unit/research-agent.test.ts
+++ b/tests/unit/research-agent.test.ts
@@ -278,6 +278,42 @@ describe("Research Agent - Real Fetching", () => {
       expect(result.research_metadata.errors).toBeDefined();
       expect(result.research_metadata.errors!.length).toBeGreaterThan(0);
     });
+
+    it("should auto-enable real fetching in production environment", async () => {
+      mockEnv.ENVIRONMENT = "production";
+
+      const request: WebResearchRequest = {
+        query: "test referral",
+        depth: "quick",
+        sources: ["producthunt"],
+        max_results: 5,
+      };
+
+      // Mock fetch to simulate attempt
+      global.fetch = vi.fn().mockRejectedValue(new Error("Network error"));
+
+      const result = await executeReferralResearch(mockEnv, request);
+
+      expect(result.research_metadata.used_real_fetching).toBe(true);
+    });
+
+    it("should auto-enable real fetching when RESEARCH_USE_REAL_FETCHING is true", async () => {
+      mockEnv.RESEARCH_USE_REAL_FETCHING = "true";
+
+      const request: WebResearchRequest = {
+        query: "test referral",
+        depth: "quick",
+        sources: ["producthunt"],
+        max_results: 5,
+      };
+
+      // Mock fetch to simulate attempt
+      global.fetch = vi.fn().mockRejectedValue(new Error("Network error"));
+
+      const result = await executeReferralResearch(mockEnv, request);
+
+      expect(result.research_metadata.used_real_fetching).toBe(true);
+    });
   });
 
   describe("convertResearchToReferrals", () => {

--- a/worker/lib/research-agent/orchestrator.ts
+++ b/worker/lib/research-agent/orchestrator.ts
@@ -190,8 +190,12 @@ export async function executeReferralResearch(
   const hasApiKeys = Boolean(
     apiKeys.productHuntToken || apiKeys.githubToken || apiKeys.redditClientId,
   );
-  // Auto-enable real fetching when API keys are available, unless explicitly disabled
-  const useRealFetching = request.options?.use_real_fetching ?? hasApiKeys;
+  // Auto-enable real fetching when API keys are available, in production, or via env var, unless explicitly disabled
+  const useRealFetching =
+    request.options?.use_real_fetching ??
+    (env.ENVIRONMENT === "production" ||
+      env.RESEARCH_USE_REAL_FETCHING === "true" ||
+      hasApiKeys);
 
   // Gather research from multiple sources
   const discoveredCodes: ReferralResearchResult["discovered_codes"] = [];
@@ -534,7 +538,7 @@ export async function researchAllReferralPossibilities(
   env: Env,
   domain: string,
   depth: WebResearchRequest["depth"] = "thorough",
-  useRealFetching = false,
+  useRealFetching?: boolean,
 ): Promise<ReferralResearchResult> {
   const request: WebResearchRequest = {
     query: `${domain} referral code invite program`,

--- a/worker/types.ts
+++ b/worker/types.ts
@@ -328,6 +328,7 @@ export interface Env {
   TELEGRAM_BOT_TOKEN?: string;
   TELEGRAM_CHAT_ID?: string;
   EMAIL_WEBHOOK_SECRET?: string;
+  RESEARCH_USE_REAL_FETCHING?: string;
   // D1 Migration Feature Flags
   USE_D1_READS?: string;
   DISABLE_DUAL_WRITE?: string;


### PR DESCRIPTION
The research agent was previously running in simulated mode by default, even if real fetching infrastructure was available. This change updates the orchestration logic to auto-enable real fetching when:
1. The environment is 'production'.
2. The `RESEARCH_USE_REAL_FETCHING` environment variable is set to 'true'.
3. API keys for Product Hunt, GitHub, or Reddit are detected.

It preserves the ability to explicitly override this behavior via request options and ensures development/test environments still default to simulated mode unless otherwise configured. New integration and unit tests verify these behaviors.

Fixes #265

---
*PR created automatically by Jules for task [12399819020391884470](https://jules.google.com/task/12399819020391884470) started by @do-ops885*