### PR TITLE
test(e2e): toHaveCSS substitution for box-shadow focus ring

### DIFF
--- a/tests/browser/popup_a11y.spec.ts
+++ b/tests/browser/popup_a11y.spec.ts
@@ -91,14 +91,13 @@ test.describe("Extension Popup Accessibility Tests", () => {
       attempts++;
     }
 
-    // Check for focus-visible ring
-    const boxReference = await manualBtn.evaluate((el) => {
-      return window.getComputedStyle(el).boxShadow;
-    });
-
-    // The focus-visible ring should be present (4f46e5)
-    // Note: Playwright sometimes reports computed colors as rgb or rgba
-    expect(boxReference).toMatch(/rgb\(79, 70, 229\)|rgba\(79, 70, 229/);
+    // Use Playwright's auto-retrying `toHaveCSS` so this assertion polls
+    // through `.btn`'s `transition: all 0.2s` (synchronous getComputedStyle
+    // races mid-transition). Carved out of PR #494 commit 1b323e9.
+    await expect(manualBtn).toHaveCSS(
+      "box-shadow",
+      /rgb\(79, 70, 229\)|rgba\(79, 70, 229\)/,
+    );
   });
 
   test("settings button is a semantic button", async ({ page }) => {
@@ -131,9 +130,9 @@ test.describe("Extension Popup Accessibility Tests", () => {
     await detectionItem.focus();
     await expect(detectionItem).toBeFocused();
 
-    const boxShadow = await detectionItem.evaluate((el) => {
-      return window.getComputedStyle(el).boxShadow;
-    });
-    expect(boxShadow).toMatch(/rgb\(79, 70, 229\)|rgba\(79, 70, 229/);
+    await expect(detectionItem).toHaveCSS(
+      "box-shadow",
+      /rgb\(79, 70, 229\)|rgba\(79, 70, 229\)/,
+    );
   });
 });


### PR DESCRIPTION
# test(e2e): toHaveCSS substitution for box-shadow focus ring

Standalone follow-up PR. PR #494 deliberately excluded this rewrite
to keep that PR atomic on the `mockChromeAPI` fix; this PR carries
ONLY the test rewrite so it gets a dedicated review surface.

## What

Replaces the two `getComputedStyle().boxShadow` reads followed by
`expect(string).toMatch(...)` in `tests/browser/popup_a11y.spec.ts`
with Playwright's auto-retrying
`await expect(locator).toHaveCSS("box-shadow", regex)`.

## Why

`.btn` and `.detection-item` in `extension/popup.html` declare
`transition: all 0.2s`. A synchronous `getComputedStyle` read
captures the box-shadow MID-TRANSITION -- often `rgba(0,0,0,0)` --
and the regex race-fails the test in headless Chromium. Playwright's
`toHaveCSS` polls through the transition.

## Touched

- `focus-visible styles are applied`:    `manualBtn` toHaveCSS
- `detection items are reachable`:       `detectionItem` toHaveCSS

## Why a separate PR

PR #494 explicitly carved this out as a follow-up to keep its scope
atomic. This PR is that follow-up.

Refs: PR #494 / commit `1b323e9`.
