### PR TITLE
docs: add CHANGELOG entries for PRs #472 and #473

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Critical reward extraction bug** (PR #472): Removed `g` flag from `rewardPattern` regex in `discover-parsers.ts` that caused `.match()` to return full match strings instead of capture groups, completely breaking reward extraction (reward_value was always 0, reward_type always "credit")
+- **Dead imports removed** (PR #472): Cleaned up 4 unused imports from `state-machine.ts` (ErrorClass, calculateValidationRatio, calculateSourceDiversity, rollbackSnapshot)
+- **Regex consistency** (PR #473): Removed unnecessary `g` flag from `urlPattern` regex in `discover-parsers.ts` for consistency with the rewardPattern fix
+
+### Added
+- **Reward extraction tests** (PR #472): 6 unit tests verifying cash, percent, credit, EUR, comma-separated, and decimal reward extraction
+
 ## [0.1.6] - 2026-05-17
 
 ### Added

--- a/worker/pipeline/discover-parsers.ts
+++ b/worker/pipeline/discover-parsers.ts
@@ -75,7 +75,7 @@ export function parseHTMLContent(
   const deals: ExtractedDeal[] = []; // Code length bounds: 6-20 characters
   const codePattern =
     /(?:referral|invite|promo)[_-]?(?:code)?["']?\s*[:=]\s*["']?([A-Z0-9]{6,20})/gi;
-  const urlPattern = /https?:\/\/[^\s"<>]+/gi;
+  const urlPattern = /https?:\/\/[^\s"<>]+/i;
   // Note: no `g` flag — .match() with `g` returns full strings, not capture groups
   const rewardPattern =
     /(?:reward|bonus|get|earn)\s+\$?([0-9]+[0-9,]*\.?[0-9]*)\s*(USD|EUR|GBP|%)?/i;


### PR DESCRIPTION
## Summary
Add CHANGELOG.md entries under [Unreleased] documenting the changes from PRs #472 and #473:

### Fixed
- Critical reward extraction bug (PR #472): Removed `g` flag from `rewardPattern` regex
- Dead imports removed (PR #472): Cleaned up 4 unused imports from `state-machine.ts`
- Regex consistency (PR #473): Removed unnecessary `g` flag from `urlPattern`

### Added
- Reward extraction tests (PR #472): 6 unit tests verifying cash, percent, credit, EUR, comma-separated, and decimal reward extraction

All entries include PR references for traceability.