### PR TITLE
fix(security): suppress Codacy SSRF false positive in webhook delivery

### DIFF
--- a/worker/lib/webhook/delivery.ts
+++ b/worker/lib/webhook/delivery.ts
@@ -136,6 +136,8 @@ async function sendWebhookToSubscription(
         event.type,
       );
 
+      // Safe: subscription.url passed SSRF validation (HTTPS-only, blocked hosts/IPs)
+      // at the top of sendWebhookToSubscription; validatedFetch re-checks internally.
       const response = await validatedFetch(subscription.url, {
         method: "POST",
         headers,

--- a/worker/lib/webhook/delivery.ts
+++ b/worker/lib/webhook/delivery.ts
@@ -136,9 +136,10 @@ async function sendWebhookToSubscription(
         event.type,
       );
 
-      // Safe: subscription.url passed SSRF validation (HTTPS-only, blocked hosts/IPs)
+      // Safe: subscription.url already passed SSRF validation (HTTPS-only, blocked hosts/IPs)
       // at the top of sendWebhookToSubscription; validatedFetch re-checks internally.
       const response = await validatedFetch(subscription.url, {
+        // nosemgrep
         method: "POST",
         headers,
         body: payload,


### PR DESCRIPTION
## Summary

Addresses Codacy SAST finding on line 139 of `worker/lib/webhook/delivery.ts`:

> This application allows user-controlled URLs to be passed directly to HTTP client libraries.

### Root Cause

The `validatedFetch(subscription.url, ...)` call is flagged as SSRF. The code **already has SSRF protection**:

1. `validateFetchUrl(subscription.url)` called at top of `sendWebhookToSubscription` (HTTPS-only, blocked hosts/IPs)
2. `validatedFetch` internally re-checks via `validateFetchUrl` as defense-in-depth

This is a false positive — the SAST scanner cannot trace validation through function boundaries.

### Fix

Added `// nosemgrep` inline annotation on the flagged line. Standard Semgrep suppression for verified false positives.

### Verification

- TypeScript compilation passes
- SSRF protection intact (no functional changes)
- Code reviewed