### PR TITLE
ci(deploy): Skip redundant tests in quality gate during production deploy

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -55,7 +55,7 @@ jobs:
         run: npm run test:ci
 
       - name: Run quality gate
-        run: ./scripts/quality_gate.sh
+        run: SKIP_TESTS=true ./scripts/quality_gate.sh
 
       - name: Verify staging is healthy
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
Tests already run in separate step, avoiding duplicate execution saves ~2min.