### PR TITLE
docs(plans): ADR-018/019 CI failure triage

### DIFF
--- a/plans/ADR-019-deploy-timeout-too-low.md
+++ b/plans/ADR-019-deploy-timeout-too-low.md
@@ -1,0 +1,51 @@
+# ADR-019: Deploy Workflow Timeout Too Low
+
+**Status**: Accepted (blocked)
+**Created**: 2026-07-07
+**Type**: CI Infrastructure
+
+---
+
+## Context
+
+The `Deploy - Production` workflow's `Pre-Deploy Validation` job has a 15-minute timeout. The job runs:
+1. `npm ci` (~30s)
+2. `npm run test:ci` (full test suite, ~11 min)
+3. `./scripts/quality_gate.sh` (~1 min)
+4. Verify staging health (optional, ~10s)
+
+Total: ~12.5 min — dangerously close to the 15-min limit. On slower runners or with cache misses, it exceeds the limit and gets cancelled.
+
+## Root Cause
+
+The timeout was set before the test suite grew to its current size. Unit tests alone take ~11 minutes.
+
+## Fix
+
+Increase `timeout-minutes` from 15 to 30 for `pre-deploy-checks` and from 15 to 20 for `deploy-production`.
+
+**File**: `.github/workflows/deploy-production.yml`
+
+```yaml
+# Before
+pre-deploy-checks:
+  timeout-minutes: 15
+deploy-production:
+  timeout-minutes: 15
+
+# After
+pre-deploy-checks:
+  timeout-minutes: 30
+deploy-production:
+  timeout-minutes: 20
+```
+
+## Blocker
+
+The OAuth token used by the agent lacks `workflow` scope, preventing direct pushes to `.github/workflows/` files. A human must apply this change manually or grant the token `workflow` scope.
+
+## Impact
+
+- Deploy workflow cancelled on every push to `main`
+- All other CI checks pass
+- Deployments via `wrangler deploy` work when triggered manually

--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -112,6 +112,15 @@
 
 ---
 
+## Blocked — External Dependencies
+
+| ID | Item | Source | Blocker | ADR |
+|:---|:---|:---|:---|:---|
+| BLOCKED-1 | **Workers Builds: do-deal-relay** — Cloudflare dashboard auto-deploy fails on every push | CI | Cloudflare dashboard integration misconfigured (not managed via code) | [ADR-018](ADR-018-cloudflare-workers-builds-failure.md) |
+| BLOCKED-2 | **Deploy timeout too low** — Pre-Deploy Validation cancelled (15m timeout, tests take 11m+) | CI | OAuth token lacks `workflow` scope to push workflow file changes | [ADR-019](ADR-019-deploy-timeout-too-low.md) |
+
+---
+
 ## P3 — Low Priority (18 Open — Polish & Future)
 
 ### Minor Correctness


### PR DESCRIPTION
Documents two pre-existing CI failures per AGENTS.md triage protocol:

1. **ADR-018**: Workers Builds (Cloudflare dashboard) failure — external integration
2. **ADR-019**: Deploy timeout too low — needs human to push workflow fix (OAuth lacks workflow scope)