### PR TITLE
[Jules Audit] Docs: add JSDoc annotations for parseBoundedIntegerConfig

### DIFF
--- a/.agents/metrics/metrics-jules.jsonl
+++ b/.agents/metrics/metrics-jules.jsonl
@@ -1,1 +1,2 @@
 {"timestamp": "2026-08-21T07:35:00Z", "agent": "jules", "task": "perf(categorization): optimize scoring functions by pre-lowercasing definitions", "status": "completed"}
+{"timestamp": "2026-08-25T03:22:00Z", "agent": "jules", "task": "overnight codebase health audit", "status": "completed"}

--- a/worker/lib/config-utils.ts
+++ b/worker/lib/config-utils.ts
@@ -1,6 +1,16 @@
 import { CONFIG } from "../config";
 import type { Env } from "../types";
 
+/**
+ * Parse an integer configuration variable bounded within a specific range
+ * @param name Variable name for error messages
+ * @param value String configuration value to parse
+ * @param fallback Default fallback number if value is missing/empty
+ * @param minimum Minimum acceptable inclusive value
+ * @param maximum Maximum acceptable inclusive value
+ * @returns Parsed bounded integer
+ * @throws Error if value is not an integer or is outside bounds
+ */
 export function parseBoundedIntegerConfig(
   name: string,
   value: string | undefined,


### PR DESCRIPTION
## What was found
`parseBoundedIntegerConfig` in `worker/lib/config-utils.ts` was missing JSDoc annotations.

## What was changed
- Added standard JSDoc `@param`, `@returns`, and `@throws` annotations for `parseBoundedIntegerConfig` in `worker/lib/config-utils.ts`.

## Quality Gate
Status: PASS ✅
Command used: `bash scripts/quality_gate.sh && npm run test:unit`

## Audit files location
`plans/jules-audit/`

## Skipped / Needs Human Review
None.

---
*PR created automatically by Jules for task [3014005654192623222](https://jules.google.com/task/3014005654192623222) started by @do-ops885*