### PR TITLE
feat(ux): add tooltip and hide decorative icon for rescan button

### DIFF
--- a/extension/popup.html
+++ b/extension/popup.html
@@ -695,8 +695,9 @@
         class="settings-btn"
         id="refresh-btn"
         aria-label="Rescan page"
+        title="Rescan page"
       >
-        🔄
+        <span aria-hidden="true">🔄</span>
       </button>
     </div>
 


### PR DESCRIPTION
Enhances the accessibility and visual hover feedback of the Chrome extension rescan button (#refresh-btn) by adding a title attribute and wrapping its decorative emoji icon in an aria-hidden span.

---
*PR created automatically by Jules for task [3629220795006562660](https://jules.google.com/task/3629220795006562660) started by @do-ops885*