### PR TITLE
perf(pipeline): eliminate double hash and duplicate snapshot fetches

### DIFF
--- a/plans/PEV-snapshot-optimize.md
+++ b/plans/PEV-snapshot-optimize.md
@@ -1,0 +1,37 @@
+# PEV Spec — Snapshot Pipeline Optimize (F-8)
+
+**Title**: Eliminate double hash and duplicate KV re-parses in stage/publish (F-8)
+**Author**: opencode
+**Date**: 2026-09-02
+**Priority**: medium
+
+## Goal
+Reduce snapshot re-parses from ~5x to 2x per run and eliminate double hash computation in stage/publish path.
+
+## Approach
+Add cached helpers in `worker/lib/storage.ts` (`putStagingSnapshot` direct write + `promoteStagingToProduction` with injected staging/production) and repoint `worker/pipeline/stage.ts` and `worker/publish.ts` to reuse already-fetched snapshots and already-computed hash.
+
+## Non-Goals
+- Not changing validation or schema
+- Not touching circuit breaker (F-10 done)
+- Not adding new storage backend
+
+## Steps
+| Step | Description | Files Touched | Risk |
+| 1 | Add putStagingSnapshot + promoteStagingToProduction cached variants | worker/lib/storage.ts | low |
+| 2 | Stage: reuse hash, write via putStagingSnapshot, verify with cached read | worker/pipeline/stage.ts | low |
+| 3 | Publish: reuse staging+production fetched in steps 1-2, promote via cached helper | worker/publish.ts | low |
+
+## Acceptance Criteria
+- [ ] No second `generateSnapshotHash` call in stage path for same deals array
+- [ ] `promoteToProduction` not double-fetching staging/production when caller already has them
+- [ ] `npx tsc --noEmit` passes
+- [ ] `npm run test:unit` passes
+- [ ] pev-gates format/typecheck pass (ci-workflow-validator triaged)
+
+## Open Questions
+- None
+
+## Risk Assessment
+| Risk | Impact | Mitigation |
+| Cached snapshot stale vs KV | low | Hash chain check still validates against cached prod snapshot; fallback to fetch if null |

--- a/worker/lib/storage.ts
+++ b/worker/lib/storage.ts
@@ -52,7 +52,28 @@ export async function getStagingSnapshot(env: Env): Promise<Snapshot | null> {
 }
 
 /**
- * Write snapshot to staging (candidate)
+ * Write snapshot to staging (candidate) — direct put without recomputing hash.
+ * Caller must have already computed `snapshot_hash`; validates and writes.
+ * Fixes F-8 double-hash path in stage.ts.
+ */
+export async function putStagingSnapshot(
+  env: Env,
+  snapshot: Snapshot,
+): Promise<void> {
+  const result = SnapshotSchema.safeParse(snapshot);
+  if (!result.success) {
+    throw new Error(`Invalid snapshot: ${result.error.message}`);
+  }
+  await env.DEALS_STAGING.put(
+    CONFIG.KV_KEYS.STAGING_SNAPSHOT,
+    JSON.stringify(snapshot),
+  );
+}
+
+/**
+ * Write snapshot to staging (candidate) — legacy helper that computes hash.
+ * Kept for backward compat; stage.ts now uses putStagingSnapshot to avoid
+ * double hash.
  */
 export async function writeStagingSnapshot(
   env: Env,
@@ -79,7 +100,43 @@ export async function writeStagingSnapshot(
 }
 
 /**
- * Promote staging to production (atomic operation)
+ * Promote staging to production (atomic operation) — cached variant.
+ * If `cachedStaging` / `cachedProd` are supplied, avoids re-fetching
+ * (F-8: publish already has both).
+ */
+export async function promoteStagingToProduction(
+  env: Env,
+  cachedStaging: Snapshot,
+  expectedPreviousHash: string,
+  cachedProd: Snapshot | null | undefined = undefined,
+): Promise<Snapshot> {
+  let staging: Snapshot | null = cachedStaging;
+  if (!staging) {
+    staging = await getStagingSnapshot(env);
+  }
+  if (!staging) {
+    throw new Error("No staging snapshot found to promote");
+  }
+  let currentProd: Snapshot | null | undefined = cachedProd;
+  if (cachedProd === undefined) {
+    currentProd = await getProductionSnapshot(env);
+  }
+  const actualPreviousHash = currentProd?.snapshot_hash || "";
+  if (actualPreviousHash !== expectedPreviousHash) {
+    throw new Error(
+      `Hash chain broken: expected ${expectedPreviousHash}, got ${actualPreviousHash}`,
+    );
+  }
+  await env.DEALS_PROD.put(
+    CONFIG.KV_KEYS.PROD_SNAPSHOT,
+    JSON.stringify(staging),
+  );
+  return staging;
+}
+
+/**
+ * Promote staging to production (atomic operation) — legacy entry point
+ * that re-fetches both snapshots (kept for compat).
  */
 export async function promoteToProduction(
   env: Env,

--- a/worker/pipeline/stage.ts
+++ b/worker/pipeline/stage.ts
@@ -1,12 +1,8 @@
 import { Deal, Snapshot, PipelineContext } from "../types";
 import { SnapshotSchema } from "../types";
 import { CONFIG } from "../config";
-import {
-  generateSnapshotHash,
-  generateRunId,
-  generateUUID,
-} from "../lib/crypto";
-import { writeStagingSnapshot } from "../lib/storage";
+import { generateSnapshotHash } from "../lib/crypto";
+import { putStagingSnapshot } from "../lib/storage";
 import type { Env } from "../types";
 
 // ============================================================================
@@ -71,10 +67,10 @@ export async function stage(
     throw new Error(`Invalid snapshot: ${validation.error.message}`);
   }
 
-  // Write to staging
-  await writeStagingSnapshot(env, snapshotBase);
+  // Write to staging — use direct put to avoid second hash (F-8)
+  await putStagingSnapshot(env, snapshot);
 
-  // Read-after-write verification
+  // Read-after-write verification (single read, no re-hash)
   const verified = await verifyStaging(env, snapshot);
 
   return {

--- a/worker/publish.ts
+++ b/worker/publish.ts
@@ -1,5 +1,5 @@
 import { Snapshot, PipelineContext, PipelineError } from "./types";
-import { promoteToProduction, revertProduction } from "./lib/storage";
+import { promoteStagingToProduction, revertProduction } from "./lib/storage";
 import {
   commitSnapshot,
   isSnapshotCommitted,
@@ -100,10 +100,12 @@ export async function publishSnapshot(
       return { success: true };
     }
 
-    // Step 4: Promote to production KV
-    const publishedSnapshot = await promoteToProduction(
+    // Step 4: Promote to production KV — reuse cached staging/production (F-8)
+    const publishedSnapshot = await promoteStagingToProduction(
       env,
+      staging,
       expectedPreviousHash,
+      production,
     );
 
     // Step 5: Batch-insert referral records from snapshot into D1


### PR DESCRIPTION
What: add putStagingSnapshot direct write and promoteStagingToProduction cached variant in worker/lib/storage.ts:54 and worker/lib/storage.ts:86. Repoint worker/pipeline/stage.ts:75 to reuse already-computed hash via putStagingSnapshot and worker/publish.ts:104 to reuse cached staging/production via promoteStagingToProduction. Keeps legacy writeStagingSnapshot/promoteToProduction for compat.

Why: GOAP_STATE.md:103 F-8 identified publish/stage re-parsing snapshots ~5x per run + double hash. Stage computed hash then write helper recomputed; publish fetched staging+production then promote re-fetched both.

Impact: single hash per stage, zero extra KV reads on promotion when cache supplied, no validation change. tsc clean, 2732 tests pass.