### PR TITLE
docs(system): sync reference document version to 0.1.8

### DIFF
--- a/agents-docs/SYSTEM_REFERENCE.md
+++ b/agents-docs/SYSTEM_REFERENCE.md
@@ -1,5 +1,5 @@
 # System Reference
-**Version**: 0.1.6 | **Status**: Production
+**Version**: 0.1.8 | **Status**: Production
 
 ## Architecture: Two-Phase Publishing
 Candidate deals are staged, validated through 9 gates, then promoted to production.


### PR DESCRIPTION
=== Summary

Synchronizes the version line in `agents-docs/SYSTEM_REFERENCE.md` with the version currently in `package.json` (`0.1.8`).

The reference doc was still showing `0.1.6` while `package.json` and `AGENTS.md` already declared `0.1.8`, creating documentation drift.

=== Change

- `agents-docs/SYSTEM_REFERENCE.md` line 2: `**Version**: 0.1.6` → `**Version**: 0.1.8`

=== Verification

- Single-line docs change (no runtime impact).
- Branch: `chore/sync-system-version` (from `origin/develop`).
- Targets `develop` per `AGENTS.md`.

=== Notes / Out of scope

This PR intentionally does **not** touch `CHANGELOG.md`, `README.md`, or any other file. `CHANGELOG.md` last logs `0.1.7` and `README.md` still shows `0.1.7`; those should be reconciled in a follow-up if desired.