### PR TITLE
feat(ux): add copy-to-clipboard functionality and improve semantic structure

### DIFF
--- a/extension/popup.html
+++ b/extension/popup.html
@@ -83,6 +83,22 @@
         gap: 6px;
       }
 
+      .btn-group {
+        display: flex;
+        gap: 8px;
+        margin-top: 12px;
+      }
+
+      .btn-group .btn {
+        width: auto;
+      }
+
+      .btn-icon-only {
+        width: 44px;
+        flex-shrink: 0;
+        padding: 0;
+      }
+
       .current-page {
         display: flex;
         align-items: center;
@@ -523,9 +539,9 @@
     <div class="content">
       <!-- Current Page Section -->
       <div class="section">
-        <div class="section-title">
+        <h2 class="section-title">
           <span aria-hidden="true">📄</span> Current Page
-        </div>
+        </h2>
         <div class="current-page">
           <div class="favicon" id="favicon">🌐</div>
           <div class="page-info">
@@ -542,24 +558,30 @@
 
       <!-- Detected Codes Section -->
       <div class="section" id="detections-section" style="display: none">
-        <div class="section-title">
+        <h2 class="section-title">
           <span aria-hidden="true">🎯</span> Detected Codes
-        </div>
+        </h2>
         <div class="detection-list" id="detection-list"></div>
-        <button
-          class="btn btn-primary"
-          id="capture-btn"
-          style="margin-top: 12px"
-        >
-          <span aria-hidden="true">✨</span> Capture Selected
-        </button>
+        <div class="btn-group">
+          <button class="btn btn-primary" id="capture-btn" style="flex: 1">
+            <span aria-hidden="true">✨</span> Capture Selected
+          </button>
+          <button
+            class="btn btn-secondary btn-icon-only"
+            id="copy-detected-btn"
+            aria-label="Copy selected code"
+            title="Copy selected code"
+          >
+            <span aria-hidden="true">📋</span>
+          </button>
+        </div>
       </div>
 
       <!-- Manual Entry Section -->
       <div class="section" id="manual-section">
-        <div class="section-title">
+        <h2 class="section-title">
           <span aria-hidden="true">✏️</span> Manual Entry
-        </div>
+        </h2>
         <label for="manual-code" class="sr-only">Referral code</label>
         <input
           type="text"
@@ -576,21 +598,34 @@
         >
           Code must be alphanumeric (4-20 chars)
         </div>
-        <button
-          type="button"
-          class="btn btn-secondary"
-          id="manual-btn"
-          disabled
-        >
-          Add Code Manually
-        </button>
+        <div class="btn-group">
+          <button
+            type="button"
+            class="btn btn-secondary"
+            id="manual-btn"
+            style="flex: 1"
+            disabled
+          >
+            Add Code Manually
+          </button>
+          <button
+            type="button"
+            class="btn btn-secondary btn-icon-only"
+            id="copy-manual-btn"
+            aria-label="Copy manual code"
+            title="Copy manual code"
+            disabled
+          >
+            <span aria-hidden="true">📋</span>
+          </button>
+        </div>
       </div>
 
       <!-- Settings Panel (hidden by default) -->
       <div class="section settings-panel" id="settings-panel">
-        <div class="section-title">
+        <h2 class="section-title">
           <span aria-hidden="true">⚙️</span> Settings
-        </div>
+        </h2>
         <div class="settings-field">
           <label class="settings-label">API Endpoint</label>
           <input
@@ -607,9 +642,9 @@
 
       <!-- Stats Section -->
       <div class="section" id="stats-section">
-        <div class="section-title">
+        <h2 class="section-title">
           <span aria-hidden="true">📊</span> Your Stats
-        </div>
+        </h2>
         <div class="stats-grid">
           <div class="stat-item">
             <div class="stat-value" id="stat-captured">0</div>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -44,6 +44,8 @@ document.addEventListener("DOMContentLoaded", async () => {
     statSubmitted: document.getElementById("stat-submitted"),
     statSuccess: document.getElementById("stat-success"),
     manualCodeError: document.getElementById("manual-code-error"),
+    copyDetectedBtn: document.getElementById("copy-detected-btn"),
+    copyManualBtn: document.getElementById("copy-manual-btn"),
   };
 
   // ============================================================================
@@ -450,6 +452,31 @@ document.addEventListener("DOMContentLoaded", async () => {
     }, 3000);
   }
 
+  /**
+   * Copy text to clipboard with visual feedback
+   */
+  async function copyToClipboard(text, buttonElement) {
+    if (!text || buttonElement.dataset.copying === "true") return;
+
+    try {
+      buttonElement.dataset.copying = "true";
+      await navigator.clipboard.writeText(text);
+      showToast("Copied to clipboard!", "success");
+
+      // Visual feedback on button
+      const originalContent = buttonElement.innerHTML;
+      buttonElement.innerHTML = '<span aria-hidden="true">✅</span>';
+      setTimeout(() => {
+        buttonElement.innerHTML = originalContent;
+        delete buttonElement.dataset.copying;
+      }, 2000);
+    } catch (err) {
+      console.error("Failed to copy:", err);
+      showToast("Failed to copy", "error");
+      delete buttonElement.dataset.copying;
+    }
+  }
+
   function toggleSettings() {
     const isActive = elements.settingsPanel.classList.toggle("active");
     elements.manualSection.classList.toggle("hidden");
@@ -485,6 +512,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
 
     elements.manualBtn.disabled = !isValid;
+    elements.copyManualBtn.disabled = !isValid;
     return isValid;
   }
 
@@ -513,6 +541,20 @@ document.addEventListener("DOMContentLoaded", async () => {
     });
     elements.manualCode.addEventListener("keypress", (e) => {
       if (e.key === "Enter") captureManual();
+    });
+
+    // Copy buttons
+    elements.copyDetectedBtn.addEventListener("click", () => {
+      if (state.selectedDetection) {
+        copyToClipboard(state.selectedDetection.code, elements.copyDetectedBtn);
+      }
+    });
+
+    elements.copyManualBtn.addEventListener("click", () => {
+      const code = elements.manualCode.value.trim();
+      if (code) {
+        copyToClipboard(code.toUpperCase(), elements.copyManualBtn);
+      }
     });
 
     // Settings

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -463,17 +463,25 @@ document.addEventListener("DOMContentLoaded", async () => {
       await navigator.clipboard.writeText(text);
       showToast("Copied to clipboard!", "success");
 
-      // Visual feedback on button
-      const originalContent = buttonElement.innerHTML;
-      buttonElement.innerHTML = '<span aria-hidden="true">✅</span>';
+      // Visual feedback on button using DOM API (prevents XSS)
+      const children = Array.from(buttonElement.children);
+      buttonElement.textContent = "";
+      const span = document.createElement("span");
+      span.setAttribute("aria-hidden", "true");
+      span.textContent = "✅";
+      buttonElement.appendChild(span);
+
       setTimeout(() => {
-        buttonElement.innerHTML = originalContent;
-        delete buttonElement.dataset.copying;
+        buttonElement.textContent = "";
+        children.forEach(function (child) {
+          buttonElement.appendChild(child);
+        });
+        buttonElement.removeAttribute("data-copying");
       }, 2000);
     } catch (err) {
       console.error("Failed to copy:", err);
       showToast("Failed to copy", "error");
-      delete buttonElement.dataset.copying;
+      buttonElement.removeAttribute("data-copying");
     }
   }
 

--- a/tests/browser/popup_a11y.spec.ts
+++ b/tests/browser/popup_a11y.spec.ts
@@ -71,7 +71,12 @@ test.describe("Extension Popup Accessibility Tests", () => {
     const manualBtn = page.locator("#manual-btn");
     await expect(manualBtn).toBeFocused();
 
-    // Tab from #manual-btn moves to #settings-link
+    // Tab from #manual-btn moves to #copy-manual-btn
+    await page.keyboard.press("Tab");
+    const copyManualBtn = page.locator("#copy-manual-btn");
+    await expect(copyManualBtn).toBeFocused();
+
+    // Tab from #copy-manual-btn moves to #settings-link
     await page.keyboard.press("Tab");
     const settingsBtn = page.locator("#settings-link");
     await expect(settingsBtn).toBeFocused();

--- a/tests/unit/code-validator-impl.test.ts
+++ b/tests/unit/code-validator-impl.test.ts
@@ -7,6 +7,12 @@ import {
   validateCodeComplete,
 } from "../../worker/lib/validation/code-validator";
 
+vi.mock("../../worker/lib/security", () => ({
+  validateFetchUrl: vi.fn().mockResolvedValue(true),
+  validateUrl: vi.fn().mockReturnValue(true),
+  validatedFetch: vi.fn((url, init) => fetch(url, init)),
+}));
+
 describe("code-validator", () => {
   beforeEach(() => {
     vi.resetAllMocks();


### PR DESCRIPTION
What: Added 'Copy to clipboard' buttons to both detected and manually entered referral codes in the extension popup. Updated section titles from generic divs to semantic H2 headings. Improved CSS for button grouping and fixed a race condition in the copy feedback logic.

Why: Users often need to copy codes without immediately 'capturing' them. Semantic headers provide better navigation for screen reader users.

Impact: Enhanced utility and improved accessibility compliance (WCAG).

Verification:
1. Ran `npx playwright test tests/browser/popup_a11y.spec.ts` (all passed).
2. Ran `npm run test:unit` (all passed, including a fix for code-validator-impl tests).
3. Performed manual verification via a Playwright script, capturing screenshots and video of the 'Copy' interaction and toast notification.
4. Verified that the tab order is logical: Code Input -> Add Button -> Copy Button -> Settings.

---
*PR created automatically by Jules for task [7160843915798367250](https://jules.google.com/task/7160843915798367250) started by @do-ops885*