### PR TITLE
feat(ux): improve extension popup manual entry and settings accessibility

### DIFF
--- a/extension/popup.html
+++ b/extension/popup.html
@@ -444,7 +444,8 @@
         margin-bottom: 12px;
       }
 
-      .settings-label {
+      .settings-label,
+      .manual-label {
         display: block;
         font-size: 12px;
         font-weight: 500;
@@ -589,12 +590,12 @@
         <h2 class="section-title">
           <span aria-hidden="true">✏️</span> Manual Entry
         </h2>
-        <label for="manual-code" class="sr-only">Referral code</label>
+        <label for="manual-code" class="manual-label">Referral Code</label>
         <input
           type="text"
           class="manual-input"
           id="manual-code"
-          placeholder="Enter referral code..."
+          placeholder="e.g. SAVE50, WELCOME"
           maxlength="20"
           aria-describedby="manual-code-error"
         />
@@ -634,7 +635,7 @@
           <span aria-hidden="true">⚙️</span> Settings
         </h2>
         <div class="settings-field">
-          <label class="settings-label">API Endpoint</label>
+          <label for="api-endpoint" class="settings-label">API Endpoint</label>
           <input
             type="text"
             class="settings-input"


### PR DESCRIPTION
What:
- Made 'Referral Code' manual input label visible with a clean design.
- Replaced redundant placeholder with helpful format examples.
- Connected the settings 'API Endpoint' label to its input with the 'for' attribute.

Why:
- Improves screen reader navigation and cognitive visibility for form controls in the Chrome extension popup.

Impact:
- Cleaner, more professional layout that is fully compatible with modern web accessibility guidelines.

Verification:
- Visualized popup popup.html structure with Playwright in /home/jules/verification/popup_screenshot.png.
- Ran npm run lint and npm run test:unit.


---
*PR created automatically by Jules for task [9901851369218524697](https://jules.google.com/task/9901851369218524697) started by @do-ops885*