### PR TITLE
Improve manual code entry validation and accessibility in extension

### DIFF
--- a/extension/popup.html
+++ b/extension/popup.html
@@ -569,7 +569,11 @@
           maxlength="20"
           aria-describedby="manual-code-error"
         />
-        <div id="manual-code-error" class="error-text hidden" aria-live="polite">
+        <div
+          id="manual-code-error"
+          class="error-text hidden"
+          aria-live="polite"
+        >
           Code must be alphanumeric (4-20 chars)
         </div>
         <button class="btn btn-secondary" id="manual-btn" disabled>

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -442,6 +442,17 @@
         border-color: #4f46e5;
       }
 
+      .error-text {
+        color: #ef4444;
+        font-size: 11px;
+        margin-top: -6px;
+        margin-bottom: 10px;
+      }
+
+      .manual-input.invalid {
+        border-color: #ef4444;
+      }
+
       .hidden {
         display: none !important;
       }
@@ -556,8 +567,12 @@
           id="manual-code"
           placeholder="Enter referral code..."
           maxlength="20"
+          aria-describedby="manual-code-error"
         />
-        <button class="btn btn-secondary" id="manual-btn">
+        <div id="manual-code-error" class="error-text hidden" aria-live="polite">
+          Code must be alphanumeric (4-20 chars)
+        </div>
+        <button class="btn btn-secondary" id="manual-btn" disabled>
           Add Code Manually
         </button>
       </div>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -43,6 +43,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     statCaptured: document.getElementById("stat-captured"),
     statSubmitted: document.getElementById("stat-submitted"),
     statSuccess: document.getElementById("stat-success"),
+    manualCodeError: document.getElementById("manual-code-error"),
   };
 
   // ============================================================================
@@ -328,13 +329,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   async function captureManual() {
     const code = elements.manualCode.value.trim();
-    if (!code) {
-      showToast("Please enter a referral code", "error");
-      return;
-    }
-
-    if (!/^[A-Z0-9]+$/i.test(code)) {
-      showToast("Code must be alphanumeric only", "error");
+    if (!validateManualCode(code)) {
       return;
     }
 
@@ -461,12 +456,30 @@ document.addEventListener("DOMContentLoaded", async () => {
   // Event Listeners
   // ============================================================================
 
+  function validateManualCode(code) {
+    const isValid = /^[A-Z0-9]{4,20}$/i.test(code);
+
+    if (code.length > 0) {
+      elements.manualCode.classList.toggle("invalid", !isValid);
+      elements.manualCodeError.classList.toggle("hidden", isValid);
+    } else {
+      elements.manualCode.classList.remove("invalid");
+      elements.manualCodeError.classList.add("hidden");
+    }
+
+    elements.manualBtn.disabled = !isValid;
+    return isValid;
+  }
+
   function setupEventListeners() {
     // Capture button
     elements.captureBtn.addEventListener("click", captureSelected);
 
     // Manual entry
     elements.manualBtn.addEventListener("click", captureManual);
+    elements.manualCode.addEventListener("input", (e) => {
+      validateManualCode(e.target.value.trim());
+    });
     elements.manualCode.addEventListener("keypress", (e) => {
       if (e.key === "Enter") captureManual();
     });


### PR DESCRIPTION
What: Added real-time validation for the manual referral code entry field in the browser extension popup.
Why: Previously, users only received feedback via a toast message after clicking the "Add Code" button. This was not proactive and lacked clear accessibility associations.
Impact: Users now get immediate visual feedback (error message and red border) if the code is invalid (must be alphanumeric, 4-20 chars). The submission button is disabled until a valid code is entered, preventing invalid submissions. Accessibility is improved via `aria-describedby` and `aria-live` attributes.
Verification: Ran the extension popup in a browser environment using a Playwright verification script. Verified that the error message appears for short or non-alphanumeric codes and that the button enables/disables correctly. Verified accessibility attributes in the DOM.

---
*PR created automatically by Jules for task [1309565775121974768](https://jules.google.com/task/1309565775121974768) started by @do-ops885*