### PR TITLE
fix(wrangler): remove invalid PipelineLock new_sqlite_classes migration

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -136,10 +136,6 @@
   "migrations": [
     {
       "tag": "v1",
-      "new_sqlite_classes": ["PipelineLock"],
-    },
-    {
-      "tag": "v2",
       "new_sqlite_classes": ["SourceRegistry"],
     },
   ],
@@ -308,10 +304,6 @@
       "migrations": [
         {
           "tag": "v1",
-          "new_sqlite_classes": ["PipelineLock"],
-        },
-        {
-          "tag": "v2",
           "new_sqlite_classes": ["SourceRegistry"],
         },
       ],


### PR DESCRIPTION
## What

Removes the `new_sqlite_classes: ["PipelineLock"]` migration from `wrangler.jsonc` that was causing production deployments to fail with Cloudflare API error code 10074.

## Why

`PipelineLock` was already deployed with active Durable Objects. Cloudflare does not allow `new_sqlite_classes` to be applied retroactively to classes with existing objects.

## Impact

- Unblocks production deployments (currently 100% failure rate)
- `SourceRegistry` migration (renamed v2 → v1) is already applied on production — no-op
- Closes #583, #584