### PR TITLE
docs: add .dev.vars setup instructions and Playwright pre-flight check

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,12 +14,18 @@ Thank you for your interest in contributing! This guide helps you contribute eff
 git clone https://github.com/do-ops885/do-deal-relay.git
 cd do-deal-relay
 
+# Setup environment variables (required for local dev & E2E tests)
+cp .dev.vars.example .dev.vars
+# Edit .dev.vars with your actual API keys/secrets
+
 # Setup skills symlinks
 ./scripts/setup-skills.sh
 
 # Install pre-commit hook
 cp scripts/pre-commit-hook.sh .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
 ```
+
+> **Note**: Copying `.dev.vars.example` to `.dev.vars` is required before running E2E tests locally. The file provides placeholder values for `WEBHOOK_SECRET`, `EMAIL_WEBHOOK_SECRET`, `API_ENCRYPTION_KEY`, and `JWT_SECRET`. Replace with real values from your Cloudflare dashboard for full functionality.
 
 ## How to Contribute
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -39,6 +39,10 @@ cd your-project
 ## Step 2: Setup (2 minutes)
 
 ```bash
+# Setup environment variables (required for local dev & E2E tests)
+cp .dev.vars.example .dev.vars
+# Edit .dev.vars with your actual API keys/secrets
+
 # Create skill symlinks for all CLI tools
 ./scripts/setup-skills.sh
 
@@ -48,6 +52,8 @@ cp scripts/pre-commit-hook.sh .git/hooks/pre-commit && chmod +x .git/hooks/pre-c
 # Validate setup
 ./scripts/validate-skills.sh
 ```
+
+> **Note**: Copying `.dev.vars.example` → `.dev.vars` is required before running E2E tests or the dev server. Without it, the worker's config validation will fail with errors about missing `WEBHOOK_SECRET`, `EMAIL_WEBHOOK_SECRET`, or `API_ENCRYPTION_KEY`.
 
 Expected output:
 ```

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,7 +3,55 @@ import { defineConfig, devices } from "@playwright/test";
 /**
  * Playwright configuration for browser-based API testing
  * Tests the Deal Discovery System endpoints
+ *
+ * Required env vars for local E2E:
+ *   - Copy .dev.vars.example → .dev.vars for worker config validation
+ *   - Or set WEBHOOK_SECRET, EMAIL_WEBHOOK_SECRET, API_ENCRYPTION_KEY
  */
+
+// Allowlist of required env var NAMES (values are never inspected or logged).
+// See .dev.vars.example for what each one is.
+const REQUIRED_ENV_VARS = [
+  "WEBHOOK_SECRET",
+  "EMAIL_WEBHOOK_SECRET",
+  "API_ENCRYPTION_KEY",
+] as const;
+
+// Presence-only check; values are never compared, returned, or logged.
+function getMissingEnvVars(): readonly string[] {
+  const missing: string[] = [];
+  if (
+    process.env.WEBHOOK_SECRET === undefined ||
+    process.env.WEBHOOK_SECRET.trim() === ""
+  )
+    missing.push("WEBHOOK_SECRET");
+  if (
+    process.env.EMAIL_WEBHOOK_SECRET === undefined ||
+    process.env.EMAIL_WEBHOOK_SECRET.trim() === ""
+  )
+    missing.push("EMAIL_WEBHOOK_SECRET");
+  if (
+    process.env.API_ENCRYPTION_KEY === undefined ||
+    process.env.API_ENCRYPTION_KEY.trim() === ""
+  )
+    missing.push("API_ENCRYPTION_KEY");
+  return missing;
+}
+
+const missing = getMissingEnvVars();
+if (missing.length > 0) {
+  const names = missing.join(", ");
+  console.error(
+    `\n  ❌ Missing required environment variables:\n` +
+      `     ${missing.map((n) => `- ${n}`).join("\n     ")}\n` +
+      `  → Copy .dev.vars.example to .dev.vars and populate them.\n`,
+  );
+  if (process.env.CI !== undefined) {
+    // Fail fast in CI: missing env vars is a configuration error.
+    throw new Error(`Missing required env vars: ${names}`);
+  }
+}
+
 export default defineConfig({
   testDir: "./tests/e2e",
   fullyParallel: true,


### PR DESCRIPTION
## Changes\n\n**Documentation**\n- \u2022 CONTRIBUTING.md: Added .dev.vars copy step to Quick Start with note explaining required env vars\n- \u2022 docs/QUICKSTART.md: Added .dev.vars step before skill setup with E2E prerequisites note\n\n**Developer Experience**\n- \u2022 playwright.config.ts: Added checkRequiredEnvVars() pre-flight validation that warns about missing WEBHOOK_SECRET, EMAIL_WEBHOOK_SECRET, and API_ENCRYPTION_KEY with actionable guidance pointing to .dev.vars.example\n\nAddresses items from plans/FOLLOWUP-e2e-local-env-setup.md