### PR TITLE
fix: update stale references to deleted web-doc-resolver skill

### DIFF
--- a/.agents/skills/web-search-researcher/SKILL.md
+++ b/.agents/skills/web-search-researcher/SKILL.md
@@ -168,7 +168,7 @@ site:github.com tokio spawn_blocking
 
 - **feature-implement**: Research before
 - **debug-troubleshoot**: Find patterns
-- **web-doc-resolver**: Fetch URLs
+- **researcher-docs**: Fetch and analyze technical documentation from URLs
 
 ## Best Practices
 

--- a/.agents/skills/web-search-researcher/reference/guide.md
+++ b/.agents/skills/web-search-researcher/reference/guide.md
@@ -954,7 +954,7 @@ Recommendation: Consult project maintainers or experiment empirically.
 - **feature-implement**: Research API documentation and best practices before implementation
 - **debug-troubleshoot**: Search for similar error patterns and solutions
 - **architecture-validation**: Research architectural patterns and trade-offs
-- **web-doc-resolver**: Use for fetching specific URLs identified during research
+- **researcher-docs**: Use for fetching and analyzing specific documentation URLs identified during research
 
 ## Best Practices Summary
 


### PR DESCRIPTION
## Changes
- Replace web-doc-resolver with researcher-docs in web-search-researcher/SKILL.md Integration section
- Replace web-doc-resolver with researcher-docs in web-search-researcher/reference/guide.md Integration section
- researcher-docs semantically matches the original intent (documentation URL fetching)

This is a followup cleanup after PR #482 deleted the web-doc-resolver skill.

## Verification
- Typecheck passes
- Format check passes
- Code reviewer approved