### PR TITLE
ci(fix): pin checkout action to full sha

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Enable auto-merge for Dependabot PRs
         env:


### PR DESCRIPTION
What: Pinned actions/checkout to full-length commit SHA instead of version tag.

Why: Repository security policy requires all actions to be pinned to full-length commit SHA. The previous PR #636 used @v7.0.1 tag which was rejected.

Impact: Fixes auto-merge workflow so it can actually run on Dependabot PRs.