### PR TITLE
Enable HMAC Webhook Signature Verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,10 @@
 # AGENTS.md - Deal Discovery System (do-deal-relay)
 
-> Single source of truth for all AI coding agents in this repository.
-> Supported by: Claude Code, Gemini CLI, Qwen Code, Windsurf, Jules.
-> See: https://agents.md
+> Single source of truth for all AI coding agents in this
+> repository.
+> Supported by: Claude Code, Gemini CLI, Qwen Code, Windsurf,
+> Jules.
+> See: <https://agents.md>
 
 ## Named Constants
 
@@ -23,38 +25,55 @@ readonly MAX_COMMIT_SUBJECT_LENGTH=72
 
 ## Development Phases (Agent Workflow)
 
-We use a GOAP (Goal-Oriented Action Planning) approach combined with ADRs (Architecture Decision Records) for structured development.
+We use a GOAP (Goal-Oriented Action Planning) approach combined
+with ADRs (Architecture Decision Records) for structured
+development.
 
 1. **ANALYZE & STRATEGIZE (Phase 1)**
-   - **Action**: Evaluate the problem, identify architecture requirements. Write an **ADR** (Architecture Decision Record) detailing the context, decision, and consequences.
+   - **Action**: Evaluate the problem, identify architecture
+     requirements. Write an **ADR** (Architecture Decision
+     Record) detailing the context, decision, and consequences.
    - **Storage**: Save the ADR in the `plans/` directory.
-   - **Instruction**: Analyze the repository before asking questions. Infer from existing patterns first.
+   - **Instruction**: Analyze the repository before asking
+     questions. Infer from existing patterns first.
 
 2. **DECOMPOSE & PLAN (Phase 2)**
-   - **Action**: Break down the problem into atomic, testable tasks. Record these in a plan file under `plans/`.
-   - **Instruction**: produce a written plan, wait for confirmation for non-trivial tasks.
+   - **Action**: Break down the problem into atomic, testable
+     tasks. Record these in a plan file under `plans/`.
+   - **Instruction**: produce a written plan, wait for
+     confirmation for non-trivial tasks.
 
 3. **EXECUTE & COORDINATE (Phase 3)**
-   - **Action**: Execute tasks systematically using the atomic commit workflow.
-   - **Mandatory**: Run `./scripts/quality_gate.sh` before every commit.
-   - **Instruction**: Respect existing 9 validation gates. Avoid speculative rewrites.
+   - **Action**: Execute tasks systematically using the atomic
+     commit workflow.
+   - **Mandatory**: Run `./scripts/quality_gate.sh` before every
+     commit.
+   - **Instruction**: Respect existing 9 validation gates. Avoid
+     speculative rewrites.
 
 4. **SYNTHESIZE (Phase 4)**
-   - **Action**: Extract discoveries and update project-specific documentation or `AGENTS.md` contexts.
+   - **Action**: Extract discoveries and update project-specific
+     documentation or `AGENTS.md` contexts.
 
 ## Atomic Commit Workflow (Mandatory)
 
 All agent-driven changes MUST use the helper script:
+
 ```bash
-./scripts/ai-commit.sh --type <type> [--scope <scope>] --subject <subject> [--body <body>]
+./scripts/ai-commit.sh --type <type> [--scope <scope>] \
+  --subject <subject> [--body <body>]
 ```
 
 ### Commit Types
-`feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`.
+
+`feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`,
+`build`, `ci`, `chore`, `revert`.
 
 ## Quality Gates (System Infrastructure)
 
-The system enforces 13 quality gates via `./scripts/quality_gate.sh`:
+The system enforces 13 quality gates via
+`./scripts/quality_gate.sh`:
+
 1. TypeScript compilation
 2. Unit tests
 3. Validation gate orchestration check
@@ -71,7 +90,9 @@ The system enforces 13 quality gates via `./scripts/quality_gate.sh`:
 
 ## Validation Gates (Per-Deal Logic)
 
-The system enforces 9 mandatory validation gates in the worker pipeline (`worker/validation/pipeline.ts`):
+The system enforces 9 mandatory validation gates in the worker
+pipeline (`worker/validation/pipeline.ts`):
+
 1. `schema_validation`
 2. `normalization_verification`
 3. `deduplication_check`
@@ -84,15 +105,21 @@ The system enforces 9 mandatory validation gates in the worker pipeline (`worker
 
 ## Repository Structure Rules
 
-- **Allowed in root**: Only standard config files (package.json, wrangler.jsonc, etc.).
+- **Allowed in root**: Only standard config files
+  (package.json, wrangler.jsonc, etc.).
 - **Documentation**: MUST be in `docs/` or `agents-docs/`.
 - **Plans/Reports**: MUST be in `plans/` or `reports/`.
 - **Skills**: Canonical source is `.agents/skills/`.
-- **Temporary Files**: MUST be in `temp/`. Diagnostic or transient files (e.g., `typecheck_*.txt`) in the root are forbidden.
+- **Temporary Files**: MUST be in `temp/`. Diagnostic or
+  transient files (e.g., `typecheck_*.txt`) in the root are
+  forbidden.
 
 ## Agent Guidance
 
-- **Minimal Clarification**: Do not ask questions that can be answered by analyzing the repo.
-- **Architectural Consistency**: Preserve existing state-machine and modular gate architecture.
+- **Minimal Clarification**: Do not ask questions that can be
+  answered by analyzing the repo.
+- **Architectural Consistency**: Preserve existing state-machine
+  and modular gate architecture.
 - **Incremental Changes**: Make small, verified changes.
-- **Verification**: Always use read-only tools to confirm the effect of your changes.
+- **Verification**: Always use read-only tools to confirm the
+  effect of your changes.

--- a/docs/WEBHOOKS.md
+++ b/docs/WEBHOOKS.md
@@ -1,0 +1,71 @@
+# Webhook Signature Verification
+
+The Referral Discovery System uses HMAC-SHA256 signatures to ensure the authenticity and integrity of incoming webhooks.
+
+## Headers
+
+Every webhook request must include the following security headers:
+
+- `X-Webhook-Signature`: The HMAC-SHA256 signature, prefixed with `sha256=`.
+- `X-Webhook-Timestamp`: The Unix timestamp (in seconds) when the request was generated.
+- `X-Webhook-Id`: A unique identifier for the webhook event.
+
+## Signature Generation
+
+The signature is generated using a shared secret key and the request payload.
+
+### Step 1: Prepare the Signed Payload
+
+Concatenate the timestamp and the raw request body with a period (`.`) separator:
+
+```
+signed_payload = timestamp + "." + request_body
+```
+
+### Step 2: Compute the HMAC
+
+Compute the HMAC-SHA256 of the `signed_payload` using your secret key.
+
+### Step 3: Hex Encode the Result
+
+Convert the resulting HMAC binary to a hexadecimal string.
+
+### Step 4: Add the Prefix
+
+Prepend `sha256=` to the hex-encoded signature.
+
+## Implementation Examples
+
+### Node.js
+
+```javascript
+const crypto = require('crypto');
+
+function generateSignature(secret, timestamp, body) {
+  const signedPayload = `${timestamp}.${body}`;
+  const hmac = crypto.createHmac('sha256', secret);
+  hmac.update(signedPayload);
+  const signature = hmac.digest('hex');
+  return `sha256=${signature}`;
+}
+```
+
+### Python
+
+```python
+import hmac
+import hashlib
+
+def generate_signature(secret, timestamp, body):
+    signed_payload = f"{timestamp}.{body}".encode('utf-8')
+    signature = hmac.new(
+        secret.encode('utf-8'),
+        signed_payload,
+        hashlib.sha256
+    ).hexdigest()
+    return f"sha256={signature}"
+```
+
+## Replay Protection
+
+The system enforces a 5-minute (300 seconds) tolerance for the `X-Webhook-Timestamp`. Requests with a timestamp older than this will be rejected with a `401 Unauthorized` response to prevent replay attacks.

--- a/tests/unit/webhook-security-fix.test.ts
+++ b/tests/unit/webhook-security-fix.test.ts
@@ -1,83 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  verifyWebhookSignature,
+  generateHmacSignature,
+} from "../../worker/lib/hmac";
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { verifyWebhookSignature, generateHmacSignature } from '../../worker/lib/hmac';
+describe("Webhook Security - Unified Verification", () => {
+  const secret = "test-secret";
 
-describe('Webhook Security - Unified Verification', () => {
-  const secret = 'test-secret';
-
-  it('should reject requests with missing headers', async () => {
-    const request = new Request('https://api.example.com/webhook', {
-      method: 'POST',
-      body: JSON.stringify({ data: 'test' }),
+  it("should reject requests with missing headers", async () => {
+    const request = new Request("https://api.example.com/webhook", {
+      method: "POST",
+      body: JSON.stringify({ data: "test" }),
     });
 
     const result = await verifyWebhookSignature(request, secret);
     expect(result.valid).toBe(false);
-    expect(result.error).toBe('Missing signature or timestamp headers');
+    expect(result.error).toBe("Missing signature or timestamp headers");
   });
 
-  it('should reject requests with invalid signature format', async () => {
-    const request = new Request('https://api.example.com/webhook', {
-      method: 'POST',
+  it("should reject requests with invalid signature format", async () => {
+    const request = new Request("https://api.example.com/webhook", {
+      method: "POST",
       headers: {
-        'X-Webhook-Signature': 'invalid-format',
-        'X-Webhook-Timestamp': Math.floor(Date.now() / 1000).toString(),
+        "X-Webhook-Signature": "invalid-format",
+        "X-Webhook-Timestamp": Math.floor(Date.now() / 1000).toString(),
       },
-      body: JSON.stringify({ data: 'test' }),
+      body: JSON.stringify({ data: "test" }),
     });
 
     const result = await verifyWebhookSignature(request, secret);
     expect(result.valid).toBe(false);
-    expect(result.error).toBe('Invalid signature header format');
+    expect(result.error).toBe("Invalid signature header format");
   });
 
-  it('should reject requests with expired timestamp (replay protection)', async () => {
-    const payload = JSON.stringify({ data: 'test' });
+  it("should reject requests with expired timestamp (replay protection)", async () => {
+    const payload = JSON.stringify({ data: "test" });
     const oldTimestamp = Math.floor(Date.now() / 1000) - 301;
-    const signature = await generateHmacSignature(payload, secret, oldTimestamp);
+    const signature = await generateHmacSignature(
+      payload,
+      secret,
+      oldTimestamp,
+    );
 
-    const request = new Request('https://api.example.com/webhook', {
-      method: 'POST',
+    const request = new Request("https://api.example.com/webhook", {
+      method: "POST",
       headers: {
-        'X-Webhook-Signature': `sha256=${signature}`,
-        'X-Webhook-Timestamp': oldTimestamp.toString(),
+        "X-Webhook-Signature": `sha256=${signature}`,
+        "X-Webhook-Timestamp": oldTimestamp.toString(),
       },
       body: payload,
     });
 
     const result = await verifyWebhookSignature(request, secret);
     expect(result.valid).toBe(false);
-    expect(result.error).toContain('Webhook timestamp too old');
+    expect(result.error).toContain("Webhook timestamp too old");
   });
 
-  it('should reject requests with invalid HMAC signature', async () => {
-    const payload = JSON.stringify({ data: 'test' });
+  it("should reject requests with invalid HMAC signature", async () => {
+    const payload = JSON.stringify({ data: "test" });
     const timestamp = Math.floor(Date.now() / 1000);
 
-    const request = new Request('https://api.example.com/webhook', {
-      method: 'POST',
+    const request = new Request("https://api.example.com/webhook", {
+      method: "POST",
       headers: {
-        'X-Webhook-Signature': `sha256=incorrectsignature`,
-        'X-Webhook-Timestamp': timestamp.toString(),
+        "X-Webhook-Signature": `sha256=incorrectsignature`,
+        "X-Webhook-Timestamp": timestamp.toString(),
       },
       body: payload,
     });
 
     const result = await verifyWebhookSignature(request, secret);
     expect(result.valid).toBe(false);
-    expect(result.error).toBe('Invalid signature');
+    expect(result.error).toBe("Invalid signature");
   });
 
-  it('should accept requests with valid signature and timestamp', async () => {
-    const payload = JSON.stringify({ data: 'test' });
+  it("should accept requests with valid signature and timestamp", async () => {
+    const payload = JSON.stringify({ data: "test" });
     const timestamp = Math.floor(Date.now() / 1000);
     const signature = await generateHmacSignature(payload, secret, timestamp);
 
-    const request = new Request('https://api.example.com/webhook', {
-      method: 'POST',
+    const request = new Request("https://api.example.com/webhook", {
+      method: "POST",
       headers: {
-        'X-Webhook-Signature': `sha256=${signature}`,
-        'X-Webhook-Timestamp': timestamp.toString(),
+        "X-Webhook-Signature": `sha256=${signature}`,
+        "X-Webhook-Timestamp": timestamp.toString(),
       },
       body: payload,
     });

--- a/tests/unit/webhook-security-fix.test.ts
+++ b/tests/unit/webhook-security-fix.test.ts
@@ -1,0 +1,88 @@
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { verifyWebhookSignature, generateHmacSignature } from '../../worker/lib/hmac';
+
+describe('Webhook Security - Unified Verification', () => {
+  const secret = 'test-secret';
+
+  it('should reject requests with missing headers', async () => {
+    const request = new Request('https://api.example.com/webhook', {
+      method: 'POST',
+      body: JSON.stringify({ data: 'test' }),
+    });
+
+    const result = await verifyWebhookSignature(request, secret);
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('Missing signature or timestamp headers');
+  });
+
+  it('should reject requests with invalid signature format', async () => {
+    const request = new Request('https://api.example.com/webhook', {
+      method: 'POST',
+      headers: {
+        'X-Webhook-Signature': 'invalid-format',
+        'X-Webhook-Timestamp': Math.floor(Date.now() / 1000).toString(),
+      },
+      body: JSON.stringify({ data: 'test' }),
+    });
+
+    const result = await verifyWebhookSignature(request, secret);
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('Invalid signature header format');
+  });
+
+  it('should reject requests with expired timestamp (replay protection)', async () => {
+    const payload = JSON.stringify({ data: 'test' });
+    const oldTimestamp = Math.floor(Date.now() / 1000) - 301;
+    const signature = await generateHmacSignature(payload, secret, oldTimestamp);
+
+    const request = new Request('https://api.example.com/webhook', {
+      method: 'POST',
+      headers: {
+        'X-Webhook-Signature': `sha256=${signature}`,
+        'X-Webhook-Timestamp': oldTimestamp.toString(),
+      },
+      body: payload,
+    });
+
+    const result = await verifyWebhookSignature(request, secret);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('Webhook timestamp too old');
+  });
+
+  it('should reject requests with invalid HMAC signature', async () => {
+    const payload = JSON.stringify({ data: 'test' });
+    const timestamp = Math.floor(Date.now() / 1000);
+
+    const request = new Request('https://api.example.com/webhook', {
+      method: 'POST',
+      headers: {
+        'X-Webhook-Signature': `sha256=incorrectsignature`,
+        'X-Webhook-Timestamp': timestamp.toString(),
+      },
+      body: payload,
+    });
+
+    const result = await verifyWebhookSignature(request, secret);
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('Invalid signature');
+  });
+
+  it('should accept requests with valid signature and timestamp', async () => {
+    const payload = JSON.stringify({ data: 'test' });
+    const timestamp = Math.floor(Date.now() / 1000);
+    const signature = await generateHmacSignature(payload, secret, timestamp);
+
+    const request = new Request('https://api.example.com/webhook', {
+      method: 'POST',
+      headers: {
+        'X-Webhook-Signature': `sha256=${signature}`,
+        'X-Webhook-Timestamp': timestamp.toString(),
+      },
+      body: payload,
+    });
+
+    const result = await verifyWebhookSignature(request, secret);
+    expect(result.valid).toBe(true);
+  });
+});

--- a/tests/unit/webhook/routes-dispatcher.test.ts
+++ b/tests/unit/webhook/routes-dispatcher.test.ts
@@ -336,7 +336,7 @@ describe("Webhook Route Dispatcher", () => {
         body: "{}",
       });
       const response = await handleIncomingWebhookRequest(request, env, "p1");
-      expect(response.status).toBe(400);
+      expect(response.status).toBe(401);
     });
 
     it("should process request with all required headers", async () => {

--- a/tests/unit/webhook/routes-dispatcher.test.ts
+++ b/tests/unit/webhook/routes-dispatcher.test.ts
@@ -374,12 +374,43 @@ describe("Webhook Route Dispatcher", () => {
 
     it("should return 500 on internal error", async () => {
       const env = createEnv(kv);
+      // Set up a partner so partner lookup succeeds
+      const partnerSecret = "whsec_test_secret";
+      const partners = [{
+        id: "p1",
+        name: "Test Partner",
+        secret: partnerSecret,
+        active: true,
+        allowed_events: ["referral.created"],
+        rate_limit_per_minute: 60,
+        created_at: new Date().toISOString(),
+      }];
+      kv.storage.set("webhook_partners", JSON.stringify(partners));
+
+      // Compute valid HMAC signature for the FAIL payload
+      const now = Math.floor(Date.now() / 1000);
+      const encoder = new TextEncoder();
+      const signedPayload = `${now}.FAIL`;
+      const key = await crypto.subtle.importKey(
+        "raw",
+        encoder.encode(partnerSecret),
+        { name: "HMAC", hash: "SHA-256" },
+        false,
+        ["sign"],
+      );
+      const sigBuffer = await crypto.subtle.sign(
+        "HMAC", key, encoder.encode(signedPayload),
+      );
+      const signature = Array.from(new Uint8Array(sigBuffer))
+        .map((b) => b.toString(16).padStart(2, "0"))
+        .join("");
+
       const request = new Request("http://localhost/test", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "X-Webhook-Signature": "sha256=abc",
-          "X-Webhook-Timestamp": String(Math.floor(Date.now() / 1000)),
+          "X-Webhook-Signature": `sha256=${signature}`,
+          "X-Webhook-Timestamp": String(now),
           "X-Webhook-Id": "wh_1",
         },
         body: "FAIL",

--- a/tests/unit/webhook/routes-dispatcher.test.ts
+++ b/tests/unit/webhook/routes-dispatcher.test.ts
@@ -376,15 +376,17 @@ describe("Webhook Route Dispatcher", () => {
       const env = createEnv(kv);
       // Set up a partner so partner lookup succeeds
       const partnerSecret = "whsec_test_secret";
-      const partners = [{
-        id: "p1",
-        name: "Test Partner",
-        secret: partnerSecret,
-        active: true,
-        allowed_events: ["referral.created"],
-        rate_limit_per_minute: 60,
-        created_at: new Date().toISOString(),
-      }];
+      const partners = [
+        {
+          id: "p1",
+          name: "Test Partner",
+          secret: partnerSecret,
+          active: true,
+          allowed_events: ["referral.created"],
+          rate_limit_per_minute: 60,
+          created_at: new Date().toISOString(),
+        },
+      ];
       kv.storage.set("webhook_partners", JSON.stringify(partners));
 
       // Compute valid HMAC signature for the FAIL payload
@@ -399,7 +401,9 @@ describe("Webhook Route Dispatcher", () => {
         ["sign"],
       );
       const sigBuffer = await crypto.subtle.sign(
-        "HMAC", key, encoder.encode(signedPayload),
+        "HMAC",
+        key,
+        encoder.encode(signedPayload),
       );
       const signature = Array.from(new Uint8Array(sigBuffer))
         .map((b) => b.toString(16).padStart(2, "0"))

--- a/worker/lib/hmac.ts
+++ b/worker/lib/hmac.ts
@@ -45,6 +45,35 @@ export async function generateHmacSignature(
 }
 
 /**
+ * Unified webhook signature verification for Request objects
+ */
+export async function verifyWebhookSignature(
+  request: Request,
+  secret: string,
+): Promise<SignatureResult> {
+  const signatureHeader = request.headers.get("x-webhook-signature");
+  const timestampHeader = request.headers.get("x-webhook-timestamp");
+
+  if (!signatureHeader || !timestampHeader) {
+    return { valid: false, error: "Missing signature or timestamp headers" };
+  }
+
+  const parsed = parseSignatureHeader(signatureHeader);
+  if (!parsed) {
+    return { valid: false, error: "Invalid signature header format" };
+  }
+
+  const body = await request.clone().text();
+  const timestamp = parseInt(timestampHeader, 10);
+
+  if (isNaN(timestamp)) {
+    return { valid: false, error: "Invalid timestamp" };
+  }
+
+  return await verifyHmacSignature(body, parsed.signature, secret, timestamp);
+}
+
+/**
  * Verify HMAC-SHA256 signature with timing-safe comparison
  * Includes timestamp validation to prevent replay attacks
  */

--- a/worker/lib/webhook/incoming.ts
+++ b/worker/lib/webhook/incoming.ts
@@ -35,6 +35,7 @@ export async function handleIncomingWebhook(
     webhookId: string;
     idempotencyKey?: string;
   },
+  verified?: boolean,
 ): Promise<IncomingWebhookResult> {
   const requestId = generateId();
   logger.info(`Incoming webhook received: ${headers.webhookId}`, {
@@ -96,25 +97,27 @@ export async function handleIncomingWebhook(
       }
     }
 
-    // 4. Verify HMAC signature
-    const timestamp = parseInt(headers.timestamp, 10);
-    const signatureResult = await verifyHmacSignature(
-      payload,
-      headers.signature.replace("sha256=", ""),
-      partner.secret,
-      timestamp,
-    );
-    if (!signatureResult.valid) {
-      logger.warn(
-        `Invalid webhook signature from ${partnerId}: ${signatureResult.error}`,
-        { component: "webhook", partner_id: partnerId },
+    // 4. Verify HMAC signature (skip if already verified at request boundary)
+    if (!verified) {
+      const timestamp = parseInt(headers.timestamp, 10);
+      const signatureResult = await verifyHmacSignature(
+        payload,
+        headers.signature.replace("sha256=", ""),
+        partner.secret,
+        timestamp,
       );
-      return {
-        success: false,
-        statusCode: 401,
-        message: "Invalid signature",
-        error: signatureResult.error,
-      };
+      if (!signatureResult.valid) {
+        logger.warn(
+          `Invalid webhook signature from ${partnerId}: ${signatureResult.error}`,
+          { component: "webhook", partner_id: partnerId },
+        );
+        return {
+          success: false,
+          statusCode: 401,
+          message: "Invalid signature",
+          error: signatureResult.error,
+        };
+      }
     }
 
     // 5. Parse and validate payload

--- a/worker/routes/email.ts
+++ b/worker/routes/email.ts
@@ -2,7 +2,7 @@ import type { Env } from "../types";
 import { processEmail, emailWorkerHandler } from "../email/handler";
 import { createHelpEmail } from "../email/templates";
 import { logger } from "../lib/global-logger";
-import { verifyHmacSignature, parseSignatureHeader } from "../lib/hmac";
+import { verifyWebhookSignature } from "../lib/hmac";
 import { unauthorizedResponse, errorResponse, jsonResponse } from "./utils";
 
 // ============================================================================
@@ -12,41 +12,6 @@ import { unauthorizedResponse, errorResponse, jsonResponse } from "./utils";
 // GET /api/email/help - Get help email content
 // ============================================================================
 
-/**
- * Verify webhook signature for email endpoints
- */
-async function verifyEmailWebhook(
-  request: Request,
-  secret: string,
-): Promise<{ valid: boolean; error?: string }> {
-  const signatureHeader = request.headers.get("x-webhook-signature");
-  const timestampHeader = request.headers.get("x-webhook-timestamp");
-
-  if (!signatureHeader || !timestampHeader) {
-    return { valid: false, error: "Missing signature or timestamp headers" };
-  }
-
-  const parsed = parseSignatureHeader(signatureHeader);
-  if (!parsed) {
-    return { valid: false, error: "Invalid signature header format" };
-  }
-
-  const body = await request.clone().text();
-  const timestamp = parseInt(timestampHeader, 10);
-
-  if (isNaN(timestamp)) {
-    return { valid: false, error: "Invalid timestamp" };
-  }
-
-  const result = await verifyHmacSignature(
-    body,
-    parsed.signature,
-    secret,
-    timestamp,
-  );
-  return result;
-}
-
 export async function handleEmailIncoming(
   request: Request,
   env: Env,
@@ -54,7 +19,7 @@ export async function handleEmailIncoming(
   try {
     // Verify webhook signature if configured (CRITICAL SECURITY FIX)
     if (env.EMAIL_WEBHOOK_SECRET) {
-      const verification = await verifyEmailWebhook(
+      const verification = await verifyWebhookSignature(
         request,
         env.EMAIL_WEBHOOK_SECRET,
       );

--- a/worker/routes/webhooks/incoming.ts
+++ b/worker/routes/webhooks/incoming.ts
@@ -52,10 +52,18 @@ export async function handleIncomingWebhookRequest(
       );
     }
 
-    // Get headers for downstream processing
+    // Validate webhook ID header (verifyWebhookSignature already checked signature + timestamp)
+    const webhookId = request.headers.get("x-webhook-id");
+    if (!webhookId) {
+      return jsonResponse(
+        { error: "Missing required headers", required: ["X-Webhook-Id"] },
+        401,
+      );
+    }
+
+    // Get remaining headers for downstream processing
     const signature = request.headers.get("x-webhook-signature") || "";
     const timestamp = request.headers.get("x-webhook-timestamp") || "";
-    const webhookId = request.headers.get("x-webhook-id") || "";
     const idempotencyKey = request.headers.get("idempotency-key") || undefined;
 
     // Read payload

--- a/worker/routes/webhooks/incoming.ts
+++ b/worker/routes/webhooks/incoming.ts
@@ -70,12 +70,18 @@ export async function handleIncomingWebhookRequest(
     const payload = await request.text();
 
     // Process webhook (HMAC already verified at route level)
-    const result = await handleIncomingWebhook(env, partnerId, payload, {
-      signature,
-      timestamp,
-      webhookId,
-      idempotencyKey,
-    }, true);
+    const result = await handleIncomingWebhook(
+      env,
+      partnerId,
+      payload,
+      {
+        signature,
+        timestamp,
+        webhookId,
+        idempotencyKey,
+      },
+      true,
+    );
 
     return jsonResponse(
       {

--- a/worker/routes/webhooks/incoming.ts
+++ b/worker/routes/webhooks/incoming.ts
@@ -43,7 +43,7 @@ export async function handleIncomingWebhookRequest(
             "X-Webhook-Id",
           ],
         },
-        400,
+        401,
       );
     }
 

--- a/worker/routes/webhooks/incoming.ts
+++ b/worker/routes/webhooks/incoming.ts
@@ -6,6 +6,8 @@ import type { Env } from "../../types";
 import { logger } from "../../lib/global-logger";
 import { handleError } from "../../lib/error-handler";
 import { handleIncomingWebhook } from "../../lib/webhook/index";
+import { verifyWebhookSignature } from "../../lib/hmac";
+import { getWebhookPartner } from "../../lib/webhook/subscriptions";
 import { jsonResponse } from "./types";
 
 // ============================================================================
@@ -27,36 +29,45 @@ export async function handleIncomingWebhookRequest(
       );
     }
 
-    // Get headers
+    // Look up partner for secret (needed for HMAC verification)
+    const partner = await getWebhookPartner(env, partnerId);
+    if (!partner) {
+      return jsonResponse({ error: "Unknown partner" }, 401);
+    }
+    if (!partner.active) {
+      return jsonResponse({ error: "Partner deactivated" }, 403);
+    }
+
+    // Verify webhook signature at request boundary (defense-in-depth)
+    const verification = await verifyWebhookSignature(request, partner.secret);
+    if (!verification.valid) {
+      logger.warn("Webhook signature verification failed", {
+        component: "webhook",
+        partner_id: partnerId,
+        error: verification.error,
+      });
+      return jsonResponse(
+        { error: `Invalid webhook signature: ${verification.error}` },
+        401,
+      );
+    }
+
+    // Get headers for downstream processing
     const signature = request.headers.get("x-webhook-signature") || "";
     const timestamp = request.headers.get("x-webhook-timestamp") || "";
     const webhookId = request.headers.get("x-webhook-id") || "";
     const idempotencyKey = request.headers.get("idempotency-key") || undefined;
 
-    if (!signature || !timestamp || !webhookId) {
-      return jsonResponse(
-        {
-          error: "Missing required headers",
-          required: [
-            "X-Webhook-Signature",
-            "X-Webhook-Timestamp",
-            "X-Webhook-Id",
-          ],
-        },
-        401,
-      );
-    }
-
     // Read payload
     const payload = await request.text();
 
-    // Process webhook
+    // Process webhook (HMAC already verified at route level)
     const result = await handleIncomingWebhook(env, partnerId, payload, {
       signature,
       timestamp,
       webhookId,
       idempotencyKey,
-    });
+    }, true);
 
     return jsonResponse(
       {

--- a/worker/types.ts
+++ b/worker/types.ts
@@ -328,6 +328,7 @@ export interface Env {
   TELEGRAM_BOT_TOKEN?: string;
   TELEGRAM_CHAT_ID?: string;
   EMAIL_WEBHOOK_SECRET?: string;
+  WEBHOOK_SECRET?: string;
   RESEARCH_USE_REAL_FETCHING?: string;
   // D1 Migration Feature Flags
   USE_D1_READS?: string;


### PR DESCRIPTION
Enabled HMAC-SHA256 signature verification across webhook endpoints. Implemented a unified helper for Request-based verification and updated the email and partner webhook routes to correctly enforce security checks and return 401 Unauthorized on failure. Added documentation and updated tests.

Fixes #269

---
*PR created automatically by Jules for task [3576716455789566274](https://jules.google.com/task/3576716455789566274) started by @do-ops885*