### PR TITLE
docs: sync cron schedules and security controls in human documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Cron schedules documentation**: Explicitly documented all 4 system background cron schedules (`0 */6 * * *`, `*/30 * * * *`, `0 9 * * *`, `0 0 * * SUN`) in `README.md` and `docs/DEPLOYMENT.md`.
+- **Security controls documentation**: Added Security Architecture & Controls section in `SECURITY.md` covering HMAC signature verification standards, SSRF protection, RBAC, and input hardening.
+
+### Security
+- **HMAC signature leakage prevention**: Hardened HMAC verification in `worker/lib/hmac.ts` to omit computed signature return values on verification failures.
+
 ## [0.1.8] - 2026-07-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -124,7 +124,11 @@ The system utilizes Cloudflare D1 (SQLite) for structured data and identity mana
 
 ### Current Settings
 
-- **Cron**: Every 6 hours
+- **Cron Schedules**:
+  - `0 */6 * * *`: Discovery Pipeline (Every 6 hours)
+  - `*/30 * * * *`: Reddit post lifecycle moderation (Every 30 minutes)
+  - `0 9 * * *`: Expiration check & experience aggregation (Daily at 09:00 UTC)
+  - `0 0 * * SUN`: Continuous validation gate sweep (Weekly on Sundays)
 - **KV Namespaces**: 5 (PROD, STAGING, LOG, LOCK, SOURCES)
 - **Max Deals**: 1000 per run
 - **Trust Threshold**: Dev 0.1 / Staging 0.25 / Prod 0.3

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,6 +32,20 @@ privately to the maintainers.
 2. **Assessment** — severity and scope evaluation with progress updates
 3. **Fix & disclosure** — coordinated release and public advisory upon resolution
 
+## Security Architecture & Controls
+
+### HMAC-SHA256 Webhook Verification
+- **Constant-Time Comparison**: Webhook and email webhook signature verifications utilize constant-time string comparisons (`timingSafeEqual`) to prevent timing side-channel attacks.
+- **Zero Signature Leakage**: Verification failure results explicitly omit expected/computed HMAC signatures from error responses to prevent signature leakage.
+- **Replay Protection**: Enforces timestamp tolerance validation (default: 300 seconds) against request timestamps.
+
+### SSRF Protection
+- **Host Resolution Validation**: All outgoing URL fetches in the discovery and validation pipelines undergo SSRF checks (`validateFetchUrl`) resolving underlying host IPs to block access to private/internal network ranges.
+
+### Access Control & Input Hardening
+- **Role-Based Access Control (RBAC)**: Strict separation between `public`, `user`, and `admin` API tiers.
+- **Input Hardening**: Rejection of control characters, null bytes, tabs, and open-redirect path patterns across URL and referral submission handlers.
+
 ## Scope
 
 This policy covers the source code, workflows, scripts, and configuration files

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -55,7 +55,7 @@
 - **D1 Database**: Full-text search and advanced deal queries
 - **MCP Server**: Model Context Protocol 2025-11-25 for AI agent integration
 - **Webhook System**: Event notifications with HMAC signature verification
-- **Cron Triggers**: Discovery every 6 hours (`0 */6 * * *`), expiry check at 9am (`0 9 * * *`)
+- **Cron Triggers**: Discovery (`0 */6 * * *`), Reddit moderation (`*/30 * * * *`), Expirations (`0 9 * * *`), and Weekly validation sweep (`0 0 * * SUN`)
 
 ---
 


### PR DESCRIPTION
This pull request updates human-facing documentation across the codebase:
- **README.md & docs/DEPLOYMENT.md**: Explicitly documents all four background cron schedules (`0 */6 * * *`, `*/30 * * * *`, `0 9 * * *`, `0 0 * * SUN`).
- **SECURITY.md**: Adds Security Architecture & Controls section detailing HMAC-SHA256 signature verification standards, SSRF protection (`validateFetchUrl`), RBAC, and input hardening.
- **CHANGELOG.md**: Records cron documentation additions, security controls, and HMAC signature leak fix under `[Unreleased]`.

---
*PR created automatically by Jules for task [2102452838648092758](https://jules.google.com/task/2102452838648092758) started by @do-ops885*