### PR TITLE
fix(deploy): add durable-object exports to resolve Workers Builds 10061

### DIFF
--- a/.agents/metrics.jsonl
+++ b/.agents/metrics.jsonl
@@ -1,1 +1,2 @@
 {"timestamp": "2026-07-07T00:00:00Z", "agent": "goap-agent", "task": "Created skills infrastructure: goap-agent, typescript-coding-standards, pev-loop, validation-gates, pr-resolver, agentic-abstention, setup-skills.sh", "status": "completed"}
+{"timestamp": "2026-07-19T10:12:51Z", "agent": "opencode", "task": "fix failing CI on main — format, docs, and pre-commit hooks", "status": "completed"}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -139,6 +139,22 @@
   },
   // NOTE: No migrations needed — DOs are already deployed and provisioned.
   // migrations blocks MUST be absent for wrangler versions upload (Cloudflare Git Integration).
+  // Live durable-object exports: required so wrangler registers the DO classes
+  // with the Cloudflare API (error code 10061 otherwise). Storage uses SQLite.
+  "exports": {
+    "PipelineLock": {
+      "type": "durable-object",
+      "storage": "sqlite",
+    },
+    "SourceRegistry": {
+      "type": "durable-object",
+      "storage": "sqlite",
+    },
+    "DealRegistry": {
+      "type": "durable-object",
+      "storage": "sqlite",
+    },
+  },
   // Vectorize index for semantic search over deals and referrals
   // Index name must match SEMANTIC_SEARCH_CONFIG.INDEX_NAME in worker/lib/search/types.ts
   // Free tier limits: 100 indexes, 1000 namespaces, 1000 vectors/upsert, topK=50


### PR DESCRIPTION
What:
- Add `exports` block to wrangler.jsonc with PipelineLock, SourceRegistry, DealRegistry as durable-object bindings (sqlite storage)
- Resolves Cloudflare API error code 10061: "Cannot create binding for class 'DealRegistry' because it is not currently configured to implement Durable Objects"

Why:
The Workers Builds (Cloudflare Git Integration) deployment on main was failing with error 10061. The config had `durable_objects.bindings` but no live `exports` entry, so wrangler could not register the DO classes with the Cloudflare API. This is a pre-existing deployment failure, not covered by the earlier CI-format PR.

Impact:
- Workers Builds deployment will pass on main
- All CI checks (including pre-existing deployment build) now green