### PR TITLE
chore: improvement swarm 2026-08-25 — kv pagination, assertion sweep, popup split, ai binding, gap tests

### DIFF
--- a/extension/popup-render.js
+++ b/extension/popup-render.js
@@ -1,0 +1,152 @@
+function updatePageInfo(elements, tab) {
+  elements.pageTitle.textContent = tab.title || "Unknown";
+  try {
+    elements.pageUrl.textContent = new URL(tab.url).hostname;
+  } catch {
+    elements.pageUrl.textContent = "Invalid URL";
+  }
+  let faviconSet = false;
+  if (tab.favIconUrl) {
+    try {
+      const faviconUrl = new URL(tab.favIconUrl);
+      if (faviconUrl.protocol === "http:" || faviconUrl.protocol === "https:") {
+        const img = document.createElement("img");
+        img.src = faviconUrl.href;
+        img.width = img.height = 32;
+        img.style.borderRadius = "6px";
+        img.alt = "";
+        elements.favicon.textContent = "";
+        elements.favicon.appendChild(img);
+        faviconSet = true;
+      }
+    } catch {}
+  }
+  if (!faviconSet) elements.favicon.textContent = "🌐";
+}
+
+function showDetections(state, elements, detections) {
+  elements.detectionsSection.style.display = "block";
+  updateScanStatus(
+    elements,
+    "found",
+    `${detections.length} referral code${detections.length > 1 ? "s" : ""} found`,
+  );
+  elements.detectionList.textContent = "";
+
+  detections.forEach((d, i) => {
+    const item = document.createElement("button");
+    item.type = "button";
+    item.className = "detection-item";
+    item.dataset.index = i.toString();
+    item.setAttribute("aria-pressed", i === 0 ? "true" : "false");
+
+    const info = document.createElement("div");
+    info.className = "detection-info";
+
+    const codeValue = document.createElement("span");
+    codeValue.className = "code-value";
+    codeValue.textContent = d.code;
+
+    const codeSource = document.createElement("span");
+    codeSource.className = "code-source";
+    codeSource.textContent = d.source.replaceAll("_", " ");
+
+    info.appendChild(codeValue);
+    info.appendChild(codeSource);
+
+    const confidence = document.createElement("span");
+    confidence.className = "confidence";
+    confidence.textContent = `${Math.round(d.confidence * 100)}%`;
+
+    item.appendChild(info);
+    item.appendChild(confidence);
+
+    item.addEventListener("click", () => {
+      elements.detectionList
+        .querySelectorAll(".detection-item")
+        .forEach((el) => {
+          el.classList.remove("selected");
+          el.setAttribute("aria-pressed", "false");
+        });
+      item.classList.add("selected");
+      item.setAttribute("aria-pressed", "true");
+      state.selectedDetection = state.detections[parseInt(item.dataset.index)];
+    });
+
+    elements.detectionList.appendChild(item);
+  });
+
+  if (detections.length > 0) {
+    const firstItem = elements.detectionList.querySelector(".detection-item");
+    if (firstItem) {
+      firstItem.classList.add("selected");
+      firstItem.setAttribute("aria-pressed", "true");
+      state.selectedDetection = detections[0];
+      elements.captureBtn.focus();
+    }
+  }
+}
+
+function showNoDetections(elements) {
+  elements.detectionsSection.style.display = "none";
+  updateScanStatus(elements, "none", "No referral codes detected on this page");
+  elements.manualCode.focus();
+}
+
+function updateScanStatus(elements, status, text) {
+  const indClass =
+    status === "found" ? "found" : status === "scanning" ? "scanning" : "none";
+  elements.scanStatus.textContent = "";
+  const indicator = document.createElement("div");
+  indicator.className = `status-indicator ${indClass}`;
+  const statusText = document.createElement("span");
+  statusText.className = "status-text";
+  statusText.textContent = text;
+  elements.scanStatus.appendChild(indicator);
+  elements.scanStatus.appendChild(statusText);
+}
+
+function showToast(elements, message, type = "") {
+  elements.toast.textContent = message;
+  elements.toast.className = `toast ${type} show`;
+  setTimeout(() => elements.toast.classList.remove("show"), 3000);
+}
+
+async function copyToClipboard(elements, text, buttonElement) {
+  if (!text || buttonElement.dataset.copying === "true") return;
+
+  const originalLabel = buttonElement.getAttribute("aria-label");
+  const originalTitle = buttonElement.getAttribute("title");
+
+  try {
+    buttonElement.dataset.copying = "true";
+    await navigator.clipboard.writeText(text);
+    showToast(elements, "Copied to clipboard!", "success");
+
+    const children = Array.from(buttonElement.children);
+    buttonElement.textContent = "";
+    const span = document.createElement("span");
+    span.setAttribute("aria-hidden", "true");
+    span.textContent = "✅";
+    buttonElement.appendChild(span);
+
+    buttonElement.setAttribute("aria-label", "Copied!");
+    buttonElement.setAttribute("title", "Copied!");
+
+    setTimeout(() => {
+      buttonElement.textContent = "";
+      children.forEach((child) => buttonElement.appendChild(child));
+      originalLabel
+        ? buttonElement.setAttribute("aria-label", originalLabel)
+        : buttonElement.removeAttribute("aria-label");
+      originalTitle
+        ? buttonElement.setAttribute("title", originalTitle)
+        : buttonElement.removeAttribute("title");
+      buttonElement.removeAttribute("data-copying");
+    }, 2000);
+  } catch (err) {
+    console.error("Failed to copy:", err);
+    showToast(elements, "Failed to copy", "error");
+    buttonElement.removeAttribute("data-copying");
+  }
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -702,6 +702,7 @@
 
     <div class="toast" id="toast" role="status" aria-live="polite"></div>
 
+    <script src="popup-render.js"></script>
     <script src="popup.js"></script>
   </body>
 </html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -50,7 +50,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     });
     state.currentTab = tab;
 
-    updatePageInfo(tab);
+    updatePageInfo(elements, tab);
     await requestDetections(tab);
     loadStats();
     setupEventListeners();
@@ -94,47 +94,18 @@ document.addEventListener("DOMContentLoaded", async () => {
   async function saveSettings() {
     const endpoint = elements.apiEndpoint.value.trim();
     if (!validateApiEndpoint(endpoint, true)) {
-      showToast("Please enter a valid API endpoint", "error");
+      showToast(elements, "Please enter a valid API endpoint", "error");
       return;
     }
 
     state.settings.apiEndpoint = endpoint;
     await chrome.storage.sync.set({ apiEndpoint: endpoint });
-    showToast("Settings saved!", "success");
+    showToast(elements, "Settings saved!", "success");
     toggleSettings();
   }
 
-  function updatePageInfo(tab) {
-    elements.pageTitle.textContent = tab.title || "Unknown";
-    try {
-      elements.pageUrl.textContent = new URL(tab.url).hostname;
-    } catch {
-      elements.pageUrl.textContent = "Invalid URL";
-    }
-    let faviconSet = false;
-    if (tab.favIconUrl) {
-      try {
-        const faviconUrl = new URL(tab.favIconUrl);
-        if (
-          faviconUrl.protocol === "http:" ||
-          faviconUrl.protocol === "https:"
-        ) {
-          const img = document.createElement("img");
-          img.src = faviconUrl.href;
-          img.width = img.height = 32;
-          img.style.borderRadius = "6px";
-          img.alt = "";
-          elements.favicon.textContent = "";
-          elements.favicon.appendChild(img);
-          faviconSet = true;
-        }
-      } catch {}
-    }
-    if (!faviconSet) elements.favicon.textContent = "🌐";
-  }
-
   async function requestDetections(tab) {
-    updateScanStatus("scanning", "Scanning for referral codes...");
+    updateScanStatus(elements, "scanning", "Scanning for referral codes...");
     try {
       const results = await chrome.scripting.executeScript({
         target: { tabId: tab.id },
@@ -155,105 +126,19 @@ document.addEventListener("DOMContentLoaded", async () => {
 
       if (response?.referrals?.length > 0) {
         state.detections = response.referrals;
-        showDetections(response.referrals);
+        showDetections(state, elements, response.referrals);
       } else {
-        showNoDetections();
+        showNoDetections(elements);
       }
     } catch (error) {
       console.error("Error getting detections:", error);
-      showNoDetections();
+      showNoDetections(elements);
     }
-  }
-
-  function showDetections(detections) {
-    elements.detectionsSection.style.display = "block";
-    updateScanStatus(
-      "found",
-      `${detections.length} referral code${detections.length > 1 ? "s" : ""} found`,
-    );
-    elements.detectionList.textContent = "";
-
-    detections.forEach((d, i) => {
-      const item = document.createElement("button");
-      item.type = "button";
-      item.className = "detection-item";
-      item.dataset.index = i.toString();
-      item.setAttribute("aria-pressed", i === 0 ? "true" : "false");
-
-      const info = document.createElement("div");
-      info.className = "detection-info";
-
-      const codeValue = document.createElement("span");
-      codeValue.className = "code-value";
-      codeValue.textContent = d.code;
-
-      const codeSource = document.createElement("span");
-      codeSource.className = "code-source";
-      codeSource.textContent = d.source.replaceAll("_", " ");
-
-      info.appendChild(codeValue);
-      info.appendChild(codeSource);
-
-      const confidence = document.createElement("span");
-      confidence.className = "confidence";
-      confidence.textContent = `${Math.round(d.confidence * 100)}%`;
-
-      item.appendChild(info);
-      item.appendChild(confidence);
-
-      item.addEventListener("click", () => {
-        elements.detectionList
-          .querySelectorAll(".detection-item")
-          .forEach((el) => {
-            el.classList.remove("selected");
-            el.setAttribute("aria-pressed", "false");
-          });
-        item.classList.add("selected");
-        item.setAttribute("aria-pressed", "true");
-        state.selectedDetection =
-          state.detections[parseInt(item.dataset.index)];
-      });
-
-      elements.detectionList.appendChild(item);
-    });
-
-    if (detections.length > 0) {
-      const firstItem = elements.detectionList.querySelector(".detection-item");
-      if (firstItem) {
-        firstItem.classList.add("selected");
-        firstItem.setAttribute("aria-pressed", "true");
-        state.selectedDetection = detections[0];
-        elements.captureBtn.focus();
-      }
-    }
-  }
-
-  function showNoDetections() {
-    elements.detectionsSection.style.display = "none";
-    updateScanStatus("none", "No referral codes detected on this page");
-    elements.manualCode.focus();
-  }
-
-  function updateScanStatus(status, text) {
-    const indClass =
-      status === "found"
-        ? "found"
-        : status === "scanning"
-          ? "scanning"
-          : "none";
-    elements.scanStatus.textContent = "";
-    const indicator = document.createElement("div");
-    indicator.className = `status-indicator ${indClass}`;
-    const statusText = document.createElement("span");
-    statusText.className = "status-text";
-    statusText.textContent = text;
-    elements.scanStatus.appendChild(indicator);
-    elements.scanStatus.appendChild(statusText);
   }
 
   async function captureSelected() {
     if (!state.selectedDetection) {
-      showToast("Please select a referral code first", "error");
+      showToast(elements, "Please select a referral code first", "error");
       return;
     }
 
@@ -271,7 +156,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         confidence: state.selectedDetection.confidence,
       });
 
-      showToast("Referral code captured successfully!", "success");
+      showToast(elements, "Referral code captured successfully!", "success");
       incrementStat("captured");
       elements.captureBtn.textContent = "Captured! ✅";
       setTimeout(() => {
@@ -279,7 +164,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       }, 2000);
     } catch (err) {
       console.error("Capture error:", err);
-      showToast(`Failed to capture: ${err.message}`, "error");
+      showToast(elements, `Failed to capture: ${err.message}`, "error");
       elements.captureBtn.textContent = "✨ Capture Selected";
     } finally {
       elements.captureBtn.disabled = false;
@@ -305,7 +190,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         confidence: 1.0,
       });
 
-      showToast("Code added manually!", "success");
+      showToast(elements, "Code added manually!", "success");
       elements.manualCode.value = "";
       incrementStat("captured");
       elements.manualBtn.textContent = "Added! ✅";
@@ -313,7 +198,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         elements.manualBtn.textContent = "Add Code Manually";
       }, 2000);
     } catch (err) {
-      showToast(`Failed to add: ${err.message}`, "error");
+      showToast(elements, `Failed to add: ${err.message}`, "error");
       elements.manualBtn.textContent = "Add Code Manually";
     } finally {
       elements.manualBtn.disabled = false;
@@ -372,51 +257,6 @@ document.addEventListener("DOMContentLoaded", async () => {
     document.getElementById(`stat-${key}`).textContent = value;
   }
 
-  function showToast(message, type = "") {
-    elements.toast.textContent = message;
-    elements.toast.className = `toast ${type} show`;
-    setTimeout(() => elements.toast.classList.remove("show"), 3000);
-  }
-
-  async function copyToClipboard(text, buttonElement) {
-    if (!text || buttonElement.dataset.copying === "true") return;
-
-    const originalLabel = buttonElement.getAttribute("aria-label");
-    const originalTitle = buttonElement.getAttribute("title");
-
-    try {
-      buttonElement.dataset.copying = "true";
-      await navigator.clipboard.writeText(text);
-      showToast("Copied to clipboard!", "success");
-
-      const children = Array.from(buttonElement.children);
-      buttonElement.textContent = "";
-      const span = document.createElement("span");
-      span.setAttribute("aria-hidden", "true");
-      span.textContent = "✅";
-      buttonElement.appendChild(span);
-
-      buttonElement.setAttribute("aria-label", "Copied!");
-      buttonElement.setAttribute("title", "Copied!");
-
-      setTimeout(() => {
-        buttonElement.textContent = "";
-        children.forEach((child) => buttonElement.appendChild(child));
-        originalLabel
-          ? buttonElement.setAttribute("aria-label", originalLabel)
-          : buttonElement.removeAttribute("aria-label");
-        originalTitle
-          ? buttonElement.setAttribute("title", originalTitle)
-          : buttonElement.removeAttribute("title");
-        buttonElement.removeAttribute("data-copying");
-      }, 2000);
-    } catch (err) {
-      console.error("Failed to copy:", err);
-      showToast("Failed to copy", "error");
-      buttonElement.removeAttribute("data-copying");
-    }
-  }
-
   function toggleSettings() {
     const isActive = elements.settingsPanel.classList.toggle("active");
     elements.manualSection.classList.toggle("hidden");
@@ -472,12 +312,17 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     elements.copyDetectedBtn.addEventListener("click", () => {
       if (state.selectedDetection)
-        copyToClipboard(state.selectedDetection.code, elements.copyDetectedBtn);
+        copyToClipboard(
+          elements,
+          state.selectedDetection.code,
+          elements.copyDetectedBtn,
+        );
     });
 
     elements.copyManualBtn.addEventListener("click", () => {
       const code = elements.manualCode.value.trim();
-      if (code) copyToClipboard(code.toUpperCase(), elements.copyManualBtn);
+      if (code)
+        copyToClipboard(elements, code.toUpperCase(), elements.copyManualBtn);
     });
 
     elements.settingsLink.addEventListener("click", (e) => {
@@ -502,9 +347,9 @@ document.addEventListener("DOMContentLoaded", async () => {
     elements.saveSettingsBtn.addEventListener("click", saveSettings);
 
     elements.refreshBtn.addEventListener("click", async () => {
-      updateScanStatus("scanning", "Rescanning...");
+      updateScanStatus(elements, "scanning", "Rescanning...");
       await requestDetections(state.currentTab);
-      showToast("Page rescanned", "success");
+      showToast(elements, "Page rescanned", "success");
     });
   }
 

--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -2,8 +2,27 @@
 
 **Generated**: 2026-07-06
 **Last Updated**: 2026-08-25
-**Version**: 0.17.1
-**Status**: Active — 2026-08-24 improvement run COMPLETE via PR #713: P0 correctness fixes (research-cache migration, DoH cache, telemetry batching), PipelineLock DO wired per [ADR-022](ADR-022-do-disposition-pipelinelock-first.md), EU AI Act logger live on AI paths, dead security modules removed, silent catches logged. Deferred items tracked below.
+**Version**: 0.18.0
+**Status**: Active — 2026-08-25 improvement swarm IN PROGRESS (spec: [SPEC-improvement-swarm-2026-08-25.md](SPEC-improvement-swarm-2026-08-25.md)). Prior run COMPLETE via PR #713. Deferred items tracked below.
+
+---
+
+## Improvement Run — 2026-08-25 Findings Register
+
+Fresh full-repo scan (line limits, banned patterns, dead-code recheck,
+config-as-code, KV truncation sites). Baseline: pev-gates 12/13 pass
+(only ci-workflow-validator fails = BLOCKED-3/ADR-021); `as any` = 0 in
+worker/, console.* confined to logger implementations.
+
+| ID | Finding | Priority | Workstream | Evidence |
+|:---|:---|:---|:---|:---|
+| R-1 | F-7 confirmed live: 10 KV list() call sites stop at first page (~1000 keys) — includes apikey lookup (auth.ts:112) and webhook DLQ | P2 | WS-A | auth.ts:112, storage.ts:373, delivery.ts:96,315 + 6 more |
+| R-2 | N-5 confirmed: ~55 non-null assertions in worker/ production code | P2 | WS-B (routes, ~19 sites) and WS-C (lib plus pipeline, ~36 sites) | worst: routes/core/deals.ts 8, nlq executor 5, ranking.ts 5, scoring.ts 5 |
+| R-3 | extension/popup.js 512L exceeds MAX_LINES_PER_SOURCE_FILE=500 (only remaining >500 file; orchestrator/index.ts now 438L so N-4 fully closed upstream) | P2 | WS-D | wc -l 512; loaded via plain script tag in popup.html |
+| R-4 | wrangler.jsonc lacks `"ai"` binding block while embedding-pipeline.ts uses env.AI.run — semantic search degrades where config-as-code is the deploy source | P1 | WS-F | embedding-pipeline.ts:63,69; wrangler.jsonc grep no match |
+| R-5 | Test gaps T-6/T-7/T-8 still open (SourceRegistry DO, d1/trust.ts, lib/expiration helpers have no focused coverage) | P2 | WS-E | GAP-ANALYSIS-2026-08-15 table |
+| R-6 | MI-3 re-verified 2026-08-25: ai-gateway client has zero importers outside its module — stays DEFERRED (product/cost gating decision required before wiring into NLQ paths) | P2 | deferred | grep -rln ai-gateway worker → module files only |
+
 **Sources**: [Codebase Audit (04/04)](../reports/analysis/codebase-audit-2026-04-04.md), [Swarm Analysis (04/04)](../reports/analysis/swarm-missing-implementations-2026-04-04.md), [Feature Gap Analysis](../reports/analysis/feature-gap-analysis.md), [ADR-015](ADR-015-harness-cloudflare-2026-best-practices.md)
 
 ---
@@ -87,7 +106,7 @@ Not covered by GAP-ANALYSIS-2026-08-15:
 | N-1 | Dead file worker/lib/webhook-sdk.ts (488 lines, zero imports) - parallel webhook SDK duplicating lib/webhook/* | P1 | ✅ CLOSED (deleted in PRT-6) |
 | N-2 | Dead file worker/routes/health.ts (210 lines) - duplicate of routes/core/health.ts | P1 | ✅ CLOSED (deleted with its exclusive test in PRT-6) |
 | N-3 | Parallel logging subsystems: global-logger.ts (~90 importers) vs lib/logger/* (4 modules) - divergence risk like MI-5 | P2 | ⬜ DEFERRED |
-| N-4 | Source files over 500-line limit: router/legacy-routes.ts (509), research-agent/orchestrator/index.ts (503) | P2 | 🟡 PARTIAL - legacy-routes.ts split to 472 lines during MI-1; orchestrator remains 503 |
+| N-4 | Source files over 500-line limit: router/legacy-routes.ts (509), research-agent/orchestrator/index.ts (503) | P2 | ✅ CLOSED — legacy-routes.ts split (472L); orchestrator now 438L; residual >500 file (extension/popup.js) re-registered as R-3 |
 | N-5 | 51 banned non-null assertions in worker/ (worst: routes/core/deals.ts 9, nlq/query-builder/executor.ts 6, routes/d1/deals.ts 5, lib/ranking.ts 5) | P2 | ⬜ DEFERRED (needs dedicated sweep) |
 | N-6 | 25 pre-existing unit-test failures on main (identical set on swarm branch; GitHub CI green on same commits): url-validator-impl x6, budget-allocation x5, notify x4, publish.core x3, publish.rollback x2, nlq/handlers-post x2, dependabot-patterns x2, validate x1 | P2 | ⬜ DEFERRED (dedicated fix sprint; zero regressions from PRT-6 verified by main-vs-branch diff) |
 

--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -3,7 +3,7 @@
 **Generated**: 2026-07-06
 **Last Updated**: 2026-08-25
 **Version**: 0.18.0
-**Status**: Active — 2026-08-25 improvement swarm IN PROGRESS (spec: [SPEC-improvement-swarm-2026-08-25.md](SPEC-improvement-swarm-2026-08-25.md)). Prior run COMPLETE via PR #713. Deferred items tracked below.
+**Status**: Active — 2026-08-25 improvement swarm COMPLETE on branch chore/improvement-run-2026-08-25 (spec: [SPEC-improvement-swarm-2026-08-25.md](SPEC-improvement-swarm-2026-08-25.md)). Prior run COMPLETE via PR #713. Deferred items tracked below.
 
 ---
 
@@ -14,14 +14,30 @@ config-as-code, KV truncation sites). Baseline: pev-gates 12/13 pass
 (only ci-workflow-validator fails = BLOCKED-3/ADR-021); `as any` = 0 in
 worker/, console.* confined to logger implementations.
 
-| ID | Finding | Priority | Workstream | Evidence |
+| ID | Finding | Priority | Workstream | Status |
 |:---|:---|:---|:---|:---|
-| R-1 | F-7 confirmed live: 10 KV list() call sites stop at first page (~1000 keys) — includes apikey lookup (auth.ts:112) and webhook DLQ | P2 | WS-A | auth.ts:112, storage.ts:373, delivery.ts:96,315 + 6 more |
-| R-2 | N-5 confirmed: ~55 non-null assertions in worker/ production code | P2 | WS-B (routes, ~19 sites) and WS-C (lib plus pipeline, ~36 sites) | worst: routes/core/deals.ts 8, nlq executor 5, ranking.ts 5, scoring.ts 5 |
-| R-3 | extension/popup.js 512L exceeds MAX_LINES_PER_SOURCE_FILE=500 (only remaining >500 file; orchestrator/index.ts now 438L so N-4 fully closed upstream) | P2 | WS-D | wc -l 512; loaded via plain script tag in popup.html |
-| R-4 | wrangler.jsonc lacks `"ai"` binding block while embedding-pipeline.ts uses env.AI.run — semantic search degrades where config-as-code is the deploy source | P1 | WS-F | embedding-pipeline.ts:63,69; wrangler.jsonc grep no match |
-| R-5 | Test gaps T-6/T-7/T-8 still open (SourceRegistry DO, d1/trust.ts, lib/expiration helpers have no focused coverage) | P2 | WS-E | GAP-ANALYSIS-2026-08-15 table |
-| R-6 | MI-3 re-verified 2026-08-25: ai-gateway client has zero importers outside its module — stays DEFERRED (product/cost gating decision required before wiring into NLQ paths) | P2 | deferred | grep -rln ai-gateway worker → module files only |
+| R-1 | F-7 confirmed live: 10 KV list() call sites stop at first page (~1000 keys) — includes apikey lookup (auth.ts:112) and webhook DLQ | P2 | WS-A | ✅ CLOSED — kv-pagination.ts helper + 10 sites repointed; 7 new tests; commit 270e0af |
+| R-2 | N-5 confirmed: ~55 non-null assertions in worker/ production code | P2 | WS-B (routes, ~19 sites) and WS-C (lib plus pipeline, ~36 sites) | ✅ CLOSED — zero assertions left in worker/ production code; commits 78127b2, ee01500 |
+| R-3 | extension/popup.js 512L exceeds MAX_LINES_PER_SOURCE_FILE=500 (only remaining >500 file; orchestrator/index.ts now 438L so N-4 fully closed upstream) | P2 | WS-D | ✅ CLOSED — popup.js 357L + popup-render.js 152L; playwright 22/22; commit 2d058f7 |
+| R-4 | wrangler.jsonc lacks `"ai"` binding block while embedding-pipeline.ts uses env.AI.run — semantic search degrades where config-as-code is the deploy source | P1 | WS-F | ✅ CLOSED — ai binding declared top-level + dev + production; wrangler dry-run clean; commit 0cda2c1 |
+| R-5 | Test gaps T-6/T-7/T-8 still open (SourceRegistry DO, d1/trust.ts, lib/expiration helpers have no focused coverage) | P2 | WS-E | ✅ CLOSED — 87 tests across 3 files; commit 49be5cf; 2 latent bugs documented below |
+| R-6 | MI-3 re-verified 2026-08-25: ai-gateway client has zero importers outside its module — stays DEFERRED (product/cost gating decision required before wiring into NLQ paths) | P2 | deferred | ⬜ DEFERRED |
+
+### Swarm verification summary
+
+Full suite 194 files / 2727 tests green (+115 vs baseline). pev-gates 12/13
+(only ci-workflow-validator fails = pre-existing BLOCKED-3 / ADR-021).
+tsc clean, prettier clean, markdownlint clean. Net -105 lines.
+
+### Latent bugs documented by WS-E (not fixed this run)
+
+1. `worker/lib/d1/trust.ts:159` evolveTrustBatch inserts brand-new domains
+   at hardcoded 0.5 base without applying the first adjustment (single-domain
+   evolveTrust does apply it); result reporting back-computes a wrong
+   previous_score.
+2. `worker/lib/d1/client.ts:477` executeWithRetry resolves `{error}` instead
+   of rejecting, so evolveTrust returns plausible scores even when both its
+   SELECT and INSERT fail permanently.
 
 **Sources**: [Codebase Audit (04/04)](../reports/analysis/codebase-audit-2026-04-04.md), [Swarm Analysis (04/04)](../reports/analysis/swarm-missing-implementations-2026-04-04.md), [Feature Gap Analysis](../reports/analysis/feature-gap-analysis.md), [ADR-015](ADR-015-harness-cloudflare-2026-best-practices.md)
 
@@ -41,7 +57,7 @@ scope = P0 + quick wins this run.
 | F-4 | All 3 Durable Objects have zero runtime callers; locking runs D1 CAS, staging runs KV | P1 | 🟡 PARTIAL - PipelineLock DO now PRIMARY path (D1 CAS fallback, 1s timeout guard) per [ADR-022](ADR-022-do-disposition-pipelinelock-first.md); SourceRegistry/DealRegistry deferred | lock.ts adapter + extendLock RPC; 105/105 lock tests |
 | F-5 | Dead security twins rbac.ts (291L) + refresh-tokens.ts (297L): zero importers; live paths use middleware/auth.ts and lib/auth | P1 | ✅ CLOSED - both deleted (588 lines) | ref-check clean 2026-08-24 |
 | F-6 | EU AI Act logger (453L, tested) unwired while MCP advertises eu_ai_act_compliant:true and skill docs claim compliance | P1 | ✅ CLOSED - wired into NLQ route + semantic search via compliance-log.ts; fire-and-forget with failure isolation | tests/unit/eu-ai-act-wiring.test.ts (7 passing) |
-| F-7 | KV list() single-page truncation at 8 sites (staging cleanup, webhook DLQ, apikey lookup, feature flags, cache clear) | P2 | ⬜ DEFERRED | storage.ts:290, auth.ts:112, et al. |
+| F-7 | KV list() single-page truncation at 8 sites (staging cleanup, webhook DLQ, apikey lookup, feature flags, cache clear) | P2 | ✅ CLOSED - kv-pagination.ts cursor helper applied at 10 sites (R-1, 2026-08-25 swarm) | worker/lib/kv-pagination.ts |
 | F-8 | Publish/stage re-parses full snapshots ~5x per run + double hash computation | P2 | ⬜ DEFERRED | publish.ts:63,85, storage.ts:60,87-95, stage.ts:60 |
 | F-9 | 10 bare silent catches in dashboard.ts + getSourceRegistry swallow outages from ops surfaces | P2 | ✅ CLOSED - all 10 sites log warn with error detail | dashboard.ts + storage.ts:138 |
 | F-10 | No circuit breaker on discovery fetches; sequential cron handlers stack heavy work with no resumption | P2 | ⬜ DEFERRED | discover.ts imports, scheduled.ts:69-130 |
@@ -107,7 +123,7 @@ Not covered by GAP-ANALYSIS-2026-08-15:
 | N-2 | Dead file worker/routes/health.ts (210 lines) - duplicate of routes/core/health.ts | P1 | ✅ CLOSED (deleted with its exclusive test in PRT-6) |
 | N-3 | Parallel logging subsystems: global-logger.ts (~90 importers) vs lib/logger/* (4 modules) - divergence risk like MI-5 | P2 | ⬜ DEFERRED |
 | N-4 | Source files over 500-line limit: router/legacy-routes.ts (509), research-agent/orchestrator/index.ts (503) | P2 | ✅ CLOSED — legacy-routes.ts split (472L); orchestrator now 438L; residual >500 file (extension/popup.js) re-registered as R-3 |
-| N-5 | 51 banned non-null assertions in worker/ (worst: routes/core/deals.ts 9, nlq/query-builder/executor.ts 6, routes/d1/deals.ts 5, lib/ranking.ts 5) | P2 | ⬜ DEFERRED (needs dedicated sweep) |
+| N-5 | 51 banned non-null assertions in worker/ (worst: routes/core/deals.ts 9, nlq/query-builder/executor.ts 6, routes/d1/deals.ts 5, lib/ranking.ts 5) | P2 | ✅ CLOSED - all eliminated via guards/bindings in 2026-08-25 swarm (R-2); commits 78127b2 + ee01500 | zero grep matches in worker/ production code |
 | N-6 | 25 pre-existing unit-test failures on main (identical set on swarm branch; GitHub CI green on same commits): url-validator-impl x6, budget-allocation x5, notify x4, publish.core x3, publish.rollback x2, nlq/handlers-post x2, dependabot-patterns x2, validate x1 | P2 | ⬜ DEFERRED (dedicated fix sprint; zero regressions from PRT-6 verified by main-vs-branch diff) |
 
 Supporting evidence: lint = tsc+prettier only (no ESLint gate), so banned
@@ -137,9 +153,9 @@ recorded in [GAP-ANALYSIS-2026-08-15.md](GAP-ANALYSIS-2026-08-15.md). Summary:
 | T-3 | NLQ AI enhancer + hybrid classifier untested | ⬜ OPEN |
 | T-4 | Validation scraper internals (`change-detector`, `html-extractor`, `batch-processor`) untested | ⬜ OPEN |
 | T-5 | MCP progress + SSE streaming untested | ⬜ OPEN |
-| T-6 | SourceRegistry DO untested (only KV `lib/storage` covered) | ⬜ OPEN |
-| T-7 | D1 `trust.ts` has no direct tests | ⬜ OPEN |
-| T-8 | Modular `lib/expiration/*` helpers lack focused coverage | ⬜ OPEN |
+| T-6 | SourceRegistry DO untested (only KV `lib/storage` covered) | ✅ CLOSED (25 tests, 2026-08-25 swarm R-5) |
+| T-7 | D1 `trust.ts` has no direct tests | ✅ CLOSED (27 tests, 2026-08-25 swarm R-5; 2 latent bugs documented) |
+| T-8 | Modular `lib/expiration/*` helpers lack focused coverage | ✅ CLOSED (35 tests, 2026-08-25 swarm R-5) |
 
 Full evidence and remediation notes: [GAP-ANALYSIS-2026-08-15.md](GAP-ANALYSIS-2026-08-15.md).
 

--- a/plans/PROGRESS-2026-08-25.md
+++ b/plans/PROGRESS-2026-08-25.md
@@ -38,3 +38,36 @@ DealRegistry DO disposition.
 
 All GitHub checks green including Codacy (0 issues on final commit).
 Local: tsc clean, full unit suite green, prettier/markdownlint clean.
+
+---
+
+# Improvement Swarm — 2026-08-25 (afternoon)
+
+**Branch**: chore/improvement-run-2026-08-25
+**Spec**: SPEC-improvement-swarm-2026-08-25.md
+**Orchestrator**: goap-agent skill, 5-agent parallel swarm (disjoint scopes)
+
+## Delivered
+
+| WS | Item | Commit |
+|----|------|--------|
+| - | Spec + GOAP_STATE v0.18.0 findings register | d7a6c17 |
+| A | F-7 closed: kv-pagination.ts cursor helper, 10 list sites repaginated | 270e0af |
+| B | N-5 routes: 20 non-null assertions replaced with guards/bindings | 78127b2 |
+| C | N-5 lib+pipeline: 35 assertions eliminated across 17 files | ee01500 |
+| D | popup.js 512 to 357 lines; render helpers extracted (152L) | 2d058f7 |
+| E | T-6/T-7/T-8: 87 focused tests (source-registry, d1-trust, expiration) | 49be5cf |
+| F | wrangler.jsonc declares AI binding used by embedding pipeline | 0cda2c1 |
+
+## Findings surfaced
+
+1. trust.ts evolveTrustBatch never applies first adjustment to new domains.
+2. d1 client executeWithRetry resolves {error} instead of rejecting, so
+   evolveTrust can fabricate plausible scores on permanent write failure.
+
+## Verification
+
+Full unit suite 194 files / 2727 tests green (+115 vs baseline).
+pev-gates 12/13 (ci-workflow-validator = pre-existing BLOCKED-3/ADR-021).
+tsc clean, prettier clean, markdownlint clean, wrangler dry-run clean.
+Net -105 lines; zero as-any introduced; all files under 500 lines.

--- a/plans/SPEC-improvement-swarm-2026-08-25.md
+++ b/plans/SPEC-improvement-swarm-2026-08-25.md
@@ -1,0 +1,61 @@
+# PEV Spec — Improvement Swarm 2026-08-25
+
+## Task
+
+**Title**: Improvement swarm — KV pagination, non-null assertion sweep, popup split, wrangler AI binding, test-gap coverage
+**Author**: ox-alpha (GOAP orchestrator)
+**Date**: 2026-08-25
+**Priority**: high
+
+## Goal
+
+Close the highest-value open inventory items (F-7, N-5, F-12 ai-block + popup residual, T-6/T-7/T-8) via a parallel agent swarm with disjoint file scopes.
+
+## Approach
+
+Five parallel workstreams on one branch, each verified by typecheck plus targeted unit tests; orchestrator commits each workstream atomically after independent review of its diff.
+
+## Non-Goals
+
+- [ ] Not wiring AI Gateway into NLQ (MI-3 stays deferred — product/cost decision)
+- [ ] Not adding circuit breaker to discovery (F-10 stays deferred — fail-open/closed design needed)
+- [ ] Not unifying logging subsystems (N-3), not deduping D1 route boilerplate (F-12 remainder), not touching tsconfig strict flags (F-11)
+- [ ] Not editing worker/config.ts, worker/index.ts, or worker/lib/security.ts
+
+## Steps
+
+| Step | Description | Files Touched | Risk |
+|------|-------------|---------------|------|
+| WS-A | KV list cursor-pagination helper + apply at 10 truncation sites | worker/lib/kv-pagination.ts (new), routes/dashboard.ts, routes/core/health.ts, lib/feature-flags.ts, lib/cache.ts, lib/webhook/delivery.ts, lib/logger/query.ts, lib/rate-limit-kv.ts, lib/storage.ts, lib/auth.ts, tests/unit/kv-pagination.test.ts (new) | medium |
+| WS-B | Replace banned non-null assertions in route files (~19 sites) | routes/core/deals.ts, routes/d1/deals.ts, routes/core/pipeline.ts, routes/core/analytics.ts, routes/bulk/export.ts, routes/referrals.ts | medium |
+| WS-C | Replace banned non-null assertions in lib and pipeline files (~36 sites) | nlq/query-builder/executor.ts, ranking.ts, categorization/scoring.ts, jwt.ts, webhook/sync-executor.ts, pipeline/dedupe.ts, circuit-breaker.ts, middleware/pipeline.ts, search/embedding-pipeline.ts, referral-storage/search.ts, validation/code-validator.ts, validation/url-validator.ts, crypto.ts, config-utils.ts, validation/scrapers/batch-processor.ts, scheduled.ts, pipeline-executor.ts | medium |
+| WS-D | Split extension/popup.js under 500 lines (no build step; add second script tag) | extension/popup.js, extension/popup-render.js (new), extension/popup.html | low |
+| WS-E | Focused tests: SourceRegistry DO, D1 trust.ts, lib/expiration helpers | tests/unit/source-registry.test.ts, tests/unit/d1-trust.test.ts, tests/unit/expiration-helpers.test.ts (all new) | low |
+| WS-F | Declare Workers AI binding in wrangler.jsonc (env.AI used by embedding-pipeline) | wrangler.jsonc | low |
+
+## Acceptance Criteria
+
+- [ ] All KV list() call sites iterate cursors until done (bounded loop cap)
+- [ ] Zero non-null assertions remain in the files listed above (string-literal false positives excluded)
+- [ ] extension/popup.js and all extracted chunks <= 500 lines
+- [ ] wrangler.jsonc declares `"ai": { "binding": "AI" }`
+- [ ] New test files pass; full unit suite green (no regressions vs baseline)
+- [ ] `npx tsc --noEmit` clean; `npm run fmt:check` clean; `npm run lint:md` clean
+- [ ] No file exceeds 500 lines; no `as any` introduced; no comments unless required
+
+## Risk Assessment
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Pagination helper changes auth/apikey lookup behavior | high | Bounded loop identical semantics; existing auth tests must stay green |
+| Assertion replacements alter edge-case control flow | medium | Explicit guards throwing typed errors; 2600-test suite as regression net |
+| Parallel agents race shared state | medium | Disjoint file scopes; agents never commit; orchestrator serializes commits |
+| popup.js split breaks extension | medium | Plain script-tag extraction only; no manifest changes beyond none needed |
+
+## Dependencies
+
+- Baseline pev-gates green except documented BLOCKED-3 gate (verified 2026-08-25)
+
+## Out of Scope for This Spec
+
+- MI-3 AI Gateway wiring, F-8 snapshot pass-through, F-10 discovery breaker, F-11 tsconfig flags, F-12 D1 boilerplate dedupe, SourceRegistry/DealRegistry stage-publish disposition

--- a/tests/unit/d1-trust.test.ts
+++ b/tests/unit/d1-trust.test.ts
@@ -1,0 +1,498 @@
+/**
+ * Unit tests for worker/lib/d1/trust.ts
+ *
+ * Covers evolveTrust, evolveTrustBatch, getTrustScore, getTrustScores,
+ * getTopTrustedDomains, and getDomainsNeedingReview: base-score defaults,
+ * min/max clamping, classification boundaries, batch statement construction,
+ * empty-input no-ops, and graceful degradation on failed queries.
+ *
+ * A stateful in-memory D1 double is used so repeated evolutions accumulate
+ * against real stored rows instead of canned responses.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { D1Database } from "@cloudflare/workers-types";
+import {
+  evolveTrust,
+  evolveTrustBatch,
+  getTrustScore,
+  getTrustScores,
+  getTopTrustedDomains,
+  getDomainsNeedingReview,
+} from "../../worker/lib/d1/trust";
+
+// ============================================================================
+// Stateful recording mock
+// ============================================================================
+
+interface RecordedQuery {
+  sql: string;
+  params: unknown[];
+}
+
+interface StoredTrustRow {
+  domain: string;
+  trust_score: number;
+  total_deals: number;
+  successful_deals: number;
+}
+
+const TRUST_MIN = 0;
+const TRUST_MAX = 1;
+
+function createTrustDb(
+  rows: StoredTrustRow[] = [],
+  options: { readbackMisses?: string[] } = {},
+) {
+  const queries: RecordedQuery[] = [];
+  const readbackMisses = options.readbackMisses ?? [];
+
+  function selectRows(sql: string, params: unknown[]): StoredTrustRow[] {
+    if (sql.includes("WHERE domain IN (")) {
+      const wanted = params.map(String);
+      return rows.filter((r) => wanted.includes(r.domain));
+    }
+    if (sql.includes("WHERE domain = ?")) {
+      const matched = rows.filter((r) => r.domain === params[0]);
+      // Simulate a replica lag where freshly written rows are invisible.
+      if (sql.includes("SELECT trust_score")) {
+        return matched.filter((r) => !readbackMisses.includes(r.domain));
+      }
+      return matched;
+    }
+    return [...rows];
+  }
+
+  function applyUpsert(sql: string, params: unknown[]) {
+    // Single-statement upsert (evolveTrust): explicit score is bound.
+    // [domain, newScore, successInc, classification, now, ...]
+    if (sql.includes("VALUES (?, ?")) {
+      const [domain, newScore, successInc] = params;
+      const existing = rows.find((r) => r.domain === domain);
+      if (existing) {
+        existing.trust_score = Number(newScore);
+        existing.total_deals += 1;
+        existing.successful_deals += Number(successInc);
+      } else {
+        rows.push({
+          domain: String(domain),
+          trust_score: Number(newScore),
+          total_deals: 1,
+          successful_deals: Number(successInc),
+        });
+      }
+      return;
+    }
+
+    // Batch upsert (evolveTrustBatch): score evolves from the stored value.
+    // [domain, successInc, now, adjustment, successInc, adjustment, adjustment, now]
+    const [domain, successInc, , adjustment] = params;
+    const existing = rows.find((r) => r.domain === domain);
+    if (existing) {
+      existing.trust_score = Math.max(
+        TRUST_MIN,
+        Math.min(TRUST_MAX, existing.trust_score + Number(adjustment)),
+      );
+      existing.total_deals += 1;
+      existing.successful_deals += Number(successInc);
+    } else {
+      rows.push({
+        domain: String(domain),
+        trust_score: 0.5,
+        total_deals: 1,
+        successful_deals: Number(successInc),
+      });
+    }
+  }
+
+  const makeBound = (sql: string, params: unknown[]) => ({
+    run: vi.fn(async () => {
+      if (sql.includes("INSERT INTO trust_scores")) {
+        applyUpsert(sql, params);
+        return { results: [], meta: { changes: 1 } };
+      }
+      return { results: selectRows(sql, params), meta: {} };
+    }),
+    first: vi.fn(async <T>() => {
+      const found = selectRows(sql, params)[0];
+      return (found as T | undefined) ?? null;
+    }),
+  });
+
+  const prepare = vi.fn((sql: string) => {
+    const root = makeBound(sql, []);
+    return {
+      bind: (...params: unknown[]) => {
+        queries.push({ sql, params });
+        return makeBound(sql, params);
+      },
+      run: root.run,
+      first: root.first,
+    };
+  });
+
+  const batch = vi.fn(
+    async (statements: Array<{ run: () => Promise<unknown> }>) => {
+      const results = [];
+      for (const stmt of statements) {
+        results.push(await stmt.run());
+      }
+      return results;
+    },
+  );
+
+  const db = { prepare, batch } as unknown as D1Database;
+
+  return { db, rows, queries, prepare, batch };
+}
+
+function seedRow(overrides: Partial<StoredTrustRow> = {}): StoredTrustRow {
+  return {
+    domain: "seeded.example.com",
+    trust_score: 0.5,
+    total_deals: 0,
+    successful_deals: 0,
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("d1/trust", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ==========================================================================
+  // evolveTrust
+  // ==========================================================================
+
+  describe("evolveTrust", () => {
+    it("defaults a new domain to the 0.5 base and applies +0.05 on success", async () => {
+      const rec = createTrustDb();
+
+      const result = await evolveTrust(rec.db, "new.example.com", true);
+
+      expect(result).toEqual({
+        domain: "new.example.com",
+        previous_score: 0.5,
+        new_score: 0.55,
+        adjustment: 0.05,
+        total_deals: 1,
+        successful_deals: 1,
+      });
+    });
+
+    it("applies -0.02 to a new domain on failure", async () => {
+      const rec = createTrustDb();
+
+      const result = await evolveTrust(rec.db, "new.example.com", false);
+
+      expect(result.previous_score).toBe(0.5);
+      expect(result.new_score).toBeCloseTo(0.48, 10);
+      expect(result.adjustment).toBe(-0.02);
+      expect(result.successful_deals).toBe(0);
+    });
+
+    it("reads the previous score from storage for an existing domain", async () => {
+      const rec = createTrustDb([
+        seedRow({ domain: "known.example.com", trust_score: 0.6 }),
+      ]);
+
+      const result = await evolveTrust(rec.db, "known.example.com", true);
+
+      expect(result.previous_score).toBe(0.6);
+      expect(result.new_score).toBeCloseTo(0.65, 10);
+    });
+
+    it("clamps at the maximum score of 1.0", async () => {
+      const rec = createTrustDb([seedRow({ trust_score: 0.99 })]);
+
+      const result = await evolveTrust(rec.db, "seeded.example.com", true);
+
+      expect(result.new_score).toBe(1);
+    });
+
+    it("clamps at the minimum score of 0.0", async () => {
+      const rec = createTrustDb([seedRow({ trust_score: 0.01 })]);
+
+      const result = await evolveTrust(rec.db, "seeded.example.com", false);
+
+      expect(result.new_score).toBe(0);
+    });
+
+    it("accumulates deterministically across repeated calls", async () => {
+      const rec = createTrustDb();
+      await evolveTrust(rec.db, "acc.example.com", true);
+      await evolveTrust(rec.db, "acc.example.com", false);
+
+      const third = await evolveTrust(rec.db, "acc.example.com", true);
+
+      expect(third.total_deals).toBe(3);
+      expect(third.successful_deals).toBe(2);
+      expect(third.previous_score).toBeCloseTo(0.53, 10);
+      expect(third.new_score).toBeCloseTo(0.58, 10);
+    });
+
+    it("classifies trusted at exactly 0.7 in the written statement", async () => {
+      const rec = createTrustDb([seedRow({ trust_score: 0.68 })]);
+
+      await evolveTrust(rec.db, "seeded.example.com", true);
+
+      const write = rec.queries.find((q) =>
+        q.sql.includes("INSERT INTO trust_scores"),
+      );
+      expect(write?.params[3]).toBe("trusted");
+    });
+
+    it("classifies probationary between 0.4 and 0.7 in the written statement", async () => {
+      const rec = createTrustDb([seedRow({ trust_score: 0.44 })]);
+
+      await evolveTrust(rec.db, "seeded.example.com", true);
+
+      const write = rec.queries.find((q) =>
+        q.sql.includes("INSERT INTO trust_scores"),
+      );
+      expect(write?.params[3]).toBe("probationary");
+    });
+
+    it("writes an upsert with ON CONFLICT(domain)", async () => {
+      const rec = createTrustDb();
+
+      await evolveTrust(rec.db, "upsert.example.com", true);
+
+      const write = rec.queries.find((q) =>
+        q.sql.includes("INSERT INTO trust_scores"),
+      );
+      expect(write?.sql).toContain("ON CONFLICT(domain) DO UPDATE");
+    });
+
+    it("passes an empty domain through without validation", async () => {
+      const rec = createTrustDb();
+
+      const result = await evolveTrust(rec.db, "", true);
+
+      expect(result.domain).toBe("");
+      expect(result.new_score).toBeCloseTo(0.55, 10);
+    });
+  });
+
+  // ==========================================================================
+  // evolveTrustBatch
+  // ==========================================================================
+
+  describe("evolveTrustBatch", () => {
+    it("executes one bound statement per domain in a single batch", async () => {
+      const rec = createTrustDb();
+
+      await evolveTrustBatch(rec.db, [
+        { domain: "a.example.com", success: true },
+        { domain: "b.example.com", success: false },
+      ]);
+
+      expect(rec.batch).toHaveBeenCalledTimes(1);
+      const inserts = rec.queries.filter((q) =>
+        q.sql.includes("INSERT INTO trust_scores"),
+      );
+      expect(inserts).toHaveLength(2);
+      expect(inserts.map((q) => q.params[0])).toEqual([
+        "a.example.com",
+        "b.example.com",
+      ]);
+    });
+
+    it("issues no statements and returns no results for empty input", async () => {
+      const rec = createTrustDb();
+
+      const results = await evolveTrustBatch(rec.db, []);
+
+      expect(results).toEqual([]);
+      expect(rec.batch).toHaveBeenCalledTimes(1);
+      expect(rec.queries).toHaveLength(0);
+    });
+
+    it("reports post-batch scores read back from storage", async () => {
+      const rec = createTrustDb([seedRow()]);
+
+      const results = await evolveTrustBatch(rec.db, [
+        { domain: "seeded.example.com", success: true },
+      ]);
+
+      expect(results[0]?.domain).toBe("seeded.example.com");
+      expect(results[0]?.new_score).toBeCloseTo(0.55, 10);
+      expect(results[0]?.previous_score).toBeCloseTo(0.5, 10);
+      expect(results[0]?.total_deals).toBe(1);
+      expect(results[0]?.successful_deals).toBe(1);
+    });
+
+    it("defaults missing post-batch rows to base values", async () => {
+      const rec = createTrustDb([], {
+        readbackMisses: ["ghost.example.com"],
+      });
+
+      const results = await evolveTrustBatch(rec.db, [
+        { domain: "ghost.example.com", success: true },
+      ]);
+
+      expect(results[0]?.previous_score).toBe(0.5);
+      expect(results[0]?.new_score).toBe(0.5);
+      expect(results[0]?.successful_deals).toBe(1);
+    });
+
+    it("lands a brand-new batched domain at the 0.5 insert base, not the adjusted score", async () => {
+      const rec = createTrustDb();
+
+      const results = await evolveTrustBatch(rec.db, [
+        { domain: "fresh.example.com", success: true },
+      ]);
+
+      expect(results[0]?.adjustment).toBe(0.05);
+      expect(results[0]?.new_score).toBeCloseTo(0.5, 10);
+    });
+
+    it("evolves an existing batched domain relative to its stored score", async () => {
+      const rec = createTrustDb([seedRow({ trust_score: 0.6 })]);
+
+      const results = await evolveTrustBatch(rec.db, [
+        { domain: "seeded.example.com", success: false },
+      ]);
+
+      expect(results[0]?.new_score).toBeCloseTo(0.58, 10);
+      expect(results[0]?.successful_deals).toBe(0);
+    });
+  });
+
+  // ==========================================================================
+  // getTrustScore / getTrustScores
+  // ==========================================================================
+
+  describe("getTrustScore", () => {
+    it("returns the stored row for a known domain", async () => {
+      const rec = createTrustDb([
+        seedRow({ trust_score: 0.72, total_deals: 9, successful_deals: 8 }),
+      ]);
+
+      const result = await getTrustScore(rec.db, "seeded.example.com");
+
+      expect(result?.trust_score).toBe(0.72);
+      expect(result?.total_deals).toBe(9);
+      expect(result?.successful_deals).toBe(8);
+    });
+
+    it("returns null when the domain is absent", async () => {
+      const rec = createTrustDb();
+
+      const result = await getTrustScore(rec.db, "missing.example.com");
+
+      expect(result).toBeNull();
+    });
+
+    it("degrades to null when the query fails permanently", async () => {
+      const rec = createTrustDb();
+      vi.spyOn(rec.db, "prepare").mockImplementation(() => {
+        throw new Error("no such table: trust_scores");
+      });
+
+      const result = await getTrustScore(rec.db, "any.example.com");
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("getTrustScores", () => {
+    it("returns an empty map without querying for empty input", async () => {
+      const rec = createTrustDb();
+
+      const result = await getTrustScores(rec.db, []);
+
+      expect(result.size).toBe(0);
+      expect(rec.queries).toHaveLength(0);
+    });
+
+    it("maps only the domains that exist", async () => {
+      const rec = createTrustDb([
+        seedRow({ domain: "a.example.com" }),
+        seedRow({ domain: "b.example.com" }),
+      ]);
+
+      const result = await getTrustScores(rec.db, [
+        "a.example.com",
+        "b.example.com",
+        "missing.example.com",
+      ]);
+
+      expect(result.size).toBe(2);
+      expect(result.has("a.example.com")).toBe(true);
+      expect(result.has("b.example.com")).toBe(true);
+      expect(result.has("missing.example.com")).toBe(false);
+    });
+  });
+
+  // ==========================================================================
+  // getTopTrustedDomains / getDomainsNeedingReview
+  // ==========================================================================
+
+  describe("getTopTrustedDomains", () => {
+    it("filters to trusted classifications and applies the limit", async () => {
+      const rec = createTrustDb();
+
+      await getTopTrustedDomains(rec.db, 5);
+
+      const sql = rec.queries[0]?.sql ?? "";
+      expect(sql).toContain("classification = 'trusted'");
+      expect(sql).toContain("LIMIT ?");
+      expect(rec.queries[0]?.params).toEqual([5]);
+    });
+
+    it("defaults the limit to 10", async () => {
+      const rec = createTrustDb();
+
+      await getTopTrustedDomains(rec.db);
+
+      expect(rec.queries[0]?.params).toEqual([10]);
+    });
+
+    it("returns the rows found in storage", async () => {
+      const rec = createTrustDb([
+        seedRow({ trust_score: 0.95 }),
+        seedRow({ trust_score: 0.85 }),
+      ]);
+
+      const result = await getTopTrustedDomains(rec.db, 2);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]?.trust_score).toBe(0.95);
+    });
+  });
+
+  describe("getDomainsNeedingReview", () => {
+    it("targets low scores or high failure rates and binds the threshold", async () => {
+      const rec = createTrustDb();
+
+      await getDomainsNeedingReview(rec.db, 0.25);
+
+      const sql = rec.queries[0]?.sql ?? "";
+      expect(sql).toContain("trust_score < 0.3");
+      expect(sql).toContain("successful_deals * 1.0 / total_deals < ?");
+      expect(rec.queries[0]?.params).toEqual([0.25]);
+    });
+
+    it("defaults the failure threshold to 0.3", async () => {
+      const rec = createTrustDb();
+
+      await getDomainsNeedingReview(rec.db);
+
+      expect(rec.queries[0]?.params).toEqual([0.3]);
+    });
+
+    it("returns an empty array when nothing needs review", async () => {
+      const rec = createTrustDb();
+
+      const result = await getDomainsNeedingReview(rec.db);
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/tests/unit/expiration-helpers.test.ts
+++ b/tests/unit/expiration-helpers.test.ts
@@ -1,0 +1,485 @@
+/**
+ * Unit tests for worker/lib/expiration helper functions.
+ *
+ * Covers the pure helpers isExpiringSoon and calculateExpiryUrgency with
+ * exact boundary timestamps and malformed dates, plus the KV-backed
+ * scheduling helpers (stats, validation results, notified-deal tracking)
+ * with a fixed system clock for determinism.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  isExpiringSoon,
+  calculateExpiryUrgency,
+  getValidationStats,
+  getLastValidationResults,
+} from "../../worker/lib/expiration";
+import {
+  scheduleExpiryCheck,
+  storeValidationStats,
+  getNotifiedExpiringDeals,
+  recordNotifiedExpiringDeals,
+  EXPIRY_CHECK_KEY,
+  VALIDATION_STATS_KEY,
+  NOTIFIED_EXPIRING_KEY,
+  LAST_VALIDATION_KEY,
+} from "../../worker/lib/expiration/scheduling";
+import type { Deal, Env } from "../../worker/types";
+
+// ============================================================================
+// Fixed clock and test fixtures
+// ============================================================================
+
+const NOW = new Date("2026-06-01T12:00:00.000Z");
+
+function isoAt(offsetMs: number): string {
+  return new Date(NOW.getTime() + offsetMs).toISOString();
+}
+
+type DealOverrides = Partial<Deal> & { expiryDate?: string };
+
+function createDeal(overrides: DealOverrides = {}): Deal {
+  const { expiryDate, ...rest } = overrides;
+  const deal: Deal = {
+    id: "deal-1",
+    source: {
+      url: "https://example.com/invite",
+      domain: "example.com",
+      discovered_at: "2026-05-01T00:00:00Z",
+      trust_score: 0.7,
+    },
+    title: "Test Deal",
+    description: "Test description",
+    code: "CODE123",
+    url: "https://example.com/invite/CODE123",
+    reward: { type: "cash", value: 50, currency: "USD" },
+    expiry: {
+      date: isoAt(30 * DAY_MS),
+      confidence: 0.8,
+      type: "soft",
+    },
+    metadata: {
+      category: ["test"],
+      tags: ["test"],
+      normalized_at: "2026-05-01T00:00:00Z",
+      confidence_score: 0.8,
+      status: "active",
+    },
+    ...rest,
+  };
+  if (expiryDate !== undefined) {
+    deal.expiry = { ...deal.expiry, date: expiryDate };
+  }
+  return deal;
+}
+
+interface KvBacking {
+  get<T>(key: string, type?: string): Promise<T | null>;
+  put(key: string, value: string): Promise<void>;
+}
+
+function createMockEnv(): { env: Env; kv: Map<string, string> } {
+  const kv = new Map<string, string>();
+  const backing: KvBacking = {
+    async get<T>(key: string, type?: string) {
+      const value = kv.get(key);
+      if (value === undefined) return null;
+      if (type === "json") return JSON.parse(value) as T;
+      return value as T;
+    },
+    async put(key: string, value: string) {
+      kv.set(key, value);
+    },
+  };
+  const env = { DEALS_PROD: backing } as unknown as Env;
+  return { env, kv };
+}
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("expiration helpers", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // ==========================================================================
+  // isExpiringSoon
+  // ==========================================================================
+
+  describe("isExpiringSoon", () => {
+    it("returns true for an active deal inside the window", () => {
+      const deal = createDeal({ expiryDate: isoAt(5 * DAY_MS) });
+      expect(isExpiringSoon(deal, 7)).toBe(true);
+    });
+
+    it("returns false when the deal expires beyond the window", () => {
+      const deal = createDeal({ expiryDate: isoAt(8 * DAY_MS) });
+      expect(isExpiringSoon(deal, 7)).toBe(false);
+    });
+
+    it("returns true when days-until-expiry equals the window exactly", () => {
+      const deal = createDeal({ expiryDate: isoAt(7 * DAY_MS - HOUR_MS) });
+      expect(isExpiringSoon(deal, 7)).toBe(true);
+    });
+
+    it("rounds fractional days up before comparing", () => {
+      const deal = createDeal({ expiryDate: isoAt(2 * DAY_MS + 1) });
+      expect(isExpiringSoon(deal, 3)).toBe(true);
+      expect(isExpiringSoon(deal, 2)).toBe(false);
+    });
+
+    it("returns false for an already expired deal even with a wide window", () => {
+      const deal = createDeal({ expiryDate: isoAt(-5 * DAY_MS) });
+      expect(isExpiringSoon(deal, 365)).toBe(false);
+    });
+
+    it("returns false at exactly the expiry instant", () => {
+      const deal = createDeal({ expiryDate: NOW.toISOString() });
+      expect(isExpiringSoon(deal, 30)).toBe(false);
+    });
+
+    it("returns false when the deal has no expiry date", () => {
+      const deal = createDeal();
+      deal.expiry.date = undefined;
+      expect(isExpiringSoon(deal, 30)).toBe(false);
+    });
+
+    it("returns false for non-active deals regardless of expiry", () => {
+      const quarantined = createDeal({
+        metadata: {
+          category: [],
+          tags: [],
+          normalized_at: "2026-05-01T00:00:00Z",
+          confidence_score: 0.8,
+          status: "quarantined",
+        },
+        expiryDate: isoAt(3 * DAY_MS),
+      });
+      const rejected = createDeal({
+        metadata: {
+          category: [],
+          tags: [],
+          normalized_at: "2026-05-01T00:00:00Z",
+          confidence_score: 0.8,
+          status: "rejected",
+        },
+        expiryDate: isoAt(3 * DAY_MS),
+      });
+      expect(isExpiringSoon(quarantined, 30)).toBe(false);
+      expect(isExpiringSoon(rejected, 30)).toBe(false);
+    });
+
+    it("treats malformed expiry dates as not expiring soon", () => {
+      const deal = createDeal({ expiryDate: "not-a-date" });
+      expect(isExpiringSoon(deal, 30)).toBe(false);
+    });
+  });
+
+  // ==========================================================================
+  // calculateExpiryUrgency
+  // ==========================================================================
+
+  describe("calculateExpiryUrgency", () => {
+    it("returns 1.0 for deals already past expiry", () => {
+      const deal = createDeal({ expiryDate: isoAt(-1 * DAY_MS) });
+      expect(calculateExpiryUrgency(deal)).toBe(1.0);
+    });
+
+    it("returns 1.0 at exactly the expiry instant", () => {
+      const deal = createDeal({ expiryDate: NOW.toISOString() });
+      expect(calculateExpiryUrgency(deal)).toBe(1.0);
+    });
+
+    it("returns 0.8 within the 7-day band", () => {
+      const deal = createDeal({ expiryDate: isoAt(5 * DAY_MS) });
+      expect(calculateExpiryUrgency(deal)).toBe(0.8);
+    });
+
+    it("returns 0.8 when days-until-expiry rounds up to exactly 7", () => {
+      const deal = createDeal({ expiryDate: isoAt(6 * DAY_MS + HOUR_MS) });
+      expect(calculateExpiryUrgency(deal)).toBe(0.8);
+    });
+
+    it("returns 0.5 within the 30-day band", () => {
+      const deal = createDeal({ expiryDate: isoAt(20 * DAY_MS) });
+      expect(calculateExpiryUrgency(deal)).toBe(0.5);
+    });
+
+    it("returns 0.5 when days-until-expiry rounds up to exactly 30", () => {
+      const deal = createDeal({
+        expiryDate: isoAt(29 * DAY_MS + HOUR_MS),
+      });
+      expect(calculateExpiryUrgency(deal)).toBe(0.5);
+    });
+
+    it("returns 0.2 within the 90-day band", () => {
+      const deal = createDeal({ expiryDate: isoAt(80 * DAY_MS) });
+      expect(calculateExpiryUrgency(deal)).toBe(0.2);
+    });
+
+    it("returns 0.2 when days-until-expiry rounds up to exactly 90", () => {
+      const deal = createDeal({
+        expiryDate: isoAt(89 * DAY_MS + HOUR_MS),
+      });
+      expect(calculateExpiryUrgency(deal)).toBe(0.2);
+    });
+
+    it("returns 0 beyond the 90-day horizon", () => {
+      const deal = createDeal({ expiryDate: isoAt(120 * DAY_MS) });
+      expect(calculateExpiryUrgency(deal)).toBe(0);
+    });
+
+    it("returns 0 when the deal has no expiry date", () => {
+      const deal = createDeal();
+      deal.expiry.date = undefined;
+      expect(calculateExpiryUrgency(deal)).toBe(0);
+    });
+
+    it("returns 0 for non-active deals", () => {
+      const deal = createDeal({
+        metadata: {
+          category: [],
+          tags: [],
+          normalized_at: "2026-05-01T00:00:00Z",
+          confidence_score: 0.8,
+          status: "quarantined",
+        },
+        expiryDate: isoAt(3 * DAY_MS),
+      });
+      expect(calculateExpiryUrgency(deal)).toBe(0);
+    });
+
+    it("treats malformed expiry dates as zero urgency", () => {
+      const deal = createDeal({ expiryDate: "not-a-date" });
+      expect(calculateExpiryUrgency(deal)).toBe(0);
+    });
+  });
+
+  // ==========================================================================
+  // scheduleExpiryCheck
+  // ==========================================================================
+
+  describe("scheduleExpiryCheck", () => {
+    it("persists the next check roughly one day ahead under the meta key", async () => {
+      const { env, kv } = createMockEnv();
+
+      await scheduleExpiryCheck(env);
+
+      expect(kv.has(EXPIRY_CHECK_KEY)).toBe(true);
+      const stored = JSON.parse(kv.get(EXPIRY_CHECK_KEY) ?? "{}") as {
+        scheduled_at?: string;
+        checked_at?: string;
+      };
+      expect(stored.checked_at).toBe(NOW.toISOString());
+      const scheduledAt = new Date(stored.scheduled_at ?? "").getTime();
+      // setHours targets 9 AM local time, so allow for timezone offsets.
+      expect(scheduledAt).toBeGreaterThan(NOW.getTime() + 12 * HOUR_MS);
+      expect(scheduledAt).toBeLessThan(NOW.getTime() + 40 * HOUR_MS);
+    });
+  });
+
+  // ==========================================================================
+  // Validation stats round-trip
+  // ==========================================================================
+
+  describe("storeValidationStats / getValidationStats", () => {
+    it("stores stats under the validation stats key", async () => {
+      const { env, kv } = createMockEnv();
+
+      await storeValidationStats(env, {
+        timestamp: NOW.toISOString(),
+        total: 10,
+        valid: 8,
+        invalid: 2,
+        errors: 0,
+      });
+
+      expect(kv.has(VALIDATION_STATS_KEY)).toBe(true);
+    });
+
+    it("round-trips stats through KV JSON", async () => {
+      const { env } = createMockEnv();
+
+      await storeValidationStats(env, {
+        timestamp: NOW.toISOString(),
+        total: 10,
+        valid: 8,
+        invalid: 2,
+        errors: 0,
+      });
+
+      const stats = await getValidationStats(env);
+      expect(stats).toEqual({
+        timestamp: NOW.toISOString(),
+        total: 10,
+        valid: 8,
+        invalid: 2,
+        errors: 0,
+      });
+    });
+
+    it("returns null when no stats have been stored", async () => {
+      const { env } = createMockEnv();
+
+      const stats = await getValidationStats(env);
+
+      expect(stats).toBeNull();
+    });
+  });
+
+  // ==========================================================================
+  // getLastValidationResults
+  // ==========================================================================
+
+  describe("getLastValidationResults", () => {
+    it("returns null when nothing has been recorded", async () => {
+      const { env } = createMockEnv();
+
+      const results = await getLastValidationResults(env);
+
+      expect(results).toBeNull();
+    });
+
+    it("reads back previously stored sweep results", async () => {
+      const { env, kv } = createMockEnv();
+      const payload = {
+        timestamp: NOW.toISOString(),
+        results: { validated: 42, deactivated: 3, notified: 7 },
+      };
+      kv.set(LAST_VALIDATION_KEY, JSON.stringify(payload));
+
+      const results = await getLastValidationResults(env);
+
+      expect(results).toEqual(payload);
+    });
+  });
+
+  // ==========================================================================
+  // Notified expiring deals dedup window
+  // ==========================================================================
+
+  describe("getNotifiedExpiringDeals", () => {
+    it("returns an empty list when nothing was recorded", async () => {
+      const { env } = createMockEnv();
+
+      const ids = await getNotifiedExpiringDeals(env);
+
+      expect(ids).toEqual([]);
+    });
+
+    it("returns recently notified deal ids", async () => {
+      const { env, kv } = createMockEnv();
+      kv.set(
+        NOTIFIED_EXPIRING_KEY,
+        JSON.stringify({
+          deals: ["deal-1", "deal-2"],
+          notified_at: isoAt(-2 * HOUR_MS),
+        }),
+      );
+
+      const ids = await getNotifiedExpiringDeals(env);
+
+      expect(ids).toEqual(["deal-1", "deal-2"]);
+    });
+
+    it("drops notifications older than 24 hours", async () => {
+      const { env, kv } = createMockEnv();
+      kv.set(
+        NOTIFIED_EXPIRING_KEY,
+        JSON.stringify({
+          deals: ["deal-1"],
+          notified_at: isoAt(-25 * HOUR_MS),
+        }),
+      );
+
+      const ids = await getNotifiedExpiringDeals(env);
+
+      expect(ids).toEqual([]);
+    });
+
+    it("includes deals at exactly the 24-hour boundary cutoff", async () => {
+      const { env, kv } = createMockEnv();
+      kv.set(
+        NOTIFIED_EXPIRING_KEY,
+        JSON.stringify({
+          deals: ["boundary-deal"],
+          notified_at: isoAt(-24 * HOUR_MS),
+        }),
+      );
+
+      const ids = await getNotifiedExpiringDeals(env);
+
+      expect(ids).toEqual(["boundary-deal"]);
+    });
+
+    it("swallows malformed payloads and returns an empty list", async () => {
+      const { env, kv } = createMockEnv();
+      kv.set(NOTIFIED_EXPIRING_KEY, "{broken json");
+
+      const ids = await getNotifiedExpiringDeals(env);
+
+      expect(ids).toEqual([]);
+    });
+  });
+
+  describe("recordNotifiedExpiringDeals", () => {
+    it("merges new ids with existing ones and deduplicates", async () => {
+      const { env, kv } = createMockEnv();
+      kv.set(
+        NOTIFIED_EXPIRING_KEY,
+        JSON.stringify({
+          deals: ["deal-1"],
+          notified_at: isoAt(-1 * HOUR_MS),
+        }),
+      );
+
+      await recordNotifiedExpiringDeals(env, ["deal-2", "deal-1"]);
+
+      const stored = JSON.parse(kv.get(NOTIFIED_EXPIRING_KEY) ?? "{}") as {
+        deals?: string[];
+        notified_at?: string;
+      };
+      expect([...(stored.deals ?? [])].sort()).toEqual(["deal-1", "deal-2"]);
+      expect(stored.notified_at).toBe(NOW.toISOString());
+    });
+
+    it("starts fresh when no prior record exists", async () => {
+      const { env, kv } = createMockEnv();
+
+      await recordNotifiedExpiringDeals(env, ["deal-9"]);
+
+      const stored = JSON.parse(kv.get(NOTIFIED_EXPIRING_KEY) ?? "{}") as {
+        deals?: string[];
+      };
+      expect(stored.deals).toEqual(["deal-9"]);
+    });
+
+    it("ignores prior records that fell outside the 24-hour window", async () => {
+      const { env, kv } = createMockEnv();
+      kv.set(
+        NOTIFIED_EXPIRING_KEY,
+        JSON.stringify({
+          deals: ["stale-deal"],
+          notified_at: isoAt(-48 * HOUR_MS),
+        }),
+      );
+
+      await recordNotifiedExpiringDeals(env, ["fresh-deal"]);
+
+      const stored = JSON.parse(kv.get(NOTIFIED_EXPIRING_KEY) ?? "{}") as {
+        deals?: string[];
+      };
+      expect(stored.deals).toEqual(["fresh-deal"]);
+    });
+  });
+});

--- a/tests/unit/kv-pagination.test.ts
+++ b/tests/unit/kv-pagination.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, type Mock } from "vitest";
+import type {
+  KVNamespaceListKey,
+  KVNamespaceListResult,
+} from "@cloudflare/workers-types";
+import {
+  listAllKvKeys,
+  KV_PAGINATION_LIMITS,
+} from "../../worker/lib/kv-pagination";
+
+type KvKey = KVNamespaceListKey<unknown>;
+type KvListResult = KVNamespaceListResult<unknown>;
+type ListOptions = { prefix?: string; cursor?: string };
+type ListFn = (options?: ListOptions) => Promise<KvListResult>;
+type FakeKv = { list: Mock<ListFn> };
+
+interface FakePage {
+  keys: KvKey[];
+  complete: boolean;
+}
+
+const PAGE_SIZE = 1000;
+
+function key(name: string, metadata?: unknown): KvKey {
+  return metadata === undefined ? { name } : { name, metadata };
+}
+
+function indexedKey(index: number): KvKey {
+  return key(`key:${String(index).padStart(6, "0")}`, { i: index });
+}
+
+function done(keys: KvKey[]): FakePage {
+  return { keys, complete: true };
+}
+
+function more(keys: KvKey[]): FakePage {
+  return { keys, complete: false };
+}
+
+function toResult(page: FakePage, index: number): KvListResult {
+  if (page.complete) {
+    return { list_complete: true, keys: page.keys, cacheStatus: null };
+  }
+  return {
+    list_complete: false,
+    keys: page.keys,
+    cursor: String(index + 1),
+    cacheStatus: null,
+  };
+}
+
+function createPagedKv(pages: FakePage[]): FakeKv {
+  const list: Mock<ListFn> = vi.fn(async (options?: ListOptions) => {
+    const index =
+      options?.cursor === undefined ? 0 : Number.parseInt(options.cursor, 10);
+    const page = pages[index] ?? { keys: [], complete: true };
+    return toResult(page, index);
+  });
+  return { list };
+}
+
+function createPrefixedKv(names: string[], perPage: number): FakeKv {
+  const matching = names
+    .filter((n) => n.startsWith("apikey:"))
+    .map((n) => key(n));
+  const list: Mock<ListFn> = vi.fn(async (options?: ListOptions) => {
+    expect(options?.prefix).toBe("apikey:");
+    const start =
+      options?.cursor === undefined ? 0 : Number.parseInt(options.cursor, 10);
+    const slice = matching.slice(start, start + perPage);
+    const complete = start + perPage >= matching.length;
+    if (complete) {
+      return { list_complete: true, keys: slice, cacheStatus: null };
+    }
+    return {
+      list_complete: false,
+      keys: slice,
+      cursor: String(start + perPage),
+      cacheStatus: null,
+    };
+  });
+  return { list };
+}
+
+describe("listAllKvKeys", () => {
+  it("accumulates keys across multiple pages until list_complete", async () => {
+    const kv = createPagedKv([
+      more([indexedKey(0), indexedKey(1)]),
+      more([indexedKey(2), indexedKey(3)]),
+      done([indexedKey(4)]),
+    ]);
+
+    const result = await listAllKvKeys(kv);
+
+    expect(result.keys.map((k) => k.name)).toEqual([
+      "key:000000",
+      "key:000001",
+      "key:000002",
+      "key:000003",
+      "key:000004",
+    ]);
+    expect(result.truncated).toBe(false);
+    expect(result.pages).toBe(3);
+    expect(kv.list).toHaveBeenCalledTimes(3);
+    expect(kv.list.mock.calls[0]?.[0]).toEqual({});
+    expect(kv.list.mock.calls[1]?.[0]).toEqual({ cursor: "1" });
+    expect(kv.list.mock.calls[2]?.[0]).toEqual({ cursor: "2" });
+  });
+
+  it("passes prefix through on every page request", async () => {
+    const kv = createPrefixedKv(
+      ["apikey:aaa", "unrelated:1", "apikey:bbb", "other:2"],
+      1,
+    );
+
+    const result = await listAllKvKeys(kv, { prefix: "apikey:" });
+
+    expect(kv.list.mock.calls.every((c) => c[0]?.prefix === "apikey:")).toBe(
+      true,
+    );
+    expect(result.keys.map((k) => k.name)).toEqual([
+      "apikey:aaa",
+      "apikey:bbb",
+    ]);
+    expect(result.truncated).toBe(false);
+  });
+
+  it("returns empty keys for an empty namespace", async () => {
+    const kv = createPagedKv([done([])]);
+
+    const result = await listAllKvKeys(kv);
+
+    expect(result.keys).toEqual([]);
+    expect(result.truncated).toBe(false);
+    expect(result.pages).toBe(1);
+    expect(kv.list).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves metadata on returned keys", async () => {
+    const kv = createPagedKv([done([key("with-meta", { owner: "test" })])]);
+
+    const result = await listAllKvKeys(kv);
+
+    expect(result.keys[0]?.metadata).toEqual({ owner: "test" });
+  });
+
+  it("stops at maxPages safety cap and marks result truncated", async () => {
+    const kv = createPagedKv([
+      more([indexedKey(0)]),
+      more([indexedKey(1)]),
+      more([indexedKey(2)]),
+    ]);
+
+    const result = await listAllKvKeys(kv, { maxPages: 2 });
+
+    expect(result.truncated).toBe(true);
+    expect(result.pages).toBe(2);
+    expect(result.keys.map((k) => k.name)).toEqual([
+      "key:000000",
+      "key:000001",
+    ]);
+    expect(kv.list).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops at maxKeys safety cap and truncates overflow on final page", async () => {
+    const manyKeys = [0, 1, 2, 3, 4].map(indexedKey);
+    const kv = createPagedKv([done(manyKeys)]);
+
+    const result = await listAllKvKeys(kv, { maxKeys: 3 });
+
+    expect(result.keys.map((k) => k.name)).toEqual([
+      "key:000000",
+      "key:000001",
+      "key:000002",
+    ]);
+    expect(result.truncated).toBe(true);
+  });
+
+  it("exposes named safety limits instead of magic numbers", () => {
+    expect(KV_PAGINATION_LIMITS.MAX_PAGES).toBeGreaterThan(0);
+    expect(KV_PAGINATION_LIMITS.MAX_KEYS).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/source-registry.test.ts
+++ b/tests/unit/source-registry.test.ts
@@ -1,0 +1,493 @@
+import { describe, it, expect, vi } from "vitest";
+import type { DurableObjectState } from "@cloudflare/workers-types";
+import {
+  SourceRegistry,
+  type TrustScore,
+} from "../../worker/durable-objects/source-registry";
+
+// ============================================================================
+// In-memory SQLite mock for state.storage.sql
+// ============================================================================
+// SourceRegistry uses Cloudflare DO SQLite (state.storage.sql).
+// exec() returns a cursor with .one() and .toArray().
+// ============================================================================
+
+interface MockSourceRow {
+  source_id: string;
+  trust_score: number;
+  total_deals: number;
+  successful_deals: number;
+  classification: string;
+  last_seen_at: number | null;
+  created_at: number;
+}
+
+const TRUST_MIN = 0;
+const TRUST_MAX = 1;
+
+function clamp(score: number): number {
+  return Math.max(TRUST_MIN, Math.min(TRUST_MAX, score));
+}
+
+function classify(score: number): string {
+  if (score >= 0.7) return "trusted";
+  if (score >= 0.4) return "probationary";
+  return "unverified";
+}
+
+function createMockSql(storage: MockSourceRow[]) {
+  function mockCursor<T>(rows: T[]) {
+    return {
+      one: () => rows[0],
+      toArray: () => rows,
+    };
+  }
+
+  const exec = vi.fn((sql: string, ...params: unknown[]) => {
+    const upperSql = sql.trimStart().toUpperCase();
+
+    if (upperSql.startsWith("CREATE")) {
+      return mockCursor([]);
+    }
+
+    // Upsert: insert with base score 0.5 when the source is new.
+    if (upperSql.startsWith("INSERT")) {
+      const [source_id, last_seen_at, created_at] = params;
+      const exists = storage.some((r) => r.source_id === source_id);
+      if (!exists) {
+        storage.push({
+          source_id: String(source_id),
+          trust_score: 0.5,
+          total_deals: 0,
+          successful_deals: 0,
+          classification: "unverified",
+          last_seen_at: Number(last_seen_at),
+          created_at: Number(created_at),
+        });
+      }
+      return mockCursor([]);
+    }
+
+    // Atomic evolution. Param order:
+    // [min, max, delta, successInc, now, min, max, delta, trustedAt, min, max, delta, probationaryAt, source_id]
+    if (upperSql.startsWith("UPDATE")) {
+      const min = Number(params[0]);
+      const max = Number(params[1]);
+      const delta = Number(params[2]);
+      const successInc = Number(params[3]);
+      const now = Number(params[4]);
+      const sourceId = String(params[13]);
+      const row = storage.find((r) => r.source_id === sourceId);
+      if (row) {
+        const updated = Math.max(min, Math.min(max, row.trust_score + delta));
+        row.trust_score = updated;
+        row.total_deals += 1;
+        row.successful_deals += successInc;
+        row.last_seen_at = now;
+        row.classification =
+          updated >= Number(params[8])
+            ? "trusted"
+            : updated >= Number(params[12])
+              ? "probationary"
+              : "unverified";
+      }
+      return mockCursor([]);
+    }
+
+    if (upperSql.startsWith("SELECT")) {
+      let results = [...storage];
+
+      if (sql.includes("IN (")) {
+        results = results.filter((r) =>
+          params.map(String).includes(r.source_id),
+        );
+      } else if (sql.includes("WHERE source_id = ?")) {
+        results = results.filter((r) => r.source_id === params[0]);
+      }
+
+      if (sql.includes("ORDER BY trust_score DESC")) {
+        results.sort(
+          (a, b) =>
+            b.trust_score - a.trust_score ||
+            b.successful_deals - a.successful_deals,
+        );
+        results = results.slice(0, Number(params[0]));
+      }
+
+      if (
+        sql.includes("classification = 'unverified'") &&
+        sql.includes("ORDER BY trust_score ASC")
+      ) {
+        results = results.filter(
+          (r) =>
+            r.classification === "unverified" ||
+            (r.total_deals >= 3 && r.successful_deals / r.total_deals < 0.5),
+        );
+        results.sort(
+          (a, b) =>
+            a.trust_score - b.trust_score || b.total_deals - a.total_deals,
+        );
+      }
+
+      return mockCursor(results);
+    }
+
+    return mockCursor([]);
+  });
+
+  return exec;
+}
+
+function createRegistry(seedRows: MockSourceRow[] = []) {
+  const storage: MockSourceRow[] = [...seedRows];
+  const exec = createMockSql(storage);
+  const state = {
+    id: { name: "test-source-registry" },
+    storage: { sql: { exec } },
+    // Cast rationale: only state.storage.sql is accessed by the class; the
+    // full DurableObjectState surface is irrelevant to the unit under test.
+  } as unknown as DurableObjectState;
+  const registry = new SourceRegistry(state);
+  return { registry, storage, exec };
+}
+
+function seedRow(overrides: Partial<MockSourceRow> = {}): MockSourceRow {
+  const row: MockSourceRow = {
+    source_id: "seeded-source",
+    trust_score: 0.5,
+    total_deals: 0,
+    successful_deals: 0,
+    classification: "",
+    last_seen_at: null,
+    created_at: 1700000000000,
+    ...overrides,
+  };
+  // Stored rows always carry the classification matching their score.
+  row.classification = classify(row.trust_score);
+  return row;
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("SourceRegistry", () => {
+  describe("constructor", () => {
+    it("should create the sources table on init", () => {
+      const { exec } = createRegistry();
+      expect(exec).toHaveBeenCalledWith(
+        expect.stringContaining("CREATE TABLE IF NOT EXISTS sources"),
+      );
+    });
+  });
+
+  describe("evolveTrust", () => {
+    it("should start a new source at the 0.5 base and apply the success delta", async () => {
+      const { registry } = createRegistry();
+
+      const score = await registry.evolveTrust("src-new", true);
+
+      expect(score).toBeCloseTo(0.55, 10);
+    });
+
+    it("should apply the failure delta to a new source", async () => {
+      const { registry } = createRegistry();
+
+      const score = await registry.evolveTrust("src-fail", false);
+
+      expect(score).toBeCloseTo(0.48, 10);
+    });
+
+    it("should track successful and failed deals in separate counters", async () => {
+      const { registry } = createRegistry();
+      await registry.evolveTrust("src-counters", true);
+      await registry.evolveTrust("src-counters", false);
+
+      const info = await registry.getTrustScore("src-counters");
+
+      expect(info?.total_deals).toBe(2);
+      expect(info?.successful_deals).toBe(1);
+    });
+
+    it("should not re-apply the 0.5 base to an existing source", async () => {
+      const { registry } = createRegistry();
+      await registry.evolveTrust("src-repeat", true);
+
+      const second = await registry.evolveTrust("src-repeat", true);
+
+      expect(second).toBeCloseTo(0.6, 10);
+    });
+
+    it("should accumulate deterministically across repeated calls", async () => {
+      const { registry } = createRegistry();
+      await registry.evolveTrust("src-acc", true);
+      await registry.evolveTrust("src-acc", false);
+      await registry.evolveTrust("src-acc", true);
+
+      const info = await registry.getTrustScore("src-acc");
+
+      expect(info?.trust_score).toBeCloseTo(0.58, 10);
+      expect(info?.total_deals).toBe(3);
+      expect(info?.successful_deals).toBe(2);
+    });
+
+    it("should clamp the score at the maximum of 1.0", async () => {
+      const { registry } = createRegistry([seedRow({ trust_score: 0.99 })]);
+
+      await registry.evolveTrust("seeded-source", true);
+      const clamped = await registry.evolveTrust("seeded-source", true);
+
+      expect(clamped).toBe(1);
+    });
+
+    it("should clamp the score at the minimum of 0.0", async () => {
+      const { registry } = createRegistry([
+        seedRow({ source_id: "low", trust_score: 0.01 }),
+      ]);
+
+      const clamped = await registry.evolveTrust("low", false);
+
+      expect(clamped).toBe(0);
+    });
+  });
+
+  describe("getTrustScore", () => {
+    it("should return null for an unknown source", async () => {
+      const { registry } = createRegistry();
+
+      const result = await registry.getTrustScore("ghost");
+
+      expect(result).toBeNull();
+    });
+
+    it("should return the full TrustScore record for a known source", async () => {
+      const { registry } = createRegistry([
+        seedRow({
+          source_id: "known",
+          trust_score: 0.75,
+          total_deals: 4,
+          successful_deals: 3,
+          last_seen_at: 1700000001000,
+        }),
+      ]);
+
+      const result = await registry.getTrustScore("known");
+
+      expect(result).not.toBeNull();
+      const info = result as TrustScore;
+      expect(info.source_id).toBe("known");
+      expect(info.trust_score).toBe(0.75);
+      expect(info.total_deals).toBe(4);
+      expect(info.successful_deals).toBe(3);
+      expect(info.last_seen_at).toBe(1700000001000);
+    });
+
+    it("should derive classification as trusted at exactly 0.7", async () => {
+      const { registry } = createRegistry([
+        seedRow({ source_id: "boundary-trusted", trust_score: 0.7 }),
+      ]);
+
+      const info = await registry.getTrustScore("boundary-trusted");
+
+      expect(info?.classification).toBe("trusted");
+    });
+
+    it("should derive classification as probationary at exactly 0.4", async () => {
+      const { registry } = createRegistry([
+        seedRow({ source_id: "boundary-prob", trust_score: 0.4 }),
+      ]);
+
+      const info = await registry.getTrustScore("boundary-prob");
+
+      expect(info?.classification).toBe("probationary");
+    });
+
+    it("should derive classification as unverified below 0.4", async () => {
+      const { registry } = createRegistry([
+        seedRow({ source_id: "low", trust_score: 0.39 }),
+      ]);
+
+      const info = await registry.getTrustScore("low");
+
+      expect(info?.classification).toBe("unverified");
+    });
+  });
+
+  describe("getTrustScores", () => {
+    it("should return an empty map without querying for empty input", async () => {
+      const { registry, exec } = createRegistry();
+      const callsBefore = exec.mock.calls.length;
+
+      const result = await registry.getTrustScores([]);
+
+      expect(result.size).toBe(0);
+      expect(exec.mock.calls.length).toBe(callsBefore);
+    });
+
+    it("should return only the sources that exist", async () => {
+      const { registry } = createRegistry([
+        seedRow({ source_id: "a", trust_score: 0.5 }),
+        seedRow({ source_id: "b", trust_score: 0.9 }),
+      ]);
+
+      const result = await registry.getTrustScores(["a", "b", "missing"]);
+
+      expect(result.size).toBe(2);
+      expect(result.has("a")).toBe(true);
+      expect(result.has("b")).toBe(true);
+      expect(result.has("missing")).toBe(false);
+      expect(result.get("a")?.source_id).toBe("a");
+      expect(result.get("a")?.trust_score).toBe(0.5);
+    });
+  });
+
+  describe("getTopTrusted", () => {
+    it("should order sources by trust score descending", async () => {
+      const { registry } = createRegistry([
+        seedRow({ source_id: "mid", trust_score: 0.5 }),
+        seedRow({ source_id: "top", trust_score: 0.95 }),
+        seedRow({ source_id: "bottom", trust_score: 0.2 }),
+      ]);
+
+      const top = await registry.getTopTrusted(3);
+
+      expect(top.map((t) => t.source_id)).toEqual(["top", "mid", "bottom"]);
+    });
+
+    it("should respect an explicit limit and default of 10", async () => {
+      const seeds = Array.from({ length: 12 }, (_, i) =>
+        seedRow({ source_id: `src-${i}` }),
+      );
+      const { registry } = createRegistry(seeds);
+
+      expect(await registry.getTopTrusted(2)).toHaveLength(2);
+      expect(await registry.getTopTrusted()).toHaveLength(10);
+    });
+
+    it("should break ties by successful deals descending", async () => {
+      const { registry } = createRegistry([
+        seedRow({
+          source_id: "fewer-wins",
+          trust_score: 0.6,
+          successful_deals: 2,
+        }),
+        seedRow({
+          source_id: "more-wins",
+          trust_score: 0.6,
+          successful_deals: 7,
+        }),
+      ]);
+
+      const top = await registry.getTopTrusted(2);
+
+      expect(top[0]?.source_id).toBe("more-wins");
+      expect(top[1]?.source_id).toBe("fewer-wins");
+    });
+  });
+
+  describe("getSourcesNeedingReview", () => {
+    it("should include unverified sources regardless of history", async () => {
+      const { registry } = createRegistry([
+        seedRow({ source_id: "fresh", trust_score: 0.35 }),
+      ]);
+
+      const review = await registry.getSourcesNeedingReview();
+
+      expect(review.map((r) => r.source_id)).toContain("fresh");
+    });
+
+    it("should include sources with a high failure rate after 3+ deals", async () => {
+      const { registry } = createRegistry([
+        seedRow({
+          source_id: "failing",
+          trust_score: 0.45,
+          total_deals: 4,
+          successful_deals: 1,
+        }),
+      ]);
+
+      const review = await registry.getSourcesNeedingReview();
+
+      expect(review.map((r) => r.source_id)).toContain("failing");
+    });
+
+    it("should exclude healthy probationary sources", async () => {
+      const { registry } = createRegistry([
+        seedRow({
+          source_id: "healthy",
+          trust_score: 0.55,
+          total_deals: 10,
+          successful_deals: 9,
+        }),
+      ]);
+
+      const review = await registry.getSourcesNeedingReview();
+
+      expect(review.map((r) => r.source_id)).not.toContain("healthy");
+    });
+
+    it("should exclude high-trusted sources with strong track records", async () => {
+      const { registry } = createRegistry([
+        seedRow({
+          source_id: "star",
+          trust_score: 0.9,
+          total_deals: 20,
+          successful_deals: 19,
+        }),
+      ]);
+
+      const review = await registry.getSourcesNeedingReview();
+
+      expect(review).toHaveLength(0);
+    });
+
+    it("should order results by ascending trust score", async () => {
+      const { registry } = createRegistry([
+        seedRow({ source_id: "less-bad", trust_score: 0.38 }),
+        seedRow({ source_id: "worst", trust_score: 0.05 }),
+      ]);
+
+      const review = await registry.getSourcesNeedingReview();
+
+      expect(review.map((r) => r.source_id)).toEqual(["worst", "less-bad"]);
+    });
+  });
+
+  describe("fetch", () => {
+    it("should return a 200 response pointing callers at RPC methods", async () => {
+      const { registry } = createRegistry();
+
+      const response = await registry.fetch();
+
+      expect(response.status).toBe(200);
+      const text = await response.text();
+      expect(text).toContain("SourceRegistry DO");
+      expect(text).toContain("RPC methods");
+    });
+  });
+
+  describe("full lifecycle", () => {
+    it("new source climbs from unverified to trusted through successes", async () => {
+      const { registry } = createRegistry();
+
+      let last = await registry.evolveTrust("lifecycle", true);
+      expect(last).toBeCloseTo(0.55, 10);
+
+      last = await registry.evolveTrust("lifecycle", true);
+      last = await registry.evolveTrust("lifecycle", true);
+      const mid = await registry.getTrustScore("lifecycle");
+      expect(mid?.trust_score).toBeCloseTo(0.65, 10);
+      expect(mid?.classification).toBe("probationary");
+
+      last = await registry.evolveTrust("lifecycle", true);
+      expect(last).toBeCloseTo(0.7, 10);
+      const final = await registry.getTrustScore("lifecycle");
+      expect(final?.classification).toBe("trusted");
+      expect(final?.total_deals).toBe(4);
+      expect(final?.successful_deals).toBe(4);
+
+      const healthy = await registry.getSourcesNeedingReview();
+      expect(healthy.map((r) => r.source_id)).not.toContain("lifecycle");
+    });
+  });
+});

--- a/worker/lib/auth.ts
+++ b/worker/lib/auth.ts
@@ -13,6 +13,7 @@ import {
 } from "../routes/utils";
 import { checkRateLimit, createRateLimitHeaders } from "./rate-limit";
 import { verifyToken } from "./jwt";
+import { listAllKvKeys } from "./kv-pagination";
 
 const JWT_ROLES: AuthRole[] = ["admin", "user", "readonly", "viewer"];
 
@@ -109,7 +110,7 @@ export async function storeApiKey(
  */
 export async function listApiKeys(env: Env): Promise<ApiKeyConfig[]> {
   const kv = env.WEBHOOK_API_KEYS || env.DEALS_SOURCES;
-  const list = await kv.list({ prefix: "apikey:" });
+  const list = await listAllKvKeys(kv, { prefix: "apikey:" });
 
   const results = await Promise.all(
     list.keys.map(async (key) => {

--- a/worker/lib/cache.ts
+++ b/worker/lib/cache.ts
@@ -3,6 +3,7 @@ import type { Env } from "../types";
 import { executeInBatches } from "./utils";
 import { logger } from "./global-logger";
 import { toErrMessage } from "./errors";
+import { listAllKvKeys } from "./kv-pagination";
 
 // ============================================================================
 // Cache Entry Types
@@ -195,7 +196,9 @@ export class KVCache {
    */
   async clear(): Promise<void> {
     try {
-      const list = await this.kv.list({ prefix: `cache:${this.namespace}:` });
+      const list = await listAllKvKeys(this.kv, {
+        prefix: `cache:${this.namespace}:`,
+      });
 
       // Optimization: Parallel batch delete instead of sequential loop
       // This reduces latency from O(N) to O(N/batchSize)

--- a/worker/lib/categorization/scoring.ts
+++ b/worker/lib/categorization/scoring.ts
@@ -107,23 +107,20 @@ export function calculateCategoryScores(deal: Deal): Map<string, number> {
 
   // Score each category using preprocessed lowercased structures
   // to avoid redundant string lowercasing and replace regex operations in hot loops.
-  for (let i = 0; i < PREPROCESSED_CATEGORIES.length; i++) {
-    const item = PREPROCESSED_CATEGORIES[i]!;
+  for (const item of PREPROCESSED_CATEGORIES) {
     let score = 0;
 
     // Check domain match (highest weight)
-    const domains = item.lowercasedDomains;
-    for (let d = 0; d < domains.length; d++) {
-      if (sourceDomain.includes(domains[d]!)) {
+    for (const domain of item.lowercasedDomains) {
+      if (sourceDomain.includes(domain)) {
         score += 10;
         break;
       }
     }
 
     // Check keyword matches
-    const keywords = item.lowercasedKeywords;
-    for (let k = 0; k < keywords.length; k++) {
-      if (text.includes(keywords[k]!)) {
+    for (const keyword of item.lowercasedKeywords) {
+      if (text.includes(keyword)) {
         score += 1;
       }
     }
@@ -146,14 +143,12 @@ export function calculateTagScores(deal: Deal): Map<string, number> {
   const text = `${deal.title} ${deal.description}`.toLowerCase();
 
   // Check keyword-based tags using preprocessed lowercased structures
-  for (let i = 0; i < PREPROCESSED_TAGS.length; i++) {
-    const item = PREPROCESSED_TAGS[i]!;
+  for (const item of PREPROCESSED_TAGS) {
     let score = 0;
 
     // Check keyword matches
-    const keywords = item.lowercasedKeywords;
-    for (let k = 0; k < keywords.length; k++) {
-      if (text.includes(keywords[k]!)) {
+    for (const keyword of item.lowercasedKeywords) {
+      if (text.includes(keyword)) {
         score += 1;
       }
     }

--- a/worker/lib/circuit-breaker.ts
+++ b/worker/lib/circuit-breaker.ts
@@ -44,16 +44,17 @@ interface CircuitBreakerMetrics {
 const metricsMap = new Map<string, CircuitBreakerMetrics>();
 
 function getMetrics(name: string): CircuitBreakerMetrics {
-  if (!metricsMap.has(name)) {
-    metricsMap.set(name, {
-      stateChanges: 0,
-      totalCalls: 0,
-      successfulCalls: 0,
-      failedCalls: 0,
-      rejectedCalls: 0,
-    });
-  }
-  return metricsMap.get(name)!;
+  const existing = metricsMap.get(name);
+  if (existing) return existing;
+  const metrics: CircuitBreakerMetrics = {
+    stateChanges: 0,
+    totalCalls: 0,
+    successfulCalls: 0,
+    failedCalls: 0,
+    rejectedCalls: 0,
+  };
+  metricsMap.set(name, metrics);
+  return metrics;
 }
 
 function recordStateChange(
@@ -384,19 +385,20 @@ export function getSourceCircuitBreaker(
   domain: string,
   env?: Env,
 ): CircuitBreaker {
-  if (!sourceCircuitBreakers.has(domain)) {
-    const cb = new CircuitBreaker(
-      `source:${domain}`,
-      {
-        failureThreshold: 5,
-        resetTimeoutMs: 300000, // 5 minutes for sources
-        halfOpenMaxCalls: 2,
-      },
-      env,
-    );
-    sourceCircuitBreakers.set(domain, cb);
-  }
-  return sourceCircuitBreakers.get(domain)!;
+  const existing = sourceCircuitBreakers.get(domain);
+  if (existing) return existing;
+
+  const cb = new CircuitBreaker(
+    `source:${domain}`,
+    {
+      failureThreshold: 5,
+      resetTimeoutMs: 300000, // 5 minutes for sources
+      halfOpenMaxCalls: 2,
+    },
+    env,
+  );
+  sourceCircuitBreakers.set(domain, cb);
+  return cb;
 }
 
 // Clear all source circuit breakers (useful for testing)

--- a/worker/lib/config-utils.ts
+++ b/worker/lib/config-utils.ts
@@ -64,7 +64,7 @@ export function validateConfig(env: Env): void {
     throw new Error(`Missing required config: ${missing.join(", ")}`);
   }
 
-  const threshold = parseFloat(env.TRUST_THRESHOLD!);
+  const threshold = parseFloat(env.TRUST_THRESHOLD);
   if (isNaN(threshold) || threshold < 0 || threshold > 1) {
     throw new Error(`TRUST_THRESHOLD must be a number between 0 and 1`);
   }

--- a/worker/lib/crypto.ts
+++ b/worker/lib/crypto.ts
@@ -19,8 +19,8 @@ export async function sha256(input: string): Promise<string> {
   const hashBuffer = await crypto.subtle.digest("SHA-256", data);
   const hashArray = new Uint8Array(hashBuffer);
   let result = "";
-  for (let i = 0; i < hashArray.length; i++) {
-    const hex = HEX_TABLE[hashArray[i]!];
+  for (const byte of hashArray) {
+    const hex = HEX_TABLE[byte];
     if (hex) result += hex;
   }
   return result;

--- a/worker/lib/feature-flags.ts
+++ b/worker/lib/feature-flags.ts
@@ -11,6 +11,7 @@
 import type { Env } from "../types";
 import { logger } from "./global-logger";
 import { toErrMessage } from "./errors";
+import { listAllKvKeys } from "./kv-pagination";
 
 // ============================================================================
 // Configuration
@@ -246,7 +247,9 @@ export async function getAllFeatureFlags(
   const flags = new Map<string, FeatureFlag>();
 
   try {
-    const list = await env.DEALS_LOCK.list({ prefix: FEATURE_FLAG_PREFIX });
+    const list = await listAllKvKeys(env.DEALS_LOCK, {
+      prefix: FEATURE_FLAG_PREFIX,
+    });
 
     for (const key of list.keys) {
       const flag = await env.DEALS_LOCK.get<FeatureFlag>(key.name, "json");

--- a/worker/lib/jwt.ts
+++ b/worker/lib/jwt.ts
@@ -98,15 +98,22 @@ function calculateExpiry(expiresIn: string | number): number {
   if (typeof expiresIn === "number") return nowSeconds + expiresIn;
   const match = expiresIn.match(/^(\d+)([smhd])$/);
   if (!match) throw new Error("Invalid expiresIn format: " + expiresIn);
-  const value = parseInt(match[1]!, 10);
-  const unit = match[2]!;
+  const valueStr = match[1];
+  const unit = match[2];
+  if (valueStr === undefined || unit === undefined) {
+    throw new Error("Invalid expiresIn format: " + expiresIn);
+  }
   const multipliers: Record<string, number> = {
     s: 1,
     m: 60,
     h: 3600,
     d: 86400,
   };
-  return nowSeconds + value * multipliers[unit]!;
+  const multiplier = multipliers[unit];
+  if (multiplier === undefined) {
+    throw new Error("Invalid expiresIn format: " + expiresIn);
+  }
+  return nowSeconds + parseInt(valueStr, 10) * multiplier;
 }
 
 /**

--- a/worker/lib/kv-pagination.ts
+++ b/worker/lib/kv-pagination.ts
@@ -1,0 +1,96 @@
+// ============================================================================
+// KV Pagination - Bounded cursor pagination for Workers KV list operations
+// ============================================================================
+
+import type {
+  KVNamespaceListKey,
+  KVNamespaceListOptions,
+  KVNamespaceListResult,
+} from "@cloudflare/workers-types";
+
+/**
+ * Minimal structural view of a Workers KV namespace needed for pagination.
+ * Matches Cloudflare KVNamespace while keeping the helper testable without
+ * depending on generic list() instantiations.
+ */
+export interface KvListClient {
+  list(
+    options?: KVNamespaceListOptions,
+  ): Promise<KVNamespaceListResult<unknown>>;
+}
+
+/**
+ * Safety limits for full-namespace KV scans.
+ *
+ * Guards against unbounded iteration on very large or misbehaving
+ * namespaces: MAX_PAGES bounds round trips to the KV API and
+ * MAX_KEYS bounds total accumulated keys held in memory.
+ */
+export const KV_PAGINATION_LIMITS = {
+  MAX_PAGES: 100,
+  MAX_KEYS: 10000,
+} as const;
+
+export interface ListAllKvKeysOptions {
+  prefix?: string;
+  maxPages?: number;
+  maxKeys?: number;
+}
+
+export interface ListAllKvKeysResult {
+  keys: KVNamespaceListKey<unknown>[];
+  truncated: boolean;
+  pages: number;
+}
+
+/**
+ * Lists every key in a KV namespace by following cursors until
+ * list_complete, unlike a bare list() call which stops after one page.
+ *
+ * Iteration is bounded by maxPages/maxKeys (defaults to
+ * KV_PAGINATION_LIMITS). When a limit is reached the returned result is
+ * marked truncated instead of throwing, so callers keep first-page
+ * behavior even under pathological namespace sizes.
+ */
+export async function listAllKvKeys(
+  kv: KvListClient,
+  options: ListAllKvKeysOptions = {},
+): Promise<ListAllKvKeysResult> {
+  const maxPages = options.maxPages ?? KV_PAGINATION_LIMITS.MAX_PAGES;
+  const maxKeys = options.maxKeys ?? KV_PAGINATION_LIMITS.MAX_KEYS;
+
+  const keys: KVNamespaceListKey<unknown>[] = [];
+  let cursor: string | undefined;
+  let pages = 0;
+
+  const enforceKeyCap = (): boolean => {
+    if (keys.length <= maxKeys) {
+      return false;
+    }
+    keys.length = maxKeys;
+    return true;
+  };
+
+  while (pages < maxPages && keys.length < maxKeys) {
+    const listOptions: KVNamespaceListOptions = {};
+    if (options.prefix !== undefined) {
+      listOptions.prefix = options.prefix;
+    }
+    if (cursor !== undefined) {
+      listOptions.cursor = cursor;
+    }
+
+    const page = await kv.list(listOptions);
+    pages += 1;
+    keys.push(...page.keys);
+
+    if (page.list_complete !== false) {
+      return { keys, truncated: enforceKeyCap(), pages };
+    }
+
+    cursor = page.cursor;
+  }
+
+  enforceKeyCap();
+  return { keys, truncated: true, pages };
+}

--- a/worker/lib/logger/query.ts
+++ b/worker/lib/logger/query.ts
@@ -9,6 +9,7 @@ import {
 } from "./types";
 import { fetchInBatches } from "../utils";
 import { logger } from "../global-logger";
+import { listAllKvKeys } from "../kv-pagination";
 
 export async function getRunLogs(
   env: Env,
@@ -149,7 +150,7 @@ export async function getRecentStructuredLogs(
 ): Promise<StructuredLogEntry[]> {
   try {
     const prefix = STRUCTURED_LOG_PREFIX;
-    const listResult = await env.DEALS_LOG.list({ prefix });
+    const listResult = await listAllKvKeys(env.DEALS_LOG, { prefix });
 
     // Performance optimization: direct string lexicographical comparison (< and >)
     // is significantly faster than localeCompare and avoids locale-aware collation overhead.

--- a/worker/lib/middleware/pipeline.ts
+++ b/worker/lib/middleware/pipeline.ts
@@ -87,8 +87,9 @@ function matchPath(pattern: string, actual: string): RouteParams | null {
 
   const params: RouteParams = {};
   for (let i = 0; i < patternParts.length; i++) {
-    const pp = patternParts[i]!;
-    const ap = actualParts[i]!;
+    const pp = patternParts[i];
+    const ap = actualParts[i];
+    if (pp === undefined || ap === undefined) return null;
     if (pp.startsWith(":")) {
       params[pp.slice(1)] = decodeURIComponent(ap);
     } else if (pp !== ap) {

--- a/worker/lib/nlq/query-builder/executor.ts
+++ b/worker/lib/nlq/query-builder/executor.ts
@@ -42,38 +42,39 @@ export async function executeStructuredQuery(
     let filtered = baseResults;
 
     // Filter by category
-    if (query.categories && query.categories.length > 0) {
+    const categories = query.categories;
+    if (categories && categories.length > 0) {
       filtered = filtered.filter((deal) => {
         if (!deal.category) return false;
-        return query.categories!.some((cat) => deal.category.includes(cat));
+        return categories.some((cat) => deal.category.includes(cat));
       });
     }
 
     // Filter by domain
-    if (query.domains && query.domains.length > 0) {
+    const domains = query.domains;
+    if (domains && domains.length > 0) {
       filtered = filtered.filter((deal) =>
-        query.domains!.includes(deal.domain.toLowerCase()),
+        domains.includes(deal.domain.toLowerCase()),
       );
     }
 
     // Filter by reward type
-    if (query.rewardTypes && query.rewardTypes.length > 0) {
+    const rewardTypes = query.rewardTypes;
+    if (rewardTypes && rewardTypes.length > 0) {
       filtered = filtered.filter((deal) =>
-        query.rewardTypes!.includes(deal.reward_type as RewardType),
+        rewardTypes.includes(deal.reward_type as RewardType),
       );
     }
 
     // Filter by reward value
-    if (query.minRewardValue !== undefined) {
-      filtered = filtered.filter(
-        (deal) => deal.reward_value >= query.minRewardValue!,
-      );
+    const minRewardValue = query.minRewardValue;
+    if (minRewardValue !== undefined) {
+      filtered = filtered.filter((deal) => deal.reward_value >= minRewardValue);
     }
 
-    if (query.maxRewardValue !== undefined) {
-      filtered = filtered.filter(
-        (deal) => deal.reward_value <= query.maxRewardValue!,
-      );
+    const maxRewardValue = query.maxRewardValue;
+    if (maxRewardValue !== undefined) {
+      filtered = filtered.filter((deal) => deal.reward_value <= maxRewardValue);
     }
 
     // Apply sorting if not relevance

--- a/worker/lib/ranking.ts
+++ b/worker/lib/ranking.ts
@@ -240,23 +240,23 @@ export function rankDeals(
   // Filter first
   let filtered = deals.filter((d) => d.metadata.status === "active");
 
-  if (options.minConfidence !== undefined) {
+  const minConfidence = options.minConfidence;
+  if (minConfidence !== undefined) {
     filtered = filtered.filter(
-      (d) => d.metadata.confidence_score >= options.minConfidence!,
+      (d) => d.metadata.confidence_score >= minConfidence,
     );
   }
 
-  if (options.minTrustScore !== undefined) {
-    filtered = filtered.filter(
-      (d) => d.source.trust_score >= options.minTrustScore!,
-    );
+  const minTrustScore = options.minTrustScore;
+  if (minTrustScore !== undefined) {
+    filtered = filtered.filter((d) => d.source.trust_score >= minTrustScore);
   }
 
-  if (options.category) {
+  const category = options.category;
+  if (category) {
+    const lowerCategory = category.toLowerCase();
     filtered = filtered.filter((d) =>
-      d.metadata.category.some(
-        (c) => c.toLowerCase() === options.category!.toLowerCase(),
-      ),
+      d.metadata.category.some((c) => c.toLowerCase() === lowerCategory),
     );
   }
 
@@ -325,7 +325,8 @@ export function getExpiringDeals(deals: Deal[], days: number = 7): Deal[] {
     })
     .sort(
       (a, b) =>
-        new Date(a.expiry.date!).getTime() - new Date(b.expiry.date!).getTime(),
+        new Date(a.expiry.date ?? "").getTime() -
+        new Date(b.expiry.date ?? "").getTime(),
     );
 }
 

--- a/worker/lib/rate-limit-kv.ts
+++ b/worker/lib/rate-limit-kv.ts
@@ -11,6 +11,7 @@
 import type { Env } from "../types";
 import { logger } from "./global-logger";
 import { toErrMessage } from "./errors";
+import { listAllKvKeys } from "./kv-pagination";
 
 // ============================================================================
 // Configuration
@@ -294,7 +295,9 @@ export async function getAllRateLimitStates(
   const states = new Map<string, RateLimitKVState>();
 
   try {
-    const list = await env.DEALS_LOCK.list({ prefix: `${KEY_PREFIX}:` });
+    const list = await listAllKvKeys(env.DEALS_LOCK, {
+      prefix: `${KEY_PREFIX}:`,
+    });
 
     for (const key of list.keys) {
       const state = await env.DEALS_LOCK.get<RateLimitKVState>(

--- a/worker/lib/referral-storage/search.ts
+++ b/worker/lib/referral-storage/search.ts
@@ -79,16 +79,20 @@ export async function searchReferrals(
   }
 
   // Apply filters
-  if (filters.domain) {
+  const domainFilter = filters.domain;
+  if (domainFilter) {
+    const lowerDomainFilter = domainFilter.toLowerCase();
     referrals = referrals.filter(
-      (r) => (r.domain || "").toLowerCase() === filters.domain!.toLowerCase(),
+      (r) => (r.domain || "").toLowerCase() === lowerDomainFilter,
     );
   }
 
-  if (filters.category) {
+  const categoryFilter = filters.category;
+  if (categoryFilter) {
+    const lowerCategoryFilter = categoryFilter.toLowerCase();
     referrals = referrals.filter((r: ReferralInput) =>
       (r.metadata?.category || []).some(
-        (c: string) => c.toLowerCase() === filters.category!.toLowerCase(),
+        (c: string) => c.toLowerCase() === lowerCategoryFilter,
       ),
     );
   }

--- a/worker/lib/search/embedding-pipeline.ts
+++ b/worker/lib/search/embedding-pipeline.ts
@@ -69,15 +69,26 @@ export async function generateDealEmbeddings(
         env.AI.run as (model: string, inputs: unknown) => Promise<unknown>
       )(EMBEDDING_MODEL, { text: texts })) as { data?: number[][] };
 
-      if (!Array.isArray(result.data) || result.data.length !== batch.length) {
+      const data = result.data;
+      if (!Array.isArray(data) || data.length !== batch.length) {
         failed += batch.length;
         continue;
       }
 
-      const vectors: DealVector[] = batch.map((deal, idx) => {
-        const embedding = result.data![idx];
-        return dealToVector(deal, embedding!);
-      });
+      const vectors: DealVector[] = [];
+      let batchFailed = false;
+      for (const [idx, deal] of batch.entries()) {
+        const embedding = data[idx];
+        if (!Array.isArray(embedding)) {
+          batchFailed = true;
+          break;
+        }
+        vectors.push(dealToVector(deal, embedding));
+      }
+      if (batchFailed) {
+        failed += batch.length;
+        continue;
+      }
 
       await upsertDealVectors(env, vectors, "prod");
       successful += batch.length;

--- a/worker/lib/storage.ts
+++ b/worker/lib/storage.ts
@@ -5,6 +5,7 @@ import { generateSnapshotHash } from "./crypto";
 import { executeInBatches } from "./utils";
 import { logger } from "./global-logger";
 import { toErrMessage } from "./errors";
+import { listAllKvKeys } from "./kv-pagination";
 
 // ============================================================================
 // KV Storage Abstraction Layer
@@ -370,7 +371,7 @@ export async function getLastRunMetadata(env: Env) {
  * Clear all staging data
  */
 export async function clearStaging(env: Env): Promise<void> {
-  const list = await env.DEALS_STAGING.list();
+  const list = await listAllKvKeys(env.DEALS_STAGING);
 
   // Optimization: Parallel batch delete instead of sequential loop
   // This reduces latency from O(N) to O(N/batchSize)

--- a/worker/lib/validation/code-validator.ts
+++ b/worker/lib/validation/code-validator.ts
@@ -19,16 +19,18 @@ export { validateCodeOnPage, testCodeRedemption } from "./page-validation";
 // Provider-Specific Code Formats
 // ============================================================================
 
+const GENERIC_PROVIDER_FORMAT: ProviderFormat = {
+  name: "Generic",
+  patterns: [/^[A-Za-z0-9_-]+$/],
+  minLength: 3,
+  maxLength: 50,
+  allowedChars: /^[A-Za-z0-9_-]+$/,
+  caseSensitive: false,
+  examples: ["REFERRAL123", "FRIEND50", "WELCOME2024"],
+};
+
 const PROVIDER_FORMATS: Record<string, ProviderFormat> = {
-  generic: {
-    name: "Generic",
-    patterns: [/^[A-Za-z0-9_-]+$/],
-    minLength: 3,
-    maxLength: 50,
-    allowedChars: /^[A-Za-z0-9_-]+$/,
-    caseSensitive: false,
-    examples: ["REFERRAL123", "FRIEND50", "WELCOME2024"],
-  },
+  generic: GENERIC_PROVIDER_FORMAT,
   trading212: {
     name: "Trading 212",
     patterns: [/^[A-Z]{2,}[0-9]+[A-Z]*$/i, /^[A-Z0-9]{6,20}$/i],
@@ -105,7 +107,7 @@ export function validateCodeFormat(
     };
   }
 
-  const format = PROVIDER_FORMATS[provider] ?? PROVIDER_FORMATS.generic!;
+  const format = PROVIDER_FORMATS[provider] ?? GENERIC_PROVIDER_FORMAT;
 
   if (trimmedCode.length < format.minLength) {
     errors.push(

--- a/worker/lib/validation/scrapers/batch-processor.ts
+++ b/worker/lib/validation/scrapers/batch-processor.ts
@@ -27,10 +27,12 @@ export async function batchScrapeRewards(
   const domainGroups = new Map<string, Deal[]>();
   for (const deal of deals) {
     const domain = extractDomain(deal.url);
-    if (!domainGroups.has(domain)) {
-      domainGroups.set(domain, []);
+    const group = domainGroups.get(domain);
+    if (group) {
+      group.push(deal);
+    } else {
+      domainGroups.set(domain, [deal]);
     }
-    domainGroups.get(domain)!.push(deal);
   }
 
   for (const [, domainDeals] of domainGroups) {

--- a/worker/lib/validation/url-validator.ts
+++ b/worker/lib/validation/url-validator.ts
@@ -266,10 +266,12 @@ export async function checkUrlStatusBatch(
   const domainGroups = new Map<string, string[]>();
   for (const url of limitedUrls) {
     const domain = extractDomain(url);
-    if (!domainGroups.has(domain)) {
-      domainGroups.set(domain, []);
+    const group = domainGroups.get(domain);
+    if (group) {
+      group.push(url);
+    } else {
+      domainGroups.set(domain, [url]);
     }
-    domainGroups.get(domain)!.push(url);
   }
 
   const results: UrlValidationResult[] = [];

--- a/worker/lib/webhook/delivery.ts
+++ b/worker/lib/webhook/delivery.ts
@@ -17,6 +17,7 @@ import { toError } from "../sanitize-error";
 import { logger } from "../global-logger";
 import { fetchInBatches } from "../utils";
 import { validatedFetch } from "../security";
+import { listAllKvKeys } from "../kv-pagination";
 
 /**
  * Delivery-related magic numbers and system policy constants.
@@ -93,7 +94,9 @@ async function getAllActiveSubscriptions(
     if (!kv) return [];
 
     // List all subscription keys
-    const listResult = await kv.list({ prefix: "webhook_subscription:" });
+    const listResult = await listAllKvKeys(kv, {
+      prefix: "webhook_subscription:",
+    });
 
     // Optimization: Parallel batch fetch instead of sequential loop
     // This reduces latency from O(N) to O(N/batchSize)
@@ -312,7 +315,7 @@ export async function getDeadLetterQueue(env: Env): Promise<DeadLetterEvent[]> {
     const kv = getWebhookKV(env);
     if (!kv) return [];
 
-    const listResult = await kv.list({ prefix: "webhook_dlq:" });
+    const listResult = await listAllKvKeys(kv, { prefix: "webhook_dlq:" });
 
     // Optimization: Parallel batch fetch instead of sequential loop
     // This reduces latency from O(N) to O(N/batchSize)

--- a/worker/lib/webhook/sync-executor.ts
+++ b/worker/lib/webhook/sync-executor.ts
@@ -50,15 +50,13 @@ export async function executeSync(
 
   let deals = snapshot.deals;
 
-  if (config.filters?.domains?.length) {
-    deals = deals.filter((d) =>
-      config.filters!.domains!.includes(d.source.domain),
-    );
+  const domainFilters = config.filters?.domains;
+  if (domainFilters?.length) {
+    deals = deals.filter((d) => domainFilters.includes(d.source.domain));
   }
-  if (config.filters?.status?.length) {
-    deals = deals.filter((d) =>
-      config.filters!.status!.includes(d.metadata.status),
-    );
+  const statusFilters = config.filters?.status;
+  if (statusFilters?.length) {
+    deals = deals.filter((d) => statusFilters.includes(d.metadata.status));
   }
 
   const startIndex = state.cursor ? parseInt(state.cursor, 10) || 0 : 0;

--- a/worker/pipeline-executor.ts
+++ b/worker/pipeline-executor.ts
@@ -127,6 +127,13 @@ export async function executePhase(
 
     case "publish":
       try {
+        const snapshot = ctx.snapshot;
+        if (!snapshot) {
+          throw new Error(
+            `Publish attempted without staged snapshot for run ${ctx.run_id}`,
+          );
+        }
+
         if (ctx.scored.length > 0) {
           const guardRailReport = await runGuardRails(ctx.scored, "output");
 
@@ -155,7 +162,7 @@ export async function executePhase(
           }
         }
 
-        await publishSnapshot(env, ctx.snapshot!, ctx);
+        await publishSnapshot(env, snapshot, ctx);
         if (ctx.metrics)
           recordDealCount(ctx.metrics, "published", ctx.scored.length);
 

--- a/worker/pipeline/dedupe.ts
+++ b/worker/pipeline/dedupe.ts
@@ -132,22 +132,22 @@ export function deduplicate(
     seenIds.add(deal.id);
 
     const codeKey = `${deal.source.domain}:${deal.code}`;
-    if (seenCodes.has(codeKey)) {
-      const existing = seenCodes.get(codeKey)!;
+    const existingCodeDeal = seenCodes.get(codeKey);
+    if (existingCodeDeal) {
       result.duplicates.push({
         deal,
-        matched_with: existing.id,
+        matched_with: existingCodeDeal.id,
         reason: "duplicate_code",
       });
       continue;
     }
     seenCodes.set(codeKey, deal);
 
-    if (seenUrls.has(deal.url)) {
-      const existing = seenUrls.get(deal.url)!;
+    const existingUrlDeal = seenUrls.get(deal.url);
+    if (existingUrlDeal) {
       result.duplicates.push({
         deal,
-        matched_with: existing.id,
+        matched_with: existingUrlDeal.id,
         reason: "duplicate_url",
       });
       continue;

--- a/worker/routes/bulk/export.ts
+++ b/worker/routes/bulk/export.ts
@@ -184,6 +184,10 @@ async function queryDealsFromD1(
     offset: number;
   },
 ): Promise<{ deals: ReferralInput[]; total: number }> {
+  if (!env.DEALS_DB) {
+    throw new Error("D1 database not configured");
+  }
+
   // Build dynamic query
   let whereConditions = ["1=1"];
   const bindings: (string | number)[] = [];
@@ -201,10 +205,9 @@ async function queryDealsFromD1(
   const whereClause = whereConditions.join(" AND ");
 
   // Get total count
-  const countResult = await env
-    .DEALS_DB!.prepare(
-      `SELECT COUNT(*) as count FROM referrals WHERE ${whereClause}`,
-    )
+  const countResult = await env.DEALS_DB.prepare(
+    `SELECT COUNT(*) as count FROM referrals WHERE ${whereClause}`,
+  )
     .bind(...bindings)
     .first<{ count: number }>();
 
@@ -221,8 +224,7 @@ async function queryDealsFromD1(
     LIMIT ? OFFSET ?
   `;
 
-  const result = await env
-    .DEALS_DB!.prepare(query)
+  const result = await env.DEALS_DB.prepare(query)
     .bind(...bindings, params.limit, params.offset)
     .all<Record<string, unknown>>();
 

--- a/worker/routes/core/analytics.ts
+++ b/worker/routes/core/analytics.ts
@@ -22,9 +22,8 @@ export async function handleAnalytics(
   request?: Request,
 ): Promise<Response> {
   const format = url.searchParams.get("format") || "json";
-  const days = url.searchParams.has("days")
-    ? parseInt(url.searchParams.get("days")!, 10)
-    : 30;
+  const daysParam = url.searchParams.get("days");
+  const days = daysParam !== null ? parseInt(daysParam, 10) : 30;
 
   try {
     if (format === "summary") {

--- a/worker/routes/core/deals.ts
+++ b/worker/routes/core/deals.ts
@@ -32,14 +32,13 @@ export async function handleGetDeals(
     return jsonResponse({ error: "No deals available" }, 404, request, env);
   }
 
+  const minRewardParam = url.searchParams.get("min_reward");
+  const limitParam = url.searchParams.get("limit");
   const query: GetDealsQuery = {
     category: url.searchParams.get("category") || undefined,
-    min_reward: url.searchParams.has("min_reward")
-      ? parseFloat(url.searchParams.get("min_reward")!)
-      : undefined,
-    limit: url.searchParams.has("limit")
-      ? parseInt(url.searchParams.get("limit")!, 10)
-      : 100,
+    min_reward:
+      minRewardParam !== null ? parseFloat(minRewardParam) : undefined,
+    limit: limitParam !== null ? parseInt(limitParam, 10) : 100,
   };
 
   const validation = GetDealsQuerySchema.safeParse(query);
@@ -63,10 +62,11 @@ export async function handleGetDeals(
     );
   }
 
-  if (query.min_reward !== undefined) {
+  const minReward = query.min_reward;
+  if (minReward !== undefined) {
     deals = deals.filter((d) => {
       if (typeof d.reward.value === "number") {
-        return d.reward.value >= query.min_reward!;
+        return d.reward.value >= minReward;
       }
       return false;
     });
@@ -91,9 +91,8 @@ export async function handleSimilarDeals(
 ): Promise<Response> {
   const code = url.searchParams.get("code");
   const domain = url.searchParams.get("domain");
-  const limit = url.searchParams.has("limit")
-    ? parseInt(url.searchParams.get("limit")!, 10)
-    : 5;
+  const limitParam = url.searchParams.get("limit");
+  const limit = limitParam !== null ? parseInt(limitParam, 10) : 5;
 
   if (!code && !domain) {
     return jsonResponse(
@@ -215,15 +214,14 @@ export async function handleRankedDeals(url: URL, env: Env): Promise<Response> {
   // Parse query parameters
   const sortBy = (url.searchParams.get("sort_by") || "confidence") as SortField;
   const order = (url.searchParams.get("order") || "desc") as SortOrder;
-  const limit = url.searchParams.has("limit")
-    ? parseInt(url.searchParams.get("limit")!, 10)
-    : 50;
-  const minConfidence = url.searchParams.has("min_confidence")
-    ? parseFloat(url.searchParams.get("min_confidence")!)
-    : undefined;
-  const minTrustScore = url.searchParams.has("min_trust")
-    ? parseFloat(url.searchParams.get("min_trust")!)
-    : undefined;
+  const limitParam = url.searchParams.get("limit");
+  const minConfidenceParam = url.searchParams.get("min_confidence");
+  const minTrustParam = url.searchParams.get("min_trust");
+  const limit = limitParam !== null ? parseInt(limitParam, 10) : 50;
+  const minConfidence =
+    minConfidenceParam !== null ? parseFloat(minConfidenceParam) : undefined;
+  const minTrustScore =
+    minTrustParam !== null ? parseFloat(minTrustParam) : undefined;
   const category = url.searchParams.get("category") || undefined;
   const includeScores = url.searchParams.get("include_scores") === "true";
 
@@ -268,9 +266,8 @@ export async function handleDealHighlights(
     return jsonResponse({ error: "No deals available" }, 404, undefined, env);
   }
 
-  const limit = url.searchParams.has("limit")
-    ? parseInt(url.searchParams.get("limit")!, 10)
-    : 5;
+  const limitParam = url.searchParams.get("limit");
+  const limit = limitParam !== null ? parseInt(limitParam, 10) : 5;
 
   const topDeals = getTopDeals(snapshot.deals, limit);
   const expiringSoon = getExpiringDeals(snapshot.deals, 7);

--- a/worker/routes/core/health.ts
+++ b/worker/routes/core/health.ts
@@ -8,6 +8,7 @@ import {
   prometheusResponse,
 } from "../../lib/metrics/prometheus";
 import { logger } from "../../lib/global-logger";
+import { listAllKvKeys } from "../../lib/kv-pagination";
 
 export async function handleHealth(
   env: Env,
@@ -297,7 +298,7 @@ async function getLatestSnapshot(env: Env): Promise<boolean> {
 
 async function getRecentLogs(env: Env): Promise<LogEntry[]> {
   try {
-    const result = await env.DEALS_LOG.list();
+    const result = await listAllKvKeys(env.DEALS_LOG);
     return result.keys.map((k) => JSON.parse(k.metadata as string) as LogEntry);
   } catch {
     return [];

--- a/worker/routes/core/pipeline.ts
+++ b/worker/routes/core/pipeline.ts
@@ -90,9 +90,8 @@ export async function handleGetLogs(
   }
 
   const run_id = url.searchParams.get("run_id");
-  const count = url.searchParams.has("count")
-    ? parseInt(url.searchParams.get("count")!, 10)
-    : 100;
+  const countParam = url.searchParams.get("count");
+  const count = countParam !== null ? parseInt(countParam, 10) : 100;
 
   let logs;
   if (run_id) {

--- a/worker/routes/d1/deals.ts
+++ b/worker/routes/d1/deals.ts
@@ -47,12 +47,12 @@ export async function handleD1Deals(url: URL, env: Env): Promise<Response> {
   const category = url.searchParams.get("category");
   const status = url.searchParams.get("status") || "active";
   const limit = parseInt(url.searchParams.get("limit") || "50", 10);
-  const minConfidence = url.searchParams.has("min_confidence")
-    ? parseFloat(url.searchParams.get("min_confidence")!)
-    : undefined;
-  const expiringDays = url.searchParams.has("expiring_in")
-    ? parseInt(url.searchParams.get("expiring_in")!, 10)
-    : undefined;
+  const minConfidenceParam = url.searchParams.get("min_confidence");
+  const expiringInParam = url.searchParams.get("expiring_in");
+  const minConfidence =
+    minConfidenceParam !== null ? parseFloat(minConfidenceParam) : undefined;
+  const expiringDays =
+    expiringInParam !== null ? parseInt(expiringInParam, 10) : undefined;
 
   try {
     let results;
@@ -126,9 +126,8 @@ export async function handleD1Deals(url: URL, env: Env): Promise<Response> {
 
 export async function handleD1Similar(url: URL, env: Env): Promise<Response> {
   const dealId = url.searchParams.get("deal_id");
-  const limit = url.searchParams.has("limit")
-    ? parseInt(url.searchParams.get("limit")!, 10)
-    : 5;
+  const limitParam = url.searchParams.get("limit");
+  const limit = limitParam !== null ? parseInt(limitParam, 10) : 5;
   const includeExpired = url.searchParams.get("include_expired") === "true";
 
   if (!dealId) {
@@ -186,9 +185,8 @@ export async function handleD1Recommended(
 ): Promise<Response> {
   const domainsParam = url.searchParams.get("domains") || "";
   const domains = domainsParam ? domainsParam.split(",") : [];
-  const limit = url.searchParams.has("limit")
-    ? parseInt(url.searchParams.get("limit")!, 10)
-    : 10;
+  const limitParam = url.searchParams.get("limit");
+  const limit = limitParam !== null ? parseInt(limitParam, 10) : 10;
 
   if (!env.DEALS_DB) {
     return jsonResponse(
@@ -227,12 +225,10 @@ export async function handleD1Recommended(
 // ============================================================================
 
 export async function handleD1Trending(url: URL, env: Env): Promise<Response> {
-  const days = url.searchParams.has("days")
-    ? parseInt(url.searchParams.get("days")!, 10)
-    : 7;
-  const limit = url.searchParams.has("limit")
-    ? parseInt(url.searchParams.get("limit")!, 10)
-    : 10;
+  const daysParam = url.searchParams.get("days");
+  const limitParam = url.searchParams.get("limit");
+  const days = daysParam !== null ? parseInt(daysParam, 10) : 7;
+  const limit = limitParam !== null ? parseInt(limitParam, 10) : 10;
 
   if (!env.DEALS_DB) {
     return jsonResponse(

--- a/worker/routes/dashboard.ts
+++ b/worker/routes/dashboard.ts
@@ -1,6 +1,7 @@
 import type { Env } from "../types";
 import { jsonResponse, errorResponse } from "./utils";
 import { logger } from "../lib/global-logger";
+import { listAllKvKeys } from "../lib/kv-pagination";
 
 export interface DashboardStats {
   stats: {
@@ -151,7 +152,7 @@ async function getRecentActivity(env: Env): Promise<{
     const twentyFourHoursAgo = new Date(
       Date.now() - 24 * 60 * 60 * 1000,
     ).toISOString();
-    const result = await env.DEALS_LOG.list();
+    const result = await listAllKvKeys(env.DEALS_LOG);
     const logs = result.keys
       .map((k) => JSON.parse(k.metadata as string))
       .filter((l: { ts?: string }) => l.ts && l.ts >= twentyFourHoursAgo);

--- a/worker/routes/referrals.ts
+++ b/worker/routes/referrals.ts
@@ -35,6 +35,8 @@ export async function handleGetReferrals(
   request?: Request,
 ): Promise<Response> {
   try {
+    const limitParam = url.searchParams.get("limit");
+    const offsetParam = url.searchParams.get("offset");
     const query: ReferralSearchQuery = {
       domain: url.searchParams.get("domain") || undefined,
       status:
@@ -44,12 +46,8 @@ export async function handleGetReferrals(
       source:
         (url.searchParams.get("source") as ReferralSearchQuery["source"]) ||
         "all",
-      limit: url.searchParams.has("limit")
-        ? parseInt(url.searchParams.get("limit")!, 10)
-        : 100,
-      offset: url.searchParams.has("offset")
-        ? parseInt(url.searchParams.get("offset")!, 10)
-        : 0,
+      limit: limitParam !== null ? parseInt(limitParam, 10) : 100,
+      offset: offsetParam !== null ? parseInt(offsetParam, 10) : 0,
     };
 
     const validation = ReferralSearchQuerySchema.safeParse(query);

--- a/worker/scheduled.ts
+++ b/worker/scheduled.ts
@@ -53,7 +53,7 @@ export async function handleScheduled(
         component: "scheduled",
       });
 
-      const aggResult = await runAggregation(env.DEALS_DB!);
+      const aggResult = await runAggregation(env.DEALS_DB);
 
       logger.info("Daily experience aggregation completed", {
         component: "scheduled",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -166,6 +166,10 @@
       "index_name": "deal-embeddings",
     },
   ],
+  // Workers AI binding used by worker/lib/search/embedding-pipeline.ts (env.AI)
+  "ai": {
+    "binding": "AI",
+  },
   // Environment-specific configurations
   "env": {
     // Development environment for local testing
@@ -248,6 +252,9 @@
           "index_name": "deal-embeddings",
         },
       ],
+      "ai": {
+        "binding": "AI",
+      },
     },
     // Production environment (explicitly defined for --env production flag)
     "production": {
@@ -306,6 +313,9 @@
           "index_name": "deal-embeddings",
         },
       ],
+      "ai": {
+        "binding": "AI",
+      },
       // Durable Objects for atomic concurrency control and stateful coordination
       "durable_objects": {
         "bindings": [


### PR DESCRIPTION
What
Closes F-7 (KV list cursor-pagination helper applied at 10 truncation sites incl. apikey lookup), N-5 (all 55 non-null assertions in worker/ replaced with guards/bindings across routes, lib and pipeline), R-3 (popup.js 512L split to 357+152), R-4 (wrangler.jsonc now declares the AI binding used by embedding-pipeline), T-6/T-7/T-8 (87 focused tests for SourceRegistry DO, d1 trust, expiration helpers).

Why
Unpaginated KV list silently drops data past the first page. Banned non-null assertions were unenforced debt masking crashes. popup.js violated the hard 500-line limit. The AI binding existed in code but not config-as-code. Three test gaps left core modules uncovered.

Impact
KV ops now complete across pages (auth listing correctness at scale); zero banned assertions remain in production code; extension files within limit; semantic search binding declared for config-driven deploys; suite grows +115 to 2727 green tests. Two latent trust.ts/d1-client bugs documented for a future fix sprint.

Verification
Full unit suite green; pev-gates 12/13 (ci-workflow-validator fail is pre-existing BLOCKED-3/ADR-021); tsc, prettier, markdownlint, wrangler dry-run all clean.