### PR TITLE
[Jules Audit] Deps: update types/node, js-yaml, and playwright/test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "0.1.8",
       "license": "MIT",
       "dependencies": {
-        "@types/node": "^26.1.2",
+        "@types/node": "^26.2.0",
         "cheerio": "^1.2.0",
         "discord.js": "^14.27.0",
-        "js-yaml": "^5.2.2",
+        "js-yaml": "^5.2.3",
         "protobufjs": "8.7.1",
         "telegraf": "^4.16.3",
         "zod": "^3.22.4"
@@ -20,7 +20,7 @@
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "0.19.1",
         "@cloudflare/workers-types": "5.20260731.1",
-        "@playwright/test": "^1.61.1",
+        "@playwright/test": "^1.62.1",
         "@types/js-yaml": "^4.0.9",
         "@vitest/coverage-v8": "^4.1.10",
         "artillery": "^2.0.33",
@@ -4044,19 +4044,19 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
-      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.61.1"
+        "playwright": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@playwright/test/node_modules/fsevents": {
@@ -4075,35 +4075,35 @@
       }
     },
     "node_modules/@playwright/test/node_modules/playwright": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
-      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.61.1"
+        "playwright-core": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/@playwright/test/node_modules/playwright-core": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
-      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@poppinss/colors": {
@@ -4733,9 +4733,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
-      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -8060,9 +8060,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
-      "integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.3.tgz",
+      "integrity": "sha512-n+mUVyUX5bVv7G/G2zyIHOhdxfuU1dY2NOFzTQUWiMUbFss8b57NFlgCCaggU78wSw5KVS9cllzeLyzyR+n5nw==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -37,10 +37,10 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@types/node": "^26.1.2",
+    "@types/node": "^26.2.0",
     "cheerio": "^1.2.0",
     "discord.js": "^14.27.0",
-    "js-yaml": "^5.2.2",
+    "js-yaml": "^5.2.3",
     "protobufjs": "8.7.1",
     "telegraf": "^4.16.3",
     "zod": "^3.22.4"
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "0.19.1",
     "@cloudflare/workers-types": "5.20260731.1",
-    "@playwright/test": "^1.61.1",
+    "@playwright/test": "^1.62.1",
     "@types/js-yaml": "^4.0.9",
     "@vitest/coverage-v8": "^4.1.10",
     "artillery": "^2.0.33",
@@ -68,7 +68,7 @@
     "protobufjs": "8.7.1",
     "undici": "6.27.0",
     "uuid": "14.0.0",
-    "@playwright/test": "^1.61.1",
+    "@playwright/test": "^1.62.1",
     "ws": "8.21.0",
     "engine.io-client": "6.6.5",
     "form-data": "4.0.6",


### PR DESCRIPTION
This PR upgrades standard minor and patch-level packages (@types/node, js-yaml, and @playwright/test) to ensure the codebase remains secure, stable, and up-to-date with upstream maintenance cycles.

---
*PR created automatically by Jules for task [16435916123929647448](https://jules.google.com/task/16435916123929647448) started by @do-ops885*