### PR TITLE
fix(security): prevent open redirect bypass by parsing protocol in validateUrl

### DIFF
--- a/tests/unit/routes-utils.test.ts
+++ b/tests/unit/routes-utils.test.ts
@@ -32,6 +32,24 @@ describe("Route Utilities", () => {
   it("should validate URLs", () => {
     expect(validateUrl("http://example.com")).toBeNull();
     expect(validateUrl("not-a-url")).toBeNull();
+
+    // Valid HTTPS URL
+    expect(validateUrl("https://example.com")).toBe("https://example.com");
+    expect(validateUrl("https://example.com/some/path")).toBe(
+      "https://example.com/some/path",
+    );
+
+    // Localhost allowed with HTTP or HTTPS
+    expect(validateUrl("https://localhost")).toBe("https://localhost");
+    expect(validateUrl("https://localhost/path")).toBe(
+      "https://localhost/path",
+    );
+
+    // Block common redirect bypasses
+    expect(validateUrl("https://example.com//google.com")).toBeNull();
+    expect(validateUrl("https://example.com/path//to/something")).toBeNull();
+    expect(validateUrl("https://example.com/path/../to/something")).toBeNull();
+    expect(validateUrl("https://example.com@google.com")).toBeNull();
   });
 
   it("should validate redirects", () => {

--- a/worker/routes/utils.ts
+++ b/worker/routes/utils.ts
@@ -163,7 +163,13 @@ export function validateUrl(
       }
     }
 
-    // Check for common redirect bypasses
+    // Check for common redirect bypasses in the remaining URL string (after protocol)
+    const protocolPrefix = parsed.protocol + "//";
+    if (!url.startsWith(protocolPrefix)) {
+      return null;
+    }
+    const urlWithoutProtocol = url.slice(protocolPrefix.length);
+
     const dangerousPatterns = [
       /\/\/+/g, // Multiple slashes
       /\.\./g, // Path traversal
@@ -172,7 +178,7 @@ export function validateUrl(
     ];
 
     for (const pattern of dangerousPatterns) {
-      if (pattern.test(url)) {
+      if (pattern.test(urlWithoutProtocol)) {
         return null;
       }
     }


### PR DESCRIPTION
What: Refactored the `validateUrl` function in `worker/routes/utils.ts` to extract the protocol prefix and apply standard redirect bypass patterns (like multiple slashes) only on the remaining portion of the URL string.

Why: The double-slash pattern check in `dangerousPatterns` was matching the `//` in `https://`, which incorrectly blocked valid HTTPS redirect URLs.

Impact: Resolves the functional bug and prevents open redirect vulnerabilities without compromising validation filters.

Verification: Executed the unit tests (`npm run test:unit`) and verified formatting with `npm run lint`. Added specific test coverage for valid HTTPS URLs and bypass payloads in `tests/unit/routes-utils.test.ts`.

---
*PR created automatically by Jules for task [16033153121894841445](https://jules.google.com/task/16033153121894841445) started by @do-ops885*