### PR TITLE
fix(security): enforce ssrf validation on referral creation

### DIFF
--- a/tests/unit/referral-routing.test.ts
+++ b/tests/unit/referral-routing.test.ts
@@ -42,3 +42,33 @@ describe("New split regex check", () => {
     expect(match).toBeNull();
   });
 });
+
+describe("handleCreateReferral SSRF Validation", () => {
+  it("should reject creation if URL points to prohibited loopback/private IP", async () => {
+    const { handleCreateReferral } =
+      await import("../../worker/routes/referrals");
+    const mockEnv = {} as any;
+
+    const request = new Request("https://example.com/api/referrals", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        code: "TEST1234",
+        url: "https://127.0.0.1/ref",
+        domain: "127.0.0.1",
+      }),
+    });
+
+    const response = await handleCreateReferral(request, mockEnv);
+    expect(response.status).toBe(400);
+
+    const data = (await response.json()) as {
+      error?: string;
+      message?: string;
+    };
+    expect(data.error).toBe("Disallowed URL");
+    expect(data.message).toContain("SSRF protection");
+  });
+});

--- a/worker/routes/referrals.ts
+++ b/worker/routes/referrals.ts
@@ -142,6 +142,20 @@ export async function handleCreateReferral(
       );
     }
 
+    // SSRF Hardening: Prevent SSRF attacks against internal network resources and cloud metadata endpoints
+    if (!(await validateFetchUrl(url))) {
+      return jsonResponse(
+        {
+          error: "Disallowed URL",
+          message:
+            "The provided referral URL failed security validation (SSRF protection).",
+        },
+        400,
+        request,
+        env,
+      );
+    }
+
     const existing = await getReferralByCode(env, code);
     if (existing) {
       return jsonResponse(


### PR DESCRIPTION
What:
Enforced SSRF URL validation in referral creation handler (worker/routes/referrals.ts) using validateFetchUrl.

Why:
Accepting user-submitted referral URLs without strict IP and host validation risks SSRF attacks against internal network resources, local loopback devices, or cloud metadata endpoints.

Impact:
Mitigates SSRF vulnerabilities by ensuring user-submitted referral URLs undergo full IP range and host restrictions before store/processing.

Verification:
Added unit test in tests/unit/referral-routing.test.ts verifying handleCreateReferral returns a 400 Bad Request when provided a loopback or private IP address URL. All unit tests and quality gates pass.

---
*PR created automatically by Jules for task [13836849306662604762](https://jules.google.com/task/13836849306662604762) started by @do-ops885*