### PR TITLE
Fix SSRF filter bypass in CIDR matching

### DIFF
--- a/tests/unit/security-ssrf.test.ts
+++ b/tests/unit/security-ssrf.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { isIpInCidr } from "../../worker/lib/security";
+
+describe("SSRF Protection - isIpInCidr Security Fix", () => {
+  it("should return false for non-IP hostnames matching 0.0.0.0/8", () => {
+    // Before the fix, "example.com" would match "0.0.0.0/8" because ipToLong returns 0
+    expect(isIpInCidr("example.com", "0.0.0.0/8")).toBe(false);
+    expect(isIpInCidr("google.com", "0.0.0.0/8")).toBe(false);
+  });
+
+  it("should return true for valid IPs in the 0.0.0.0/8 range", () => {
+    expect(isIpInCidr("0.0.0.0", "0.0.0.0/8")).toBe(true);
+    expect(isIpInCidr("0.255.255.255", "0.0.0.0/8")).toBe(true);
+  });
+
+  it("should return true for localhost in 127.0.0.0/8", () => {
+    expect(isIpInCidr("127.0.0.1", "127.0.0.0/8")).toBe(true);
+  });
+
+  it("should return false for valid IPs outside the range", () => {
+    expect(isIpInCidr("1.1.1.1", "0.0.0.0/8")).toBe(false);
+    expect(isIpInCidr("192.168.1.1", "10.0.0.0/8")).toBe(false);
+  });
+
+  it("should handle invalid CIDR ranges gracefully", () => {
+    expect(isIpInCidr("127.0.0.1", "invalid")).toBe(false);
+    expect(isIpInCidr("127.0.0.1", "")).toBe(false);
+  });
+
+  it("should handle IPv6 matching correctly", () => {
+    expect(isIpInCidr("::1", "::1/128")).toBe(true);
+    expect(isIpInCidr("fd00::1", "fc00::/7")).toBe(true);
+    expect(isIpInCidr("2001:db8::1", "fc00::/7")).toBe(false);
+  });
+
+  it("should return false for non-IP strings even if they look like part of IPv6", () => {
+    expect(isIpInCidr("not:an:ip", "fc00::/7")).toBe(false);
+  });
+});

--- a/worker/lib/security.ts
+++ b/worker/lib/security.ts
@@ -157,9 +157,11 @@ function normalizeIp(ip: string): string {
     if (inner.includes(".")) return inner;
     if (inner.includes(":")) {
       const parts = inner.split(":");
-      if (parts.length === 2) {
-        const high = parseInt(parts[0]!, 16);
-        const low = parseInt(parts[1]!, 16);
+      const p0 = parts[0];
+      const p1 = parts[1];
+      if (parts.length === 2 && p0 !== undefined && p1 !== undefined) {
+        const high = parseInt(p0, 16);
+        const low = parseInt(p1, 16);
         return [
           (high >> 8) & 0xff,
           high & 0xff,
@@ -221,9 +223,11 @@ export function isIpInCidr(ip: string, cidr: string): boolean {
 function ipToLong(ip: string): number {
   const parts = ip.split(".").map((p) => parseInt(p, 10));
   if (parts.length !== SECURITY_CONSTANTS.IPV4_PARTS) return 0;
-  return (
-    ((parts[0]! << 24) | (parts[1]! << 16) | (parts[2]! << 8) | parts[3]!) >>> 0
-  );
+  const p0 = parts[0] ?? 0;
+  const p1 = parts[1] ?? 0;
+  const p2 = parts[2] ?? 0;
+  const p3 = parts[3] ?? 0;
+  return ((p0 << 24) | (p1 << 16) | (p2 << 8) | p3) >>> 0;
 }
 
 function ipv6ToBigInt(ipv6: string): bigint {

--- a/worker/lib/security.ts
+++ b/worker/lib/security.ts
@@ -180,12 +180,18 @@ function isPrivateIP(ip: string): boolean {
   return false;
 }
 
-function isIpInCidr(ip: string, cidr: string): boolean {
+/** @internal */
+export function isIpInCidr(ip: string, cidr: string): boolean {
   try {
     const parts = cidr.split("/");
     const range = parts[0];
     const bitsStr = parts[1];
     if (!range) return false;
+
+    // Security: Ensure input is a valid IP address before CIDR matching.
+    // Prevents hostnames from matching 0.0.0.0/8 due to ipToLong returning 0.
+    if (!isIpAddress(ip)) return false;
+
     const normalizedIp = normalizeIp(ip);
     const normalizedRange = normalizeIp(range);
     const ipIsV4 = !normalizedIp.includes(":");


### PR DESCRIPTION
What: Modified `isIpInCidr` in `worker/lib/security.ts` to validate that the input string is a valid IP address before performing bitwise CIDR matching. Also exported the function for testing and added `tests/unit/security-ssrf.test.ts`.

Why: Hostnames (e.g., 'example.com') were resulting in `0` when passed to `ipToLong`, which caused them to match the `0.0.0.0/8` range, potentially bypassing certain SSRF filters or causing unexpected behavior in IP-based logic.

Impact: Measurably improves SSRF protection by ensuring hostname-to-IP-range checks fail fast and correctly, preventing logic bypasses.

Verification: Verified with new unit tests in `tests/unit/security-ssrf.test.ts` which confirm that hostnames do not match CIDR ranges while valid IP matching remains correct for both IPv4 and IPv6.

---
*PR created automatically by Jules for task [7783939111363315614](https://jules.google.com/task/7783939111363315614) started by @do-ops885*