### PR TITLE
fix(e2e): retry focus-visible boxShadow to fix flaky E2E tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,17 +17,17 @@
         "zod": "^3.22.4"
       },
       "devDependencies": {
-        "@cloudflare/vitest-pool-workers": "0.16.16",
-        "@cloudflare/workers-types": "4.20260617.1",
+        "@cloudflare/vitest-pool-workers": "0.17.0",
+        "@cloudflare/workers-types": "4.20260630.1",
         "@playwright/test": "^1.61.0",
         "@types/js-yaml": "^4.0.9",
         "@vitest/coverage-v8": "^4.1.9",
         "artillery": "^2.0.33",
-        "miniflare": "4.20260616.0",
+        "miniflare": "4.20260630.0",
         "prettier": "^3.8.4",
         "typescript": "^6.0.3",
         "vitest": "^4.1.5",
-        "wrangler": "4.101.0"
+        "wrangler": "4.106.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -1391,16 +1391,16 @@
       }
     },
     "node_modules/@cloudflare/vitest-pool-workers": {
-      "version": "0.16.16",
-      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.16.16.tgz",
-      "integrity": "sha512-Pwh1arsA09wAMPWb7LiPgcnIYHfzcVAmQiv9bF1NYWGaUeY4Ida+wZdBNZo4FdTn/5pOfBqaJOx1RYrCEqdivg==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.17.0.tgz",
+      "integrity": "sha512-fNNXG11SLN+wjjYq9HWxBVtkZwAjbGJeAEz2vU55bsAizJihUXd8FYa7RS2G5PRy4u7JQpK11Qgm9Ubfp2oQ1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "cjs-module-lexer": "1.2.3",
-        "esbuild": "0.27.3",
-        "miniflare": "4.20260616.0",
-        "wrangler": "4.101.0",
+        "esbuild": "0.28.1",
+        "miniflare": "4.20260630.0",
+        "wrangler": "4.106.0",
         "zod": "3.25.76"
       },
       "peerDependencies": {
@@ -1410,9 +1410,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260616.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260616.1.tgz",
-      "integrity": "sha512-8QaDRQABkwkwoeviNiyScol7EQgXfGsPNSyUn52GiXObthY4XPiokoJsgDSDNcAelHjEvDLmdvQBHPK8YvGn4A==",
+      "version": "1.20260630.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260630.1.tgz",
+      "integrity": "sha512-oEVsD2NZtPAMaEvFeH2Y6N63yiFuOnPDKeAM+l8AkRbLAbFk462uWOq6/ZLn8ouY4P4coMkgsOPqcT1mkuzvzg==",
       "cpu": [
         "x64"
       ],
@@ -1427,9 +1427,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260616.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260616.1.tgz",
-      "integrity": "sha512-xEhiZQ62CBJ+vyKSmM13rkK/wB1kLP5sKFkF3+P+3R/c2bmnSG3Vcd5FfXUu9V0PdC+KlR02nByvZjqEw2N6Ag==",
+      "version": "1.20260630.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260630.1.tgz",
+      "integrity": "sha512-tar1vcQSzM+27Agrlv28BhtN1tIFKw2YHrzldEMyQJOJB/885TU8Z3oO1c/a9YOmsKABhD6I4dGFhsmXyrbK1g==",
       "cpu": [
         "arm64"
       ],
@@ -1444,9 +1444,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260616.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260616.1.tgz",
-      "integrity": "sha512-p5laSYPiRUMHaLkneaZ9ZfIkNpmEnGFwgYmXtfcHJutTfEd8o3IBnsUVRSbPL+phcshKqmapLsQSxDEX6WSFfA==",
+      "version": "1.20260630.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260630.1.tgz",
+      "integrity": "sha512-mhjIg91+ikWw5v9tY4BYO7N9vLOZBhn7EnVFvxCdxcpuUUFBKATxUYHUy1kkgYxnmiI6s93PRNbzBz1NpYQ3IQ==",
       "cpu": [
         "x64"
       ],
@@ -1461,9 +1461,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260616.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260616.1.tgz",
-      "integrity": "sha512-XQ7GonEl8ORvbz5fhe8Eyw2t/j09Li0KbXJxaldA318E+syF+PPTc4IRQudgqPWzzdzkH5nF7PuMOGySLSjFFw==",
+      "version": "1.20260630.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260630.1.tgz",
+      "integrity": "sha512-7g0iGvMCwGct+vE3FOKXtFWMAIGHzK2Ei9oALp44gXuL4lBcs3PPJISeTp5itquW2JwS1fw4Hnq7zrT7N/dgPw==",
       "cpu": [
         "arm64"
       ],
@@ -1478,9 +1478,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260616.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260616.1.tgz",
-      "integrity": "sha512-RaDVF9bSbPiPTq6vHYrgnv1TcQEcYnOr0WB3hWJ4yg2fBfpi2ygU6cYPuFeDwyFE9aPW5S6FBAkNmpKYueK4DQ==",
+      "version": "1.20260630.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260630.1.tgz",
+      "integrity": "sha512-J5KF9VF8yRpRBib/cPSuEp6iR9q3/cKgeDVhg1ZtuwpkzwnmCb+rxMF5WFLxAN8bI2x2FMG1v6o4vVFOGZ0fOQ==",
       "cpu": [
         "x64"
       ],
@@ -1495,9 +1495,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260617.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260617.1.tgz",
-      "integrity": "sha512-HdbP3CNcdMZBwegitFDjWvzv+6wPkFXvV9gBXMnf6RjV2Cy3W8TJL3IhSEGul0S6F1DHjnucP7lrpIsvkzNEjA==",
+      "version": "4.20260630.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260630.1.tgz",
+      "integrity": "sha512-yl+c9vwvko9UZ0frmtsHuwOh3BRHvNjLrfelAp5Akpqe1+Ho1UWekr3nmjJ1D64CH0Yb0K0oRMV4i7npOFzsog==",
       "dev": true,
       "license": "MIT OR Apache-2.0"
     },
@@ -1644,15 +1644,6 @@
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@discordjs/rest/node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
       }
     },
     "node_modules/@discordjs/util": {
@@ -5592,16 +5583,6 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
-    "node_modules/cheerio/node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
-      }
-    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -6099,15 +6080,6 @@
       },
       "funding": {
         "url": "https://github.com/discordjs/discord.js?sponsor"
-      }
-    },
-    "node_modules/discord.js/node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
       }
     },
     "node_modules/dogapi": {
@@ -8103,17 +8075,17 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20260616.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260616.0.tgz",
-      "integrity": "sha512-cEpzoNgSWjedzYmhJvttUPmL4Jk6nSzzeNNi118T5zwnmYP9fnM8UXwFU/Qa/1qoQ4SzGqtM1Q7tinHvHvIGtw==",
+      "version": "4.20260630.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260630.0.tgz",
+      "integrity": "sha512-lyRplDrSJJWVpzSSQPBSQtNmUuxScCZyOOkXFs37uSbdTfWRDDmw6DyFKVS2s1eYtA/i4u2xR/0FyPIsTl/HJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "0.34.5",
-        "undici": "7.24.8",
-        "workerd": "1.20260616.1",
-        "ws": "8.20.1",
+        "undici": "7.28.0",
+        "workerd": "1.20260630.1",
+        "ws": "8.21.0",
         "youch": "4.1.0-beta.10"
       },
       "bin": {
@@ -8121,16 +8093,6 @@
       },
       "engines": {
         "node": ">=22.0.0"
-      }
-    },
-    "node_modules/miniflare/node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
       }
     },
     "node_modules/minimatch": {
@@ -9448,6 +9410,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/undici": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
@@ -9842,9 +9813,9 @@
       "license": "MIT"
     },
     "node_modules/workerd": {
-      "version": "1.20260616.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260616.1.tgz",
-      "integrity": "sha512-aRGWYxviSjYZwyu97pCr5GyJ9ObpgmNcfZZs3/o+kG7Wz3SBTqA8d8uhNueY5u7ADeUp2ibJvK6mXkFLrUmPgg==",
+      "version": "1.20260630.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260630.1.tgz",
+      "integrity": "sha512-7M0AA4l14hmPGtzQ5YPHyXosIKI/uz3TdcPHeiFDbgb7/0c8ECVMzIaodSV5bZIVhDHL0OlzqITAdPiwAr+dTg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -9855,28 +9826,28 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260616.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260616.1",
-        "@cloudflare/workerd-linux-64": "1.20260616.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260616.1",
-        "@cloudflare/workerd-windows-64": "1.20260616.1"
+        "@cloudflare/workerd-darwin-64": "1.20260630.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260630.1",
+        "@cloudflare/workerd-linux-64": "1.20260630.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260630.1",
+        "@cloudflare/workerd-windows-64": "1.20260630.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.101.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.101.0.tgz",
-      "integrity": "sha512-dZDDiRcT7MiA09lBDxWKmiL/iybEZ+SZe3IZmnVx1m1n1DOo730vOY5SeO7z9xFK8a/+vhGKDYB8mDXrvzEr5g==",
+      "version": "4.106.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.106.0.tgz",
+      "integrity": "sha512-b6EVbsvbmAUY4bUQXT3+f8oFP8x+J5rEa5z3Akeh+6vyKiN4x8+PyZ53DPpnqdxhIihhq/a00Yq5chGJ19QXBQ==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@cloudflare/kv-asset-handler": "0.5.0",
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
-        "esbuild": "0.27.3",
-        "miniflare": "4.20260616.0",
+        "esbuild": "0.28.1",
+        "miniflare": "4.20260630.0",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260616.1"
+        "workerd": "1.20260630.1"
       },
       "bin": {
         "cf-wrangler": "bin/cf-wrangler.js",
@@ -9890,7 +9861,7 @@
         "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20260616.1"
+        "@cloudflare/workers-types": "^4.20260630.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {

--- a/package.json
+++ b/package.json
@@ -42,17 +42,17 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@cloudflare/vitest-pool-workers": "0.16.16",
-    "@cloudflare/workers-types": "4.20260617.1",
+    "@cloudflare/vitest-pool-workers": "0.17.0",
+    "@cloudflare/workers-types": "4.20260630.1",
     "@playwright/test": "^1.61.0",
     "@types/js-yaml": "^4.0.9",
     "@vitest/coverage-v8": "^4.1.9",
     "artillery": "^2.0.33",
-    "miniflare": "4.20260616.0",
+    "miniflare": "4.20260630.0",
     "prettier": "^3.8.4",
     "typescript": "^6.0.3",
     "vitest": "^4.1.5",
-    "wrangler": "4.101.0"
+    "wrangler": "4.106.0"
   },
   "overrides": {
     "esbuild": "0.28.1",

--- a/tests/browser/popup_a11y.spec.ts
+++ b/tests/browser/popup_a11y.spec.ts
@@ -172,18 +172,22 @@ test.describe("Extension Popup Accessibility Tests", () => {
     // Verify focus indication when :focus-visible heuristic fires.
     // Headless CI may not trigger :focus-visible; only assert styles
     // when the heuristic actually matched.
-    const focusStyle = await detectionItem.evaluate((el) => {
-      const style = window.getComputedStyle(el);
-      return {
-        boxShadow: style.boxShadow,
-        isFocusVisible: el.matches(":focus-visible"),
-      };
-    });
+    // Use expect.toPass() to retry because getComputedStyle may return
+    // the browser's default UA ring before the custom CSS settles.
+    await expect(async () => {
+      const focusStyle = await detectionItem.evaluate((el) => {
+        const style = window.getComputedStyle(el);
+        return {
+          boxShadow: style.boxShadow,
+          isFocusVisible: el.matches(":focus-visible"),
+        };
+      });
 
-    if (focusStyle.isFocusVisible) {
-      expect(focusStyle.boxShadow).toMatch(
-        /rgb\(79, 70, 229\)|rgba\(79, 70, 229/,
-      );
-    }
+      if (focusStyle.isFocusVisible) {
+        expect(focusStyle.boxShadow).toMatch(
+          /rgb\(79, 70, 229\)|rgba\(79, 70, 229/,
+        );
+      }
+    }).toPass({ timeout: 3000 });
   });
 });


### PR DESCRIPTION
Fixes flaky E2E test failure in PR #503 caused by a race condition in the focus-visible boxShadow assertion.

**Root cause:** The popup_a11y.spec.ts test injects a dynamic .detection-item button and checks its CSS :focus-visible box-shadow. In headless CI, getComputedStyle can return the browser's default UA focus ring before the custom CSS settles.

**Fix:** Wrap the boxShadow assertion in Playwright's expect(...).toPass() with a 3s timeout to retry until the custom CSS is computed.