### PR TITLE
fix: remove g flag from rewardPattern regex, clean up dead imports, add reward extraction tests

### DIFF
--- a/tests/unit/discover.test.ts
+++ b/tests/unit/discover.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { discover } from "../../worker/pipeline/discover";
+import { parseHTMLContent } from "../../worker/pipeline/discover-parsers";
 import type {
   Deal,
   PipelineContext,
@@ -685,6 +686,59 @@ describe("Discovery Engine", () => {
 
       const result = await discover(env, ctx);
       expect(result.errors.length).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe("Reward matching (parseHTMLContent)", () => {
+    const mockSource = createMockSource({ domain: "rewards.com" });
+
+    it("should extract cash reward with USD currency from HTML", () => {
+      const html = `<p>referral_code=CASHUSD1 get $100 USD bonus</p>`;
+      const deals = parseHTMLContent(html, mockSource);
+      expect(deals).toHaveLength(1);
+      expect(deals[0]!.reward_type).toBe("cash");
+      expect(deals[0]!.reward_value).toBe(100);
+      expect(deals[0]!.reward_currency).toBe("USD");
+    });
+
+    it("should extract percent reward from HTML", () => {
+      const html = `<p>referral_code=PRCENT20 earn 20% bonus</p>`;
+      const deals = parseHTMLContent(html, mockSource);
+      expect(deals).toHaveLength(1);
+      expect(deals[0]!.reward_type).toBe("percent");
+      expect(deals[0]!.reward_value).toBe(20);
+    });
+
+    it("should default to credit type when no reward pattern found", () => {
+      const html = `<p>referral_code=NOREWRD1 sign up now</p>`;
+      const deals = parseHTMLContent(html, mockSource);
+      expect(deals).toHaveLength(1);
+      expect(deals[0]!.reward_type).toBe("credit");
+      expect(deals[0]!.reward_value).toBe(0);
+    });
+
+    it("should extract reward with EUR currency", () => {
+      const html = `<p>referral_code=EURCODE1 bonus 50 EUR reward</p>`;
+      const deals = parseHTMLContent(html, mockSource);
+      expect(deals).toHaveLength(1);
+      expect(deals[0]!.reward_type).toBe("cash");
+      expect(deals[0]!.reward_value).toBe(50);
+      expect(deals[0]!.reward_currency).toBe("EUR");
+    });
+
+    it("should handle comma-separated reward values", () => {
+      const html = `<p>referral_code=COMMACD1 get $1,000 USD bonus</p>`;
+      const deals = parseHTMLContent(html, mockSource);
+      expect(deals).toHaveLength(1);
+      expect(deals[0]!.reward_value).toBe(1000);
+    });
+
+    it("should handle decimal reward values", () => {
+      const html = `<p>referral_code=DECIMAL1 get $20.99 USD bonus</p>`;
+      const deals = parseHTMLContent(html, mockSource);
+      expect(deals).toHaveLength(1);
+      expect(deals[0]!.reward_value).toBe(20.99);
+      expect(deals[0]!.reward_currency).toBe("USD");
     });
   });
 });

--- a/worker/pipeline/discover-parsers.ts
+++ b/worker/pipeline/discover-parsers.ts
@@ -76,8 +76,9 @@ export function parseHTMLContent(
   const codePattern =
     /(?:referral|invite|promo)[_-]?(?:code)?["']?\s*[:=]\s*["']?([A-Z0-9]{6,20})/gi;
   const urlPattern = /https?:\/\/[^\s"<>]+/gi;
+  // Note: no `g` flag — .match() with `g` returns full strings, not capture groups
   const rewardPattern =
-    /(?:reward|bonus|get|earn)\s+\$?([0-9]+[0-9,]*\.?[0-9]*)\s*(USD|EUR|GBP|%)?/gi;
+    /(?:reward|bonus|get|earn)\s+\$?([0-9]+[0-9,]*\.?[0-9]*)\s*(USD|EUR|GBP|%)?/i;
 
   let match: RegExpExecArray | null = codePattern.exec(content);
   while (match !== null) {

--- a/worker/state-machine.ts
+++ b/worker/state-machine.ts
@@ -3,7 +3,6 @@ import {
   PipelineContext,
   FailurePath,
   PipelineError,
-  ErrorClass,
 } from "./types";
 import { CONFIG } from "./config";
 import { generateRunId, generateUUID } from "./lib/crypto";
@@ -14,10 +13,10 @@ import { logger } from "./lib/global-logger";
 import { discover } from "./pipeline/discover";
 import { normalize } from "./pipeline/normalize";
 import { deduplicate } from "./pipeline/dedupe";
-import { validate, calculateValidationRatio } from "./validation/pipeline";
-import { score, calculateSourceDiversity } from "./pipeline/score";
+import { validate } from "./validation/pipeline";
+import { score } from "./pipeline/score";
 import { stage } from "./pipeline/stage";
-import { publishSnapshot, rollbackSnapshot } from "./publish";
+import { publishSnapshot } from "./publish";
 import { notify } from "./notify";
 import { enforceGuardRails, runGuardRails } from "./lib/guard-rails";
 import { runExpirationCheck } from "./lib/expiration-manager";


### PR DESCRIPTION
## Summary
Three improvements:

### 1. Fixed pre-existing rewardPattern regex bug
Removed the `g` flag from the `rewardPattern` regex in `worker/pipeline/discover-parsers.ts`. The `g` flag caused `.match()` to return full match strings instead of capture groups, making `rewardMatch[1]` return the second match instead of capture group 1. This broke all reward extraction — reward_value was always 0 and reward_type always defaulted to "credit".

The `g` flag is only needed for `.exec()` loops (like `codePattern` uses), not for `.match()`.

### 2. Cleaned up dead imports in state-machine.ts
Removed 4 unused imports:
- `ErrorClass` from `./types`
- `calculateValidationRatio` from `./validation/pipeline`
- `calculateSourceDiversity` from `./pipeline/score`
- `rollbackSnapshot` from `./publish`

All verified unused by grep and TypeScript compilation passes.

### 3. Added reward extraction unit tests
Added 6 tests to `tests/unit/discover.test.ts` using `parseHTMLContent` directly:
- Cash reward with USD currency
- Percent reward
- Default credit type (no reward pattern)
- EUR currency
- Comma-separated values ($1,000)
- Decimal values ($20.99)