### PR TITLE
fix(ci): add blank line before markdown table in GOAP_STATE.md

### DIFF
--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -11,6 +11,7 @@
 ## PR Resolver Status — 2026-07-07
 
 ### Resolution Summary
+
 | PR | Title | Status | Fix Applied |
 |----|-------|--------|-------------|
 | #559 | feat(security): P3 rate limiting, async pipeline, XSS fixes, docs update | **MERGED** | Error-shaping gate violation (`toErrCtx`), markdown lint, quality gate exclusion |


### PR DESCRIPTION
Fixes MD058/blanks-around-tables lint error on line 14 of plans/GOAP_STATE.md that causes CI failure (Docs Validation, Quality Gate, Deploy).

**Root cause**: Table missing required blank line before it.
**Fix**: Add blank line between heading and table.