### PR TITLE
[Jules Audit] Docs: add JSDoc annotations for config-utils, utils, and hmac

### DIFF
--- a/worker/lib/config-utils.ts
+++ b/worker/lib/config-utils.ts
@@ -1,6 +1,16 @@
 import { CONFIG } from "../config";
 import type { Env } from "../types";
 
+/**
+ * Safely parse an integer environment variable bounded by minimum and maximum constraints
+ * @param name Parameter name used for error reporting
+ * @param value Raw string configuration value
+ * @param fallback Default fallback integer value when parameter is omitted or empty
+ * @param minimum Inclusive lower bound
+ * @param maximum Inclusive upper bound
+ * @returns Parsed integer value
+ * @throws Error if value is non-integer or outside the [minimum, maximum] range
+ */
 export function parseBoundedIntegerConfig(
   name: string,
   value: string | undefined,

--- a/worker/lib/hmac.ts
+++ b/worker/lib/hmac.ts
@@ -2,14 +2,25 @@
 // HMAC-SHA256 Signature Verification Utilities
 // ============================================================================
 
+/**
+ * Configuration options for HMAC signature verification
+ */
 export interface HmacConfig {
+  /** Webhook signing secret */
   secret: string;
+  /** Maximum allowable difference in seconds between current time and webhook timestamp */
   timestampToleranceSeconds: number;
 }
 
+/**
+ * Result object returned by HMAC signature verification
+ */
 export interface SignatureResult {
+  /** Whether the HMAC signature is valid */
   valid: boolean;
+  /** Optional error message describing validation failure */
   error?: string;
+  /** Optional computed HMAC signature string */
   computedSignature?: string;
 }
 

--- a/worker/lib/utils.ts
+++ b/worker/lib/utils.ts
@@ -1,6 +1,12 @@
 import { CONFIG } from "../config";
 import { logger } from "./global-logger";
 
+/**
+ * Creates an AbortSignal that automatically aborts after a specified duration in milliseconds,
+ * along with a cleanup function to clear the internal timer.
+ * @param ms Timeout duration in milliseconds
+ * @returns Object containing the AbortSignal instance and cleanup function
+ */
 export function createTimeoutSignal(ms: number): {
   signal: AbortSignal;
   cleanup: () => void;


### PR DESCRIPTION
## What was found
`worker/lib/config-utils.ts`, `worker/lib/utils.ts`, and `worker/lib/hmac.ts` lacked full JSDoc comments with `@param`, `@returns`, and `@throws` annotations on exported items.

## What was changed
- Added JSDoc comments for `parseBoundedIntegerConfig` in `worker/lib/config-utils.ts`
- Added JSDoc comment for `createTimeoutSignal` in `worker/lib/utils.ts`
- Added JSDoc comments for `HmacConfig` and `SignatureResult` interfaces in `worker/lib/hmac.ts`

## Quality Gate
Status: PASS ✅
Command used: `SKIP_TESTS=true ./scripts/quality_gate.sh`

## Audit files location
`plans/jules-audit/`

## Skipped / Needs Human Review
None

---
*PR created automatically by Jules for task [14190426791340676210](https://jules.google.com/task/14190426791340676210) started by @do-ops885*