### PR TITLE
fix(security): harden referral url validation and prevent redirect bypass

### DIFF
--- a/tests/unit/security-referral-url.test.ts
+++ b/tests/unit/security-referral-url.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import { validateReferralUrl } from "../../worker/lib/security";
+
+describe("validateReferralUrl", () => {
+  it("should allow valid HTTPS referral URLs matching the target domain", () => {
+    expect(
+      validateReferralUrl("https://example.com/ref?code=123", "example.com"),
+    ).toBe(true);
+    expect(
+      validateReferralUrl(
+        "https://www.example.com/ref?code=123",
+        "example.com",
+      ),
+    ).toBe(true);
+    expect(
+      validateReferralUrl(
+        "https://example.com/ref?code=123",
+        "www.example.com",
+      ),
+    ).toBe(true);
+  });
+
+  it("should block non-HTTPS referral URLs", () => {
+    expect(
+      validateReferralUrl("http://example.com/ref?code=123", "example.com"),
+    ).toBe(false);
+    expect(
+      validateReferralUrl("ftp://example.com/ref?code=123", "example.com"),
+    ).toBe(false);
+  });
+
+  it("should block referral URLs with mismatched domains", () => {
+    expect(
+      validateReferralUrl("https://evil.com/ref?code=123", "example.com"),
+    ).toBe(false);
+    expect(
+      validateReferralUrl("https://example.org/ref?code=123", "example.com"),
+    ).toBe(false);
+  });
+
+  it("should block referral URLs containing backslashes or dangerous control characters", () => {
+    expect(
+      validateReferralUrl(
+        "https://example.com\\evil.com/ref?code=123",
+        "example.com",
+      ),
+    ).toBe(false);
+    expect(
+      validateReferralUrl(
+        "https://example.com\x00/ref?code=123",
+        "example.com",
+      ),
+    ).toBe(false);
+    expect(
+      validateReferralUrl(
+        "https://example.com\x0d/ref?code=123",
+        "example.com",
+      ),
+    ).toBe(false);
+    expect(
+      validateReferralUrl(
+        "https://example.com\x0a/ref?code=123",
+        "example.com",
+      ),
+    ).toBe(false);
+    expect(
+      validateReferralUrl("https://example.com\t/ref?code=123", "example.com"),
+    ).toBe(false);
+  });
+
+  it("should block suspicious redirect search parameters pointing to other domains", () => {
+    expect(
+      validateReferralUrl(
+        "https://example.com/ref?redirect=https://evil.com",
+        "example.com",
+      ),
+    ).toBe(false);
+    expect(
+      validateReferralUrl(
+        "https://example.com/ref?url=//evil.com",
+        "example.com",
+      ),
+    ).toBe(false);
+    expect(
+      validateReferralUrl(
+        "https://example.com/ref?next=ftp://evil.com",
+        "example.com",
+      ),
+    ).toBe(false);
+  });
+
+  it("should allow suspicious redirect search parameters if they point to the safe target domain", () => {
+    expect(
+      validateReferralUrl(
+        "https://example.com/ref?redirect=https://example.com/dashboard",
+        "example.com",
+      ),
+    ).toBe(true);
+    expect(
+      validateReferralUrl(
+        "https://example.com/ref?url=https://www.example.com/welcome",
+        "example.com",
+      ),
+    ).toBe(true);
+  });
+
+  it("should handle invalid URLs gracefully without crashing", () => {
+    expect(validateReferralUrl("not-a-valid-url", "example.com")).toBe(false);
+  });
+});

--- a/worker/lib/security.ts
+++ b/worker/lib/security.ts
@@ -330,6 +330,17 @@ async function fetchDns(
  */
 export function validateReferralUrl(url: string, domain: string): boolean {
   try {
+    // Reject dangerous characters or control characters that could bypass URL parsing
+    if (
+      url.includes("\\") ||
+      url.includes("\x00") ||
+      url.includes("\x0d") ||
+      url.includes("\x0a") ||
+      url.includes("\t")
+    ) {
+      return false;
+    }
+
     const parsed = new URL(url);
 
     // 1. Enforce HTTPS


### PR DESCRIPTION
What: Hardened the `validateReferralUrl` function in `worker/lib/security.ts` to reject URLs containing control characters (`\x00`, `\x0a`, `\x0d`, `\t`) or backslashes (`\\`). Created comprehensive unit tests in `tests/unit/security-referral-url.test.ts`.

Why: URL parser differentials between parser libraries and HTTP clients are often exploited via dangerous backslash sequences or control characters to bypass domain validation checks, potentially introducing open-redirect or SSRF vulnerabilities.

Impact: Greatly reduces open-redirect and parsing-differential bypass vectors for referral URLs.

Verification: Reviewers can run `npx vitest run tests/unit/security-referral-url.test.ts` to confirm all security checks pass.

---
*PR created automatically by Jules for task [10112235281882819704](https://jules.google.com/task/10112235281882819704) started by @do-ops885*