### PR TITLE
[Jules Audit] Docs: add JSDoc annotations for public RBAC functions

### DIFF
--- a/plans/jules-audit/AUDIT_DOCS.md
+++ b/plans/jules-audit/AUDIT_DOCS.md
@@ -1,33 +1,16 @@
-# Track D — Documentation Report — 2026-08-20
+# Documentation Audit (Track D) - 2026-08-24
 
-## Summary
-Audited public functions and interfaces in `worker/lib/ranking.ts` and `worker/lib/crypto.ts` for JSDoc comment completeness (`@param`, `@returns`).
+## Target File
+`worker/lib/rbac.ts`
 
-## Documentation Updates
+## Missing JSDoc Annotations Found
+- `hasPermission`
+- `hasAllPermissions`
+- `hasAnyPermission`
+- `requirePermission`
+- `clearPermissionsCache`
+- `listRolePermissions`
+- `canAccess`
 
-### 1. Ranking Utilities (`worker/lib/ranking.ts`)
-- Added `@param` and `@returns` annotations to public functions:
-  - `calculateDealScore`: Deal score calculation
-  - `calculateDetailedScore`: Detailed score breakdown calculation
-  - `sortDeals`: Sorting deals by field and direction
-  - `rankDeals`: Ranking and filtering deals
-  - `getTopDeals`: Retrieval of top deals by score
-  - `getExpiringDeals`: Retrieval of deals expiring within N days
-  - `getRecentDeals`: Retrieval of deals discovered within N days
-  - `getHighValueDeals`: Retrieval of high value deals exceeding reward threshold
-
-### 2. Cryptographic Utilities (`worker/lib/crypto.ts`)
-- Added `@param` and `@returns` annotations to public functions:
-  - `sha256`: SHA-256 string hashing
-  - `generateDealId`: Canonical deal ID generation
-  - `generateSnapshotHash`: Canonical snapshot hash generation
-  - `generateRunId`: Run ID generation from Date
-  - `generateUUID`: Cryptographic UUID v4 generation
-  - `normalizedEquals`: Zero-allocation string equality comparison
-  - `getBigramBitset`: Bitset extraction for character bigrams
-  - `calculateStringSimilarityPrecomputed`: Jaccard similarity calculation on precomputed bitsets
-  - `calculateStringSimilarity`: Character bigram string similarity calculation
-  - `base64urlEncode`: Base64url encoding for string or Uint8Array
-  - `precomputeUrlSimilarityData`: Precomputation of URL fields for fast similarity
-  - `calculateUrlSimilarityPrecomputed`: URL similarity on precomputed structures
-  - `calculateUrlSimilarity`: URL similarity for semantic deduplication
+## Documentation Action
+Add complete JSDoc annotations including `@param`, `@returns`, and `@throws` where applicable for all public functions in `worker/lib/rbac.ts`.

--- a/worker/lib/rbac.ts
+++ b/worker/lib/rbac.ts
@@ -163,6 +163,11 @@ function getDefaultPermissions(role: AuthRole): Permission[] {
 
 /**
  * Check if a role has a specific permission.
+ *
+ * @param env Worker environment context containing D1 database bindings
+ * @param role Role to check
+ * @param permission Specific permission string (e.g. "deals:read")
+ * @returns Promise resolving to boolean indicating permission status
  */
 export async function hasPermission(
   env: Env,
@@ -175,6 +180,11 @@ export async function hasPermission(
 
 /**
  * Check if a role has ALL of the specified permissions.
+ *
+ * @param env Worker environment context
+ * @param role Role to evaluate
+ * @param requiredPermissions Array of required permission strings
+ * @returns Promise resolving to RBACResult object with authorization status
  */
 export async function hasAllPermissions(
   env: Env,
@@ -197,6 +207,11 @@ export async function hasAllPermissions(
 
 /**
  * Check if a role has ANY of the specified permissions.
+ *
+ * @param env Worker environment context
+ * @param role Role to evaluate
+ * @param requiredPermissions Array of candidate permission strings
+ * @returns Promise resolving to RBACResult object
  */
 export async function hasAnyPermission(
   env: Env,
@@ -220,6 +235,9 @@ export async function hasAnyPermission(
 /**
  * Middleware factory: require specific permission(s) for a route.
  *
+ * @param env Worker environment context
+ * @param requiredPermissions List of required permissions
+ * @returns Middleware function accepting authentication context and returning access status
  * @example
  * ```typescript
  * const rbacCheck = requirePermission(env, Permissions.DEALS_WRITE);
@@ -257,6 +275,8 @@ export function requirePermission(
 /**
  * Clear the permissions cache for a specific role or all roles.
  * Call after permission changes to ensure fresh data.
+ *
+ * @param role Optional role to invalidate from cache; clears all if omitted
  */
 export function clearPermissionsCache(role?: AuthRole): void {
   if (role) {
@@ -268,6 +288,10 @@ export function clearPermissionsCache(role?: AuthRole): void {
 
 /**
  * Get all permissions for a role (for debugging/admin UI).
+ *
+ * @param env Worker environment context
+ * @param role Role to inspect
+ * @returns Promise resolving to array of assigned permission strings
  */
 export async function listRolePermissions(
   env: Env,
@@ -279,6 +303,12 @@ export async function listRolePermissions(
 /**
  * Check if a user can access a specific resource with an action.
  * Combines RBAC check with role hierarchy (admin overrides all).
+ *
+ * @param env Worker environment context
+ * @param role Role attempting access
+ * @param resource Resource name (e.g., "deals")
+ * @param action Action name (e.g., "read")
+ * @returns Promise resolving to boolean indicating access authorization
  */
 export async function canAccess(
   env: Env,


### PR DESCRIPTION
## What was found
worker/lib/rbac.ts: Public exported functions (hasPermission, hasAllPermissions, hasAnyPermission, requirePermission, clearPermissionsCache, listRolePermissions, canAccess) were missing complete JSDoc annotations.

## What was changed
- Added complete JSDoc comments (@param, @returns) for all public functions in worker/lib/rbac.ts.

## Quality Gate
Status: PASS ✅
Command used: SKIP_TESTS=true ./scripts/quality_gate.sh && npm run lint && npm run build

## Audit files location
plans/jules-audit/

## Skipped / Needs Human Review
None.

---
*PR created automatically by Jules for task [15037796967143442009](https://jules.google.com/task/15037796967143442009) started by @do-ops885*