### PR TITLE
[Jules Audit] Docs: add JSDoc annotations for parseBoundedIntegerConfig

### DIFF
--- a/plans/jules-audit/AUDIT_DOCS.md
+++ b/plans/jules-audit/AUDIT_DOCS.md
@@ -1,33 +1,5 @@
-# Track D — Documentation Report — 2026-08-20
+# Documentation Audit Findings - 2026-08-29
 
-## Summary
-Audited public functions and interfaces in `worker/lib/ranking.ts` and `worker/lib/crypto.ts` for JSDoc comment completeness (`@param`, `@returns`).
-
-## Documentation Updates
-
-### 1. Ranking Utilities (`worker/lib/ranking.ts`)
-- Added `@param` and `@returns` annotations to public functions:
-  - `calculateDealScore`: Deal score calculation
-  - `calculateDetailedScore`: Detailed score breakdown calculation
-  - `sortDeals`: Sorting deals by field and direction
-  - `rankDeals`: Ranking and filtering deals
-  - `getTopDeals`: Retrieval of top deals by score
-  - `getExpiringDeals`: Retrieval of deals expiring within N days
-  - `getRecentDeals`: Retrieval of deals discovered within N days
-  - `getHighValueDeals`: Retrieval of high value deals exceeding reward threshold
-
-### 2. Cryptographic Utilities (`worker/lib/crypto.ts`)
-- Added `@param` and `@returns` annotations to public functions:
-  - `sha256`: SHA-256 string hashing
-  - `generateDealId`: Canonical deal ID generation
-  - `generateSnapshotHash`: Canonical snapshot hash generation
-  - `generateRunId`: Run ID generation from Date
-  - `generateUUID`: Cryptographic UUID v4 generation
-  - `normalizedEquals`: Zero-allocation string equality comparison
-  - `getBigramBitset`: Bitset extraction for character bigrams
-  - `calculateStringSimilarityPrecomputed`: Jaccard similarity calculation on precomputed bitsets
-  - `calculateStringSimilarity`: Character bigram string similarity calculation
-  - `base64urlEncode`: Base64url encoding for string or Uint8Array
-  - `precomputeUrlSimilarityData`: Precomputation of URL fields for fast similarity
-  - `calculateUrlSimilarityPrecomputed`: URL similarity on precomputed structures
-  - `calculateUrlSimilarity`: URL similarity for semantic deduplication
+| Function / Public API | Location | Finding | Action Taken |
+| --- | --- | --- | --- |
+| `parseBoundedIntegerConfig` | `worker/lib/config-utils.ts` | Missing JSDoc comment | Added comprehensive JSDoc annotations with `@param`, `@returns`, and `@throws` tags. |

--- a/worker/lib/config-utils.ts
+++ b/worker/lib/config-utils.ts
@@ -1,6 +1,16 @@
 import { CONFIG } from "../config";
 import type { Env } from "../types";
 
+/**
+ * Parses an optional environment string into a safe integer bounded by min and max values.
+ * @param name Parameter name for error messages
+ * @param value String value from environment variable or undefined
+ * @param fallback Default value to return if value is undefined or empty
+ * @param minimum Minimum permissible integer value (inclusive)
+ * @param maximum Maximum permissible integer value (inclusive)
+ * @returns Parsed bounded integer or fallback
+ * @throws Error if value is not a valid integer or falls outside minimum/maximum limits
+ */
 export function parseBoundedIntegerConfig(
   name: string,
   value: string | undefined,


### PR DESCRIPTION
## What was found
Public function `parseBoundedIntegerConfig` in `worker/lib/config-utils.ts` was missing JSDoc annotations.

## What was changed
Added `@param`, `@returns`, and `@throws` JSDoc annotations to `parseBoundedIntegerConfig` in `worker/lib/config-utils.ts`.

## Quality Gate
Status: PASS ✅
Command used: `bash ./scripts/quality_gate.sh`

## Audit files location
`plans/jules-audit/`

## Skipped / Needs Human Review
None

---
*PR created automatically by Jules for task [13822905924617970833](https://jules.google.com/task/13822905924617970833) started by @do-ops885*