### PR TITLE
perf(validation): optimize URL search parameter sorting using direct string comparison

### DIFF
--- a/worker/lib/validation-cache/key.ts
+++ b/worker/lib/validation-cache/key.ts
@@ -21,8 +21,10 @@ export function normalizeUrl(input: string): string {
     }
 
     const sorted = new URL(url.toString());
+    // Performance optimization: direct string lexicographical comparison (< and >)
+    // is significantly faster than localeCompare and avoids locale-aware collation overhead.
     const entries = [...sorted.searchParams.entries()].sort(([a], [b]) =>
-      a.localeCompare(b),
+      a < b ? -1 : a > b ? 1 : 0,
     );
     sorted.search = "";
     for (const [k, v] of entries) sorted.searchParams.append(k, v);

--- a/worker/pipeline/normalize.ts
+++ b/worker/pipeline/normalize.ts
@@ -91,8 +91,10 @@ function normalizeUrl(url: string): string {
     }
 
     // Sort remaining params for consistency
+    // Performance optimization: direct string lexicographical comparison (< and >)
+    // is significantly faster than localeCompare and avoids locale-aware collation overhead.
     const sortedParams = new URLSearchParams(
-      [...parsed.searchParams].sort(([a], [b]) => a.localeCompare(b)),
+      [...parsed.searchParams].sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)),
     );
     parsed.search = sortedParams.toString();
 


### PR DESCRIPTION
What: Optimized URL search parameter sorting inside normalizeUrl in worker/lib/validation-cache/key.ts and worker/pipeline/normalize.ts.
Why: String.prototype.localeCompare is slow because of internationalization (Intl/ICU collation rules). Standard direct lexicographical comparisons are highly deterministic, stable, and significantly faster for cache key normalization.
Impact: Avoids slow collation rules on every URL normalization pass, improving throughput and reducing CPU overhead in the ingestion pipeline.

---
*PR created automatically by Jules for task [14968859000953433727](https://jules.google.com/task/14968859000953433727) started by @do-ops885*