### PR TITLE
fix(workflow): add missing checkout step to discovery pipeline

### DIFF
--- a/.github/workflows/discovery.yml
+++ b/.github/workflows/discovery.yml
@@ -35,6 +35,11 @@ jobs:
       || github.event.schedule != ''
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          fetch-depth: 1
+
       - name: Resolve production host
         id: resolve_host
         env:
@@ -109,6 +114,11 @@ jobs:
     if: github.event.inputs.environment == 'staging'
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          fetch-depth: 1
+
       - name: Trigger discovery on staging
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
The `discovery-production` and `discovery-staging` jobs in `discovery.yml`
were failing because they lacked an `actions/checkout` step, preventing
them from accessing `scripts/worker-host.sh`.

This commit:
- Adds `actions/checkout` with pinned commit hash to both jobs.
- Sets `fetch-depth: 1` for optimal performance.
- Verified that other workflows already have necessary checkout steps.

---
*PR created automatically by Jules for task [2000471329796981542](https://jules.google.com/task/2000471329796981542) started by @do-ops885*