### PR TITLE
ci(fix): add checkout step to auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -17,6 +17,9 @@ jobs:
     timeout-minutes: 5
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.1
+
       - name: Enable auto-merge for Dependabot PRs
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
What: Added actions/checkout step before gh pr merge in auto-merge.yml workflow.

Why: gh pr merge requires a git repository to be present. The workflow was failing with 'fatal: not a git repository' because it tried to run git commands without a checkout.

Impact: Fixes auto-merge CI check failure on all Dependabot PRs.