### PR TITLE
docs(guardrails): enforce never merge with failing ci

### DIFF
--- a/.agents/skills/guard-rails/SKILL.md
+++ b/.agents/skills/guard-rails/SKILL.md
@@ -194,6 +194,43 @@ const quality = GuardRails.quality({
 });
 ```
 
+## Merge Guardrail (NON-NEGOTIABLE)
+
+**Rule: NEVER merge a PR with failing CI.** External quality gates are required and blocking.
+
+```typescript
+Rule.custom({
+  name: 'no-merge-on-red-ci',
+  check: (ctx) => {
+    const required = [
+      'CI Summary', 'Type Check', 'Format Check', 'Docs Validation',
+      'Validation Gates', 'Unit Tests', 'E2E Tests', 'Smoke Tests',
+      'Security Scan', 'Build', 'Quality Gate',
+      'CodeQL (actions, javascript-typescript)', 'Codacy Static Code Analysis',
+      'Workers Builds'
+    ];
+    for (const c of ctx.statusCheckRollup) {
+      if (required.includes(c.name) && c.conclusion !== 'SUCCESS') {
+        return { pass: false, message: `Blocked: ${c.name} is ${c.conclusion} — fix before merge` };
+      }
+    }
+    return { pass: true };
+  }
+});
+```
+
+Pre-merge verification (required):
+```bash
+gh pr view <n> --json statusCheckRollup -q '.statusCheckRollup[] | "\(.name): \(.conclusion)"'
+gh pr checks <n>  # must show 0 failures
+# Do not use --admin or admin bypass
+```
+
+Policy:
+- Any `FAILURE`, `ACTION_REQUIRED`, `TIMED_OUT`, `CANCELLED` blocks merge. `SKIPPED` only for non-required jobs like `auto-merge`.
+- External analysis (Codacy, DeepSource, CodeQL) failures — including `ACTION_REQUIRED` or `Not up to standards` with critical/high findings — must be resolved or explicitly triaged with reviewed suppression before merge.
+- Branch protection MUST require checks above; if missing, file ADR and block merge.
+
 ## Directory Hygiene Policy
 
 | Rule | Pattern | Allowed Location | Severity |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,12 @@ readonly DEFAULT_TIMEOUT_SECONDS=1800
   - Local pre-push verification: `npm run lint && npm run test:unit` (or `test:ci`) and `./scripts/quality_gate.sh` must pass before `git push`.
   - If CI fails after push, fix in the same PR (amend/push) — never open a follow-up to fix CI.
   - For Full Mode, include GOAP_STATE version bump and ADR/spec updates in the same PR; verify `plans/` docs are in sync.
+- **Merge Guardrail (NON-NEGOTIABLE)**: NEVER merge a PR with failing CI.
+  - Required checks: `CI Summary`, `Type Check`, `Format Check`, `Docs Validation`, `Validation Gates`, `Unit Tests`, `E2E Tests`, `Smoke Tests`, `Security Scan`, `Build`, `Quality Gate`, `CodeQL (actions, javascript-typescript)`, `Codacy Static Code Analysis`, `Workers Builds`. No exceptions — external quality gates are required.
+  - Any conclusion != `SUCCESS` blocks merge: `FAILURE`, `ACTION_REQUIRED`, `TIMED_OUT`, `CANCELLED` all block. `SKIPPED` only allowed for non-required jobs like `auto-merge`.
+  - Verify before merge: `gh pr view <n> --json statusCheckRollup -q '.statusCheckRollup[] | "\(.name): \(.conclusion)"'` and `gh pr checks <n>` must show zero failures. Do not use `--admin` or admin bypass.
+  - External analysis (Codacy, DeepSource, CodeQL) failures — including `ACTION_REQUIRED` or `Not up to standards` with critical/high findings — must be resolved or explicitly triaged with reviewed suppression before merge.
+  - Branch protection MUST require the checks above; if missing, block merge and file ADR.
 
 ## 5. Operational Commands & Standards
 - Setup & Quality: `./scripts/agent-toolkit.sh setup` | `./scripts/pev-gates.sh` | `./scripts/quality_gate.sh` (13+ quality gates)


### PR DESCRIPTION
What:
Add NON-NEGOTIABLE merge guardrail to AGENTS.md and guard-rails skill. Requires all CI checks (CI Summary, Type Check, Format Check, Docs Validation, Validation Gates, Unit Tests, E2E Tests, Smoke Tests, Security Scan, Build, Quality Gate, CodeQL, Codacy, Workers Builds) to be SUCCESS before merge. Any FAILURE/ACTION_REQUIRED/TIMED_OUT/CANCELLED blocks merge; external gates treated as required.

Why:
Prevent merging with failing CI (e.g. Codacy ACTION_REQUIRED / Not up to standards with critical/high findings). Direct push to main is now blocked by branch protection — this change must go via PR and pass required checks.

Impact:
Branch protection violations now fail fast. Verification requires gh pr checks and statusCheckRollup to show zero failures before merge.