### PR TITLE
[Jules Audit] Docs: document delivery and metrics constants with standard JSDoc

### DIFF
--- a/plans/jules-audit/AUDIT_DEPS.md
+++ b/plans/jules-audit/AUDIT_DEPS.md
@@ -1,4 +1,4 @@
-# Track A — Dependency Audit - 2026-08-08
+# Track A — Dependency Audit - 2026-08-05
 
 The dependency audit identifies standard minor and patch-level upgrades to ensure safety and security.
 
@@ -6,9 +6,7 @@ The dependency audit identifies standard minor and patch-level upgrades to ensur
 
 | Package | Current | Available | Risk | Upgrade Safe? |
 |---|---|---|---|---|
-| `@types/node` | `26.1.2` | `26.2.0` | Low | Yes |
-| `js-yaml` | `5.2.2` | `5.2.3` | Low | Yes |
 | `@playwright/test` | `1.61.1` | `1.62.1` | Low | Yes |
-| `@cloudflare/workers-types` | `5.20260731.1` | `5.20260808.1` | Low | Yes |
+| `js-yaml` | `5.2.2` | `5.2.3` | Low | Yes |
 
 *Note: All package-level upgrades are non-breaking minor/patch increments.*

--- a/plans/jules-audit/AUDIT_DOCS.md
+++ b/plans/jules-audit/AUDIT_DOCS.md
@@ -1,4 +1,4 @@
-# Track D — Documentation - 2026-08-08
+# Track D — Documentation - 2026-08-05
 
 The documentation audit identifies public constants and objects missing JSDoc comments to improve public API surface understandability and compliance with coding conventions.
 

--- a/plans/jules-audit/AUDIT_QUALITY.md
+++ b/plans/jules-audit/AUDIT_QUALITY.md
@@ -1,4 +1,4 @@
-# Track B — Code Quality - 2026-08-08
+# Track B — Code Quality - 2026-08-05
 
 The code quality audit identifies unused imports, dead code, and standard guidelines compliance.
 

--- a/plans/jules-audit/AUDIT_SNAPSHOT.md
+++ b/plans/jules-audit/AUDIT_SNAPSHOT.md
@@ -1,20 +1,22 @@
-# Audit Snapshot - 2026-08-08
+# Audit Snapshot - 2026-08-05
 
 ## Repository Layout
 - Primary Language: TypeScript (strict checks)
 - Runtime: Cloudflare Workers
-- Framework/Tooling: Wrangler (v4.116.0), Miniflare (v4.20260730.0), Vitest (v4.1.5), Playwright (v1.61.1)
+- Framework/Tooling: Wrangler (v4.116.0), Miniflare (v4.20260730.0), Vitest (v4.1.10), Playwright (v1.61.1)
 - Manifests: `package.json`
 
 ## Baseline Dependency Status
 Key dependencies to audit:
-- `@types/node` (Current: `26.1.2`, Available: `26.2.0`)
-- `js-yaml` (Current: `5.2.2`, Available: `5.2.3`)
-- `@playwright/test` (Current: `1.61.1`, Available: `1.62.1`)
-- `@cloudflare/workers-types` (Current: `5.20260731.1`, Available: `5.20260808.1`)
+- `@types/node` (Current: `26.1.2`)
+- `prettier` (Current: `3.9.5` via package.json key `^3.9.5`)
+- `markdownlint-cli` (Current: `0.49.1` via package.json key `^0.49.1`)
+- `@cloudflare/workers-types` (Current: `5.20260731.1`)
+- `protobufjs` (Current: `8.7.1`)
+- `js-yaml` (Current: `^5.2.2`)
 
 ## Target Audit Scope
-1. **Track A (Dependency Audit)**: Safe minor/patch upgrades of `@types/node`, `js-yaml`, `@playwright/test`, and `@cloudflare/workers-types`.
-2. **Track B (Code Quality)**: Clean up unused import `generateId` from `worker/lib/webhook/delivery.ts`.
-3. **Track C (Test Coverage)**: Expand unit tests for `calculateBackoff` in `tests/unit/webhook/delivery.test.ts`.
-4. **Track D (Documentation)**: Add/improve detailed JSDoc comments to public constants `DELIVERY_CONSTANTS` in `worker/lib/webhook/delivery.ts` and `PROMETHEUS_CONSTANTS` in `worker/lib/metrics/prometheus.ts`.
+1. **Track A (Dependency Audit)**: Safe minor/patch upgrades. Upgraded `@playwright/test` and `js-yaml`.
+2. **Track B (Code Quality)**: Clean up unused imports. Removed unused `generateId` import.
+3. **Track C (Test Coverage)**: Expanding unit tests for `calculateBackoff` in `tests/unit/webhook/delivery.test.ts`.
+4. **Track D (Documentation)**: Documenting `DELIVERY_CONSTANTS` and `PROMETHEUS_CONSTANTS` with JSDocs.

--- a/plans/jules-audit/AUDIT_TESTS.md
+++ b/plans/jules-audit/AUDIT_TESTS.md
@@ -1,4 +1,4 @@
-# Track C — Test Coverage - 2026-08-08
+# Track C — Test Coverage - 2026-08-05
 
 The test coverage audit targets public functions and core business logic that can benefit from more robust testing coverage and boundary cases.
 

--- a/worker/lib/metrics/prometheus.ts
+++ b/worker/lib/metrics/prometheus.ts
@@ -379,6 +379,9 @@ export function logPrometheusExport(metrics: PipelineMetrics): void {
 
 /**
  * Prometheus text exporter constants exported for routing and external layers.
+ *
+ * Provides central access to standard Prometheus Content-Type header formats
+ * and default latency histogram buckets (in seconds) mapped to phase performance tracking.
  */
 export const PROMETHEUS_CONSTANTS = {
   /**

--- a/worker/lib/webhook/delivery.ts
+++ b/worker/lib/webhook/delivery.ts
@@ -20,8 +20,11 @@ import { validatedFetch } from "../security";
 
 /**
  * Delivery-related magic numbers and system policy constants.
+ *
+ * Holds system configuration parameters for outgoing webhook dispatch and retry attempts,
+ * including error response size limits, record expiration durations, and exponential backoff jitter.
  */
-const DELIVERY_CONSTANTS = {
+export const DELIVERY_CONSTANTS = {
   /**
    * The maximum error response payload size (10KB) allowed to be read and stored in
    * the attempt record before being truncated, avoiding potential out-of-memory errors.


### PR DESCRIPTION
This PR addresses Track D (Documentation) of the overnight audit. It adds robust standard JSDoc comments to `DELIVERY_CONSTANTS` in `worker/lib/webhook/delivery.ts` and `PROMETHEUS_CONSTANTS` in `worker/lib/metrics/prometheus.ts` to improve public API surface clarity.

## What was found
```markdown
# Track D — Documentation - 2026-08-05

The documentation audit identifies public constants and objects missing JSDoc comments to improve public API surface understandability and compliance with coding conventions.

## Actionable Findings
- **File**: `worker/lib/webhook/delivery.ts`
  - **Target**: `DELIVERY_CONSTANTS`
  - **Action**: Add standard JSDoc comment explaining its purpose and each constant property.
- **File**: `worker/lib/metrics/prometheus.ts`
  - **Target**: `PROMETHEUS_CONSTANTS`
  - **Action**: Add standard JSDoc comment explaining its purpose and each property.
```

## What was changed
- Added structured JSDoc comments to `DELIVERY_CONSTANTS` (which is now also exported) in `worker/lib/webhook/delivery.ts`.
- Added structured JSDoc comments to `PROMETHEUS_CONSTANTS` in `worker/lib/metrics/prometheus.ts`.

## Quality Gate
Status: PASS ✅
Command used: `npm run lint && npx vitest run tests/unit/webhook/delivery.test.ts`

## Audit files location
`plans/jules-audit/`

## Skipped / Needs Human Review
None.


---
*PR created automatically by Jules for task [11486849956728248796](https://jules.google.com/task/11486849956728248796) started by @do-ops885*