### PR TITLE
[Jules Audit] Deps: upgrade prettier and vitest to safe patch versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,9 +27,9 @@
         "husky": "^9.1.7",
         "markdownlint-cli": "^0.49.1",
         "miniflare": "4.20260730.0",
-        "prettier": "^3.9.5",
+        "prettier": "^3.9.6",
         "typescript": "^7.0.2",
-        "vitest": "^4.1.5",
+        "vitest": "^4.1.10",
         "wrangler": "4.116.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -55,9 +55,9 @@
     "husky": "^9.1.7",
     "markdownlint-cli": "^0.49.1",
     "miniflare": "4.20260730.0",
-    "prettier": "^3.9.5",
+    "prettier": "^3.9.6",
     "typescript": "^7.0.2",
-    "vitest": "^4.1.5",
+    "vitest": "^4.1.10",
     "wrangler": "4.116.0"
   },
   "overrides": {


### PR DESCRIPTION
## What was found
The dependency audit scans package manifests for safe patch and minor upgrades. 

Found actionable findings:
- prettier 3.9.5 -> 3.9.6
- vitest 4.1.5 -> 4.1.10

## What was changed
- Updated package.json and package-lock.json to include upgrades of prettier and vitest.

## Quality Gate
Status: PASS ✅
Command used: SKIP_TESTS=true bash scripts/quality_gate.sh && npm run test:unit

## Audit files location
plans/jules-audit/

## Skipped / Needs Human Review
None.


---
*PR created automatically by Jules for task [7275762386285991291](https://jules.google.com/task/7275762386285991291) started by @do-ops885*