### PR TITLE
Implement SSRF Protection for Webhooks

### DIFF
--- a/tests/unit/webhook/ssrf-protection.test.ts
+++ b/tests/unit/webhook/ssrf-protection.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from "vitest";
+import { handleSubscribe } from "../../../worker/routes/webhooks/subscriptions";
+
+// Mock global-logger to avoid pollution
+vi.mock("../../../worker/lib/global-logger", () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+// Mock the webhook lib
+vi.mock("../../../worker/lib/webhook/index", () => ({
+  createSubscription: vi.fn().mockResolvedValue({
+    id: "sub_123",
+    url: "https://example.com/webhook",
+    events: ["referral.created"],
+    secret: "sec_123",
+    active: true,
+    created_at: new Date().toISOString(),
+  }),
+  VALID_WEBHOOK_EVENTS: ["referral.created", "referral.updated"],
+}));
+
+describe("Webhook Subscription SSRF Protection", () => {
+  const mockEnv = {
+    WEBHOOK_API_KEYS: {
+      get: vi.fn().mockResolvedValue(
+        JSON.stringify({
+          userId: "user_1",
+          role: "admin",
+          rateLimit: { requestsPerMinute: 60, requestsPerHour: 1000 },
+        }),
+      ),
+      put: vi.fn(),
+    },
+    DEALS_SOURCES: {
+      get: vi.fn(),
+      put: vi.fn(),
+    },
+  } as any;
+
+  it("should block subscription to private IP", async () => {
+    const request = new Request("https://api.test/subscribe", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": "ddr_12345678901234567890123456789012_1234567890",
+      },
+      body: JSON.stringify({
+        url: "https://127.0.0.1/admin",
+        events: ["referral.created"],
+      }),
+    });
+
+    const response = await handleSubscribe(request, mockEnv);
+    const data = (await response.json()) as any;
+
+    expect(response.status).toBe(400);
+    expect(data.error).toMatch(/disallowed|SSRF|blocked/i);
+  });
+
+  it("should block subscription to non-HTTPS URL", async () => {
+    const request = new Request("https://api.test/subscribe", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": "ddr_12345678901234567890123456789012_1234567890",
+      },
+      body: JSON.stringify({
+        url: "http://example.com/webhook",
+        events: ["referral.created"],
+      }),
+    });
+
+    const response = await handleSubscribe(request, mockEnv);
+    const data = (await response.json()) as any;
+
+    expect(response.status).toBe(400);
+    expect(data.error).toMatch(/disallowed|SSRF|blocked/i);
+  });
+
+  it("should allow public HTTPS URLs", async () => {
+    const request = new Request("https://api.test/subscribe", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": "ddr_12345678901234567890123456789012_1234567890",
+      },
+      body: JSON.stringify({
+        url: "https://example.com/webhook",
+        events: ["referral.created"],
+      }),
+    });
+
+    const response = await handleSubscribe(request, mockEnv);
+    expect(response.status).toBe(201);
+  });
+});

--- a/worker/lib/webhook/delivery.ts
+++ b/worker/lib/webhook/delivery.ts
@@ -15,6 +15,7 @@ import { getSubscription } from "./subscriptions";
 import { generateWebhookHeaders } from "../hmac";
 import { logger } from "../global-logger";
 import { fetchInBatches } from "../utils";
+import { validateFetchUrl } from "../security";
 
 // ============================================================================
 // Outgoing Webhooks
@@ -101,6 +102,18 @@ async function sendWebhookToSubscription(
   event: WebhookEvent,
   subscription: WebhookSubscription,
 ): Promise<void> {
+  // SSRF Protection: Ensure delivery URL is safe before fetching
+  const isSafe = await validateFetchUrl(subscription.url);
+  if (!isSafe) {
+    logger.warn(`Webhook delivery skipped: Unsafe URL detected`, {
+      component: "webhook",
+      subscription_id: subscription.id,
+      url: subscription.url,
+      event_id: event.id,
+    });
+    return;
+  }
+
   const payload = JSON.stringify(event);
   const retryPolicy = subscription.retry_policy || DEFAULT_RETRY_POLICY;
 

--- a/worker/routes/webhooks/subscriptions.ts
+++ b/worker/routes/webhooks/subscriptions.ts
@@ -22,6 +22,7 @@ import {
   type CreatePartnerRequest,
 } from "./types";
 import { requireAuth as unifiedRequireAuth } from "../../lib/auth";
+import { validateFetchUrl } from "../../lib/security";
 
 // ============================================================================
 // API Key Authentication
@@ -70,6 +71,17 @@ export async function handleSubscribe(
       new URL(body.url);
     } catch {
       return jsonResponse({ error: "Invalid URL format" }, 400, request, env);
+    }
+
+    // SSRF Protection: Ensure the URL is public and uses a safe protocol
+    const isSafe = await validateFetchUrl(body.url);
+    if (!isSafe) {
+      return jsonResponse(
+        { error: "Disallowed URL: Subscription blocked by SSRF protection" },
+        400,
+        request,
+        env,
+      );
     }
 
     const partnerId = body.partner_id || "default";


### PR DESCRIPTION
What: Implemented SSRF protection for the webhook system by validating URLs before subscription and delivery.
Why: Webhook systems are common targets for SSRF attacks, where an attacker can subscribe the system to internal URLs to probe the network or access metadata services.
Impact: Reduces the risk of SSRF by blocking private IP ranges and enforcing HTTPS for all webhook targets.
Verification: Added `tests/unit/webhook/ssrf-protection.test.ts` which confirms that private IPs and non-HTTPS URLs are blocked during subscription. Existing SSRF tests in `tests/unit/ssrf-bypass.test.ts` also pass.

---
*PR created automatically by Jules for task [1962155291261675560](https://jules.google.com/task/1962155291261675560) started by @do-ops885*