### PR TITLE
fix(lock): use inclusive expiry for d1 takeover and deterministic test

### DIFF
--- a/tests/fixtures/d1-mock.ts
+++ b/tests/fixtures/d1-mock.ts
@@ -77,11 +77,11 @@ export function createMockD1(storage: Map<string, LockRow>) {
           }
           return { success: true, results: [], meta: { changes: 0 } };
         }
-        if (sql.includes("UPDATE") && sql.includes("expires_at <")) {
+        if (sql.includes("UPDATE") && sql.includes("expires_at <=")) {
           const existing = storage.get(LOCK);
           if (
             existing &&
-            new Date(existing.expires_at) < new Date(params[5] as string)
+            new Date(existing.expires_at) <= new Date(params[5] as string)
           ) {
             storage.set(LOCK, {
               lock_name: LOCK,

--- a/tests/unit/pipeline-lock-maintenance.lifecycle.test.ts
+++ b/tests/unit/pipeline-lock-maintenance.lifecycle.test.ts
@@ -92,12 +92,14 @@ describe("PipelineLock — expiry, lifecycle, metadata", () => {
       );
     });
 
-    it("acquireLock: INSERT fails + UPDATE fails for expiring-now lock (strict < boundary)", async () => {
-      // The production code uses `WHERE expires_at < ?6` (strict less-than).
-      // When expires_at equals now, the UPDATE won't match and INSERT won't
-      // insert (row exists). This results in the "unexpected state" error —
-      // a known boundary gap in the current implementation.
-      const nowIso = new Date().toISOString();
+    it("acquireLock: should takeover lock expiring now (inclusive <= boundary)", async () => {
+      // The production code uses `WHERE expires_at <= ?6` (inclusive).
+      // When expires_at equals now, the UPDATE should match and takeover
+      // the expired lock. Use fake timers to make the boundary deterministic.
+      vi.useFakeTimers();
+      const now = new Date("2024-01-02T00:00:00.000Z");
+      vi.setSystemTime(now);
+      const nowIso = now.toISOString();
       storage.set("pipeline:lock", {
         lock_name: "pipeline:lock",
         run_id: "run-boundary",
@@ -106,9 +108,14 @@ describe("PipelineLock — expiry, lifecycle, metadata", () => {
         expires_at: nowIso,
       });
 
-      await expect(acquireLock(env, "run-new", "trace-new")).rejects.toThrow(
-        "Lock acquisition failed",
-      );
+      try {
+        const result = await acquireLock(env, "run-new", "trace-new");
+        expect(result).toBe(true);
+        expect(storage.get("pipeline:lock")!.run_id).toBe("run-new");
+        expect(storage.get("pipeline:lock")!.trace_id).toBe("trace-new");
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/worker/lib/lock.ts
+++ b/worker/lib/lock.ts
@@ -285,7 +285,7 @@ async function acquireLockViaD1(
       env.DEALS_DB.prepare(
         `UPDATE pipeline_locks
          SET run_id = ?2, trace_id = ?3, acquired_at = ?4, expires_at = ?5
-         WHERE lock_name = ?1 AND expires_at < ?6`,
+         WHERE lock_name = ?1 AND expires_at <= ?6`,
       ).bind(LOCK_NAME, run_id, trace_id, nowIso, expiresIso, nowIso),
       env.DEALS_DB.prepare(
         `SELECT run_id, trace_id, acquired_at, expires_at


### PR DESCRIPTION
What: Change D1 lock takeover from strict < to inclusive <= in worker/lib/lock.ts and tests/fixtures/d1-mock.ts, and make boundary test deterministic with fake timers.

Why: CI on main failing at 33637577906 - Unit Tests failed on pipeline-lock-maintenance.lifecycle.test.ts flaky strict < boundary. Race between test now and production now causes non-deterministic takeover.

Impact: Fixes flaky CI, aligns D1 and DO inclusive semantics (expired when expires_at <= now), no runtime metric change.