### PR TITLE
fix: clean up unused imports, make test:unit cross-platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint:fix": "tsc --noEmit && prettier --write .",
     "test": "vitest run -c vitest.config.unit.ts",
     "test:ci": "npm run test:unit",
-    "test:unit": "timeout --signal=SIGKILL 300 vitest run -c vitest.config.unit.ts; code=$?; if [ $code -eq 137 ]; then echo 'vitest killed by timeout (known upstream hang)'; exit 0; fi; exit $code",
+    "test:unit": "node -e \"try { require('child_process').execSync('vitest run -c vitest.config.unit.ts', {stdio:'inherit',timeout:300000}); } catch(e) { if(e.killed||e.signal==='SIGTERM') { console.log('vitest killed by timeout (known upstream hang)'); process.exit(0); } process.exit(e.status||1); }\"",
     "test:integration": "vitest run -c vitest.config.integration.ts",
     "test:e2e:setup": "bash tests/e2e/setup-auth.sh",
     "test:e2e": "npm run test:e2e:setup && playwright test",

--- a/worker/pipeline/discover.ts
+++ b/worker/pipeline/discover.ts
@@ -1,8 +1,7 @@
-import { Deal, SourceConfig, PipelineError, PipelineContext } from "../types";
+import { Deal, SourceConfig, PipelineContext } from "../types";
 import type { Env } from "../types";
 import { CONFIG } from "../config";
 import { getSourceRegistry, recordSourceValidation } from "../lib/storage";
-import { generateDealId, calculateStringSimilarity } from "../lib/crypto";
 import { logger } from "../lib/global-logger";
 import { getTrustThreshold } from "../lib/config-utils";
 import { createTimeoutSignal } from "../lib/utils";


### PR DESCRIPTION
## Changes
- Remove unused imports (PipelineError, generateDealId, calculateStringSimilarity) from worker/pipeline/discover.ts
- Replace bash-specific test:unit script with cross-platform Node.js timeout wrapper
- Fixes test:unit on Windows where npm uses cmd.exe by default

## Verification
- Typecheck passes (tsc --noEmit)
- Format check passes (prettier --check)
- Discovery budget tests pass (7/7)
- D1 queries tests pass (65/65)