### PR TITLE
fix: remove unnecessary g flag from urlPattern regex for consistency

### DIFF
--- a/worker/pipeline/discover-parsers.ts
+++ b/worker/pipeline/discover-parsers.ts
@@ -75,7 +75,7 @@ export function parseHTMLContent(
   const deals: ExtractedDeal[] = []; // Code length bounds: 6-20 characters
   const codePattern =
     /(?:referral|invite|promo)[_-]?(?:code)?["']?\s*[:=]\s*["']?([A-Z0-9]{6,20})/gi;
-  const urlPattern = /https?:\/\/[^\s"<>]+/gi;
+  const urlPattern = /https?:\/\/[^\s"<>]+/i;
   // Note: no `g` flag — .match() with `g` returns full strings, not capture groups
   const rewardPattern =
     /(?:reward|bonus|get|earn)\s+\$?([0-9]+[0-9,]*\.?[0-9]*)\s*(USD|EUR|GBP|%)?/i;


### PR DESCRIPTION
## Summary
Consistency cleanup: removed the `g` flag from `urlPattern` regex in `worker/pipeline/discover-parsers.ts`.

### Why
The `urlPattern` is used with `.match()`, which with the `g` flag returns full match strings without capture groups. While `urlPattern` only accesses `[0]` (the full match) so this is not a bug, removing `g` is consistent with the `rewardPattern` fix in PR #472 where the `g` flag DID cause a real bug.

This is the last regex in the file that used `g` with `.match()` unnecessarily.