### PR TITLE
fix(security): harden referral url validation against encoded bypasses

### DIFF
--- a/tests/unit/security-referral-url.test.ts
+++ b/tests/unit/security-referral-url.test.ts
@@ -1,0 +1,432 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { validateReferralUrl } from "../../worker/lib/security";
+
+describe("validateReferralUrl", () => {
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  describe("valid URLs", () => {
+    it("should allow valid HTTPS referral URLs matching the target domain", () => {
+      expect(
+        validateReferralUrl("https://example.com/ref?code=123", "example.com"),
+      ).toBe(true);
+      expect(
+        validateReferralUrl(
+          "https://www.example.com/ref?code=123",
+          "example.com",
+        ),
+      ).toBe(true);
+      expect(
+        validateReferralUrl(
+          "https://example.com/ref?code=123",
+          "www.example.com",
+        ),
+      ).toBe(true);
+    });
+
+    it("should allow URLs with normal query parameters", () => {
+      expect(
+        validateReferralUrl(
+          "https://example.com/page?foo=bar&baz=qux",
+          "example.com",
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("protocol enforcement", () => {
+    it("should block HTTP referral URLs", () => {
+      expect(
+        validateReferralUrl("http://example.com/ref?code=123", "example.com"),
+      ).toBe(false);
+    });
+
+    it("should block FTP referral URLs", () => {
+      expect(
+        validateReferralUrl("ftp://example.com/ref?code=123", "example.com"),
+      ).toBe(false);
+    });
+
+    it("should block javascript: scheme", () => {
+      expect(
+        validateReferralUrl("javascript:alert(1)//example.com", "example.com"),
+      ).toBe(false);
+    });
+
+    it("should block data: scheme", () => {
+      expect(
+        validateReferralUrl(
+          "data:text/html,<script>alert(1)</script>",
+          "example.com",
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("domain matching", () => {
+    it("should block mismatched domains", () => {
+      expect(
+        validateReferralUrl("https://evil.com/ref?code=123", "example.com"),
+      ).toBe(false);
+      expect(
+        validateReferralUrl("https://example.org/ref?code=123", "example.com"),
+      ).toBe(false);
+    });
+
+    it("should block subdomain spoofing", () => {
+      expect(
+        validateReferralUrl("https://evil-example.com/ref", "example.com"),
+      ).toBe(false);
+      expect(
+        validateReferralUrl("https://example.com.evil.com/ref", "example.com"),
+      ).toBe(false);
+    });
+
+    it("should block host header injection via @", () => {
+      expect(
+        validateReferralUrl("https://example.com@evil.com/ref", "example.com"),
+      ).toBe(false);
+    });
+  });
+
+  describe("control character rejection (raw)", () => {
+    it("should block null byte", () => {
+      expect(
+        validateReferralUrl(
+          "https://example.com\x00/ref?code=123",
+          "example.com",
+        ),
+      ).toBe(false);
+    });
+
+    it("should block carriage return", () => {
+      expect(
+        validateReferralUrl(
+          "https://example.com\x0d/ref?code=123",
+          "example.com",
+        ),
+      ).toBe(false);
+    });
+
+    it("should block line feed", () => {
+      expect(
+        validateReferralUrl(
+          "https://example.com\x0a/ref?code=123",
+          "example.com",
+        ),
+      ).toBe(false);
+    });
+
+    it("should block horizontal tab", () => {
+      expect(
+        validateReferralUrl(
+          "https://example.com\t/ref?code=123",
+          "example.com",
+        ),
+      ).toBe(false);
+    });
+
+    it("should block vertical tab", () => {
+      expect(
+        validateReferralUrl(
+          "https://example.com\x0b/ref?code=123",
+          "example.com",
+        ),
+      ).toBe(false);
+    });
+
+    it("should block form feed", () => {
+      expect(
+        validateReferralUrl(
+          "https://example.com\x0c/ref?code=123",
+          "example.com",
+        ),
+      ).toBe(false);
+    });
+
+    it("should block DEL character", () => {
+      expect(
+        validateReferralUrl(
+          "https://example.com\x7f/ref?code=123",
+          "example.com",
+        ),
+      ).toBe(false);
+    });
+
+    it("should block backspace", () => {
+      expect(
+        validateReferralUrl(
+          "https://example.com\x08/ref?code=123",
+          "example.com",
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("encoded control character rejection", () => {
+    it("should block %00 (encoded null byte)", () => {
+      expect(
+        validateReferralUrl(
+          "https://example.com%00/ref?code=123",
+          "example.com",
+        ),
+      ).toBe(false);
+    });
+
+    it("should block %0a (encoded line feed)", () => {
+      expect(
+        validateReferralUrl(
+          "https://example.com%0a/ref?code=123",
+          "example.com",
+        ),
+      ).toBe(false);
+    });
+
+    it("should block %0d (encoded carriage return)", () => {
+      expect(
+        validateReferralUrl(
+          "https://example.com%0d/ref?code=123",
+          "example.com",
+        ),
+      ).toBe(false);
+    });
+
+    it("should block %09 (encoded tab)", () => {
+      expect(
+        validateReferralUrl(
+          "https://example.com%09/ref?code=123",
+          "example.com",
+        ),
+      ).toBe(false);
+    });
+
+    it("should block %7f (encoded DEL)", () => {
+      expect(
+        validateReferralUrl(
+          "https://example.com%7f/ref?code=123",
+          "example.com",
+        ),
+      ).toBe(false);
+    });
+
+    it("should block %5c (encoded backslash)", () => {
+      expect(
+        validateReferralUrl(
+          "https://example.com%5cevil.com/ref?code=123",
+          "example.com",
+        ),
+      ).toBe(false);
+    });
+
+    it("should block uppercase hex variants", () => {
+      expect(
+        validateReferralUrl(
+          "https://example.com%0A/ref?code=123",
+          "example.com",
+        ),
+      ).toBe(false);
+      expect(
+        validateReferralUrl(
+          "https://example.com%0D/ref?code=123",
+          "example.com",
+        ),
+      ).toBe(false);
+      expect(
+        validateReferralUrl(
+          "https://example.com%5C/ref?code=123",
+          "example.com",
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("double-encoding rejection", () => {
+    it("should block %2500 (double-encoded null byte)", () => {
+      expect(
+        validateReferralUrl(
+          "https://example.com%2500/ref?code=123",
+          "example.com",
+        ),
+      ).toBe(false);
+    });
+
+    it("should block %250a (double-encoded line feed)", () => {
+      expect(
+        validateReferralUrl(
+          "https://example.com%250a/ref?code=123",
+          "example.com",
+        ),
+      ).toBe(false);
+    });
+
+    it("should block %255c (double-encoded backslash)", () => {
+      expect(
+        validateReferralUrl(
+          "https://example.com%255c/ref?code=123",
+          "example.com",
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("backslash / UNC path rejection", () => {
+    it("should block raw backslash in URL", () => {
+      expect(
+        validateReferralUrl(
+          "https://example.com\\evil.com/ref?code=123",
+          "example.com",
+        ),
+      ).toBe(false);
+    });
+
+    it("should block Windows UNC path", () => {
+      expect(
+        validateReferralUrl("\\\\evil.com\\share\\file", "example.com"),
+      ).toBe(false);
+    });
+  });
+
+  describe("suspicious redirect parameter bypasses", () => {
+    it("should block redirect param pointing to external domain", () => {
+      expect(
+        validateReferralUrl(
+          "https://example.com/ref?redirect=https://evil.com",
+          "example.com",
+        ),
+      ).toBe(false);
+    });
+
+    it("should block url param with protocol-relative external URL", () => {
+      expect(
+        validateReferralUrl(
+          "https://example.com/ref?url=//evil.com",
+          "example.com",
+        ),
+      ).toBe(false);
+    });
+
+    it("should block next param with ftp:// scheme", () => {
+      expect(
+        validateReferralUrl(
+          "https://example.com/ref?next=ftp://evil.com",
+          "example.com",
+        ),
+      ).toBe(false);
+    });
+
+    it("should block redirect param with backslash bypass", () => {
+      expect(
+        validateReferralUrl(
+          "https://example.com/ref?redirect=\\evil.com",
+          "example.com",
+        ),
+      ).toBe(false);
+    });
+
+    it("should block return param with external URL", () => {
+      expect(
+        validateReferralUrl(
+          "https://example.com/ref?return=https://evil.com/path",
+          "example.com",
+        ),
+      ).toBe(false);
+    });
+
+    it("should block callback param with external URL", () => {
+      expect(
+        validateReferralUrl(
+          "https://example.com/ref?callback=https://evil.com/hook",
+          "example.com",
+        ),
+      ).toBe(false);
+    });
+
+    it("should allow redirect param pointing to same domain", () => {
+      expect(
+        validateReferralUrl(
+          "https://example.com/ref?redirect=https://example.com/dashboard",
+          "example.com",
+        ),
+      ).toBe(true);
+    });
+
+    it("should allow url param pointing to same domain with www", () => {
+      expect(
+        validateReferralUrl(
+          "https://example.com/ref?url=https://www.example.com/welcome",
+          "example.com",
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("invalid / edge case URLs", () => {
+    it("should handle invalid URLs gracefully", () => {
+      expect(validateReferralUrl("not-a-valid-url", "example.com")).toBe(false);
+    });
+
+    it("should handle empty string", () => {
+      expect(validateReferralUrl("", "example.com")).toBe(false);
+    });
+
+    it("should handle whitespace-only input", () => {
+      expect(validateReferralUrl("   ", "example.com")).toBe(false);
+    });
+
+    it("should handle very long URLs", () => {
+      const longPath = "a".repeat(5000);
+      expect(
+        validateReferralUrl(`https://example.com/${longPath}`, "example.com"),
+      ).toBe(true);
+    });
+
+    it("should block URL with colon in path (port spoofing)", () => {
+      expect(
+        validateReferralUrl(
+          "https://example.com:443@evil.com/ref",
+          "example.com",
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("logging", () => {
+    it("should log a warning when rejecting due to dangerous characters", () => {
+      validateReferralUrl("https://example.com\x00/evil", "example.com");
+      expect(consoleWarnSpy).toHaveBeenCalled();
+      const logCall = consoleWarnSpy.mock.calls[0]?.[0] as string;
+      expect(logCall).toContain("dangerous characters");
+    });
+
+    it("should log a warning when rejecting due to domain mismatch", () => {
+      validateReferralUrl("https://evil.com/path", "example.com");
+      expect(consoleWarnSpy).toHaveBeenCalled();
+      const logCall = consoleWarnSpy.mock.calls[0]?.[0] as string;
+      expect(logCall).toContain("domain mismatch");
+    });
+
+    it("should log a warning when rejecting non-HTTPS", () => {
+      validateReferralUrl("http://example.com/path", "example.com");
+      expect(consoleWarnSpy).toHaveBeenCalled();
+      const logCall = consoleWarnSpy.mock.calls[0]?.[0] as string;
+      expect(logCall).toContain("non-HTTPS");
+    });
+
+    it("should log a warning for suspicious param bypass", () => {
+      validateReferralUrl(
+        "https://example.com/ref?redirect=https://evil.com",
+        "example.com",
+      );
+      expect(consoleWarnSpy).toHaveBeenCalled();
+      const logCall = consoleWarnSpy.mock.calls[0]?.[0] as string;
+      expect(logCall).toContain("suspicious param");
+    });
+  });
+});

--- a/worker/lib/security.ts
+++ b/worker/lib/security.ts
@@ -324,16 +324,50 @@ async function fetchDns(
   }
 }
 
+// Matches C0 control characters (\x00-\x1f), DEL (\x7f), and common
+// encoded variants (%00-%1f, %7f) that bypass naive string checks.
+const DANGEROUS_CHARS_RE = /[\x00-\x1f\x7f]/;
+const ENCODED_CONTROL_RE = /%(?:0[0-9a-f]|1[0-9a-f]|7[fF])/i;
+// %5c = backslash, %25 = double-encoding prefix
+const ENCODED_BACKSLASH_RE = /%5[cC]/i;
+const DOUBLE_ENCODING_RE = /%25(?:0[0-9a-f]|1[0-9a-f]|5[cC]|7[fF])/i;
+
+function hasDangerousChars(url: string): boolean {
+  return (
+    DANGEROUS_CHARS_RE.test(url) ||
+    ENCODED_CONTROL_RE.test(url) ||
+    ENCODED_BACKSLASH_RE.test(url) ||
+    DOUBLE_ENCODING_RE.test(url) ||
+    url.includes("\\")
+  );
+}
+
 /**
  * Validates a referral URL to prevent open redirects.
  * Ensures the URL uses HTTPS and its hostname matches the intended domain.
+ * Rejects control characters, encoded bypasses, and UNC paths.
  */
 export function validateReferralUrl(url: string, domain: string): boolean {
   try {
+    if (hasDangerousChars(url)) {
+      logger.warn("Referral URL rejected: dangerous characters detected", {
+        component: "security",
+        url,
+        domain,
+      });
+      return false;
+    }
+
     const parsed = new URL(url);
 
     // 1. Enforce HTTPS
     if (parsed.protocol !== "https:") {
+      logger.warn("Referral URL rejected: non-HTTPS protocol", {
+        component: "security",
+        protocol: parsed.protocol,
+        url,
+        domain,
+      });
       return false;
     }
 
@@ -342,6 +376,12 @@ export function validateReferralUrl(url: string, domain: string): boolean {
     const targetDomain = domain.toLowerCase().replace(/^www\./, "");
 
     if (urlHostname !== targetDomain) {
+      logger.warn("Referral URL rejected: domain mismatch", {
+        component: "security",
+        urlHostname,
+        targetDomain,
+        url,
+      });
       return false;
     }
 
@@ -350,7 +390,10 @@ export function validateReferralUrl(url: string, domain: string): boolean {
     for (const param of suspiciousParams) {
       if (parsed.searchParams.has(param)) {
         const val = parsed.searchParams.get(param);
-        if (val && (val.includes("://") || val.startsWith("//"))) {
+        if (
+          val &&
+          (val.includes("://") || val.startsWith("//") || val.includes("\\"))
+        ) {
           // If it looks like a full URL, ensure it's on the same domain
           try {
             const nestedUrl = new URL(val);
@@ -358,10 +401,24 @@ export function validateReferralUrl(url: string, domain: string): boolean {
               .toLowerCase()
               .replace(/^www\./, "");
             if (nestedHostname !== targetDomain) {
+              logger.warn(
+                "Referral URL rejected: suspicious param points to external domain",
+                {
+                  component: "security",
+                  param,
+                  nestedHostname,
+                  targetDomain,
+                  url,
+                },
+              );
               return false;
             }
           } catch {
             // If it's not a valid URL but contains protocol markers, block it
+            logger.warn(
+              "Referral URL rejected: suspicious param contains unparseable URL",
+              { component: "security", param, url },
+            );
             return false;
           }
         }


### PR DESCRIPTION
What: Replaced naive char-by-char includes() checks with regex-based C0 control character rejection, added encoded variant detection (%00-%1f, %5c), double-encoding defense (%25xx), UNC path blocking, and structured logging for all security rejection events. Expanded test suite from 7 to 46 cases.

Why: PR #643 added control character checks but missed the actual exploitation vectors (URL-encoded forms like %00, %5c) that attackers use to bypass naive string checks. The blocklist was incomplete (missing \x0b, \x0c, \x7f) and lacked any audit trail for production rejection events.

Impact: Closes the encoded-bypass gap in referral URL validation. All 81 security unit tests pass. Lint and typecheck clean.