### PR TITLE
fix(security): resolve ipv4-compatible ipv6 ssrf bypass

### DIFF
--- a/tests/unit/ssrf-bypass.test.ts
+++ b/tests/unit/ssrf-bypass.test.ts
@@ -21,6 +21,23 @@ describe("Security Utils - validateFetchUrl SSRF Bypass Prevention", () => {
     }
   });
 
+  it("should block IPv4-compatible IPv6 and unspecified IPv6 addresses", async () => {
+    const compatibleUrls = [
+      "https://[::]/",
+      "https://[::0]/",
+      "https://[::127.0.0.1]/",
+      "https://[0:0:0:0:0:0:127.0.0.1]/",
+      "https://[::7f00:1]/",
+      "https://[0:0:0:0:0:0:7f00:1]/",
+      "https://[::10.0.0.1]/",
+    ];
+
+    for (const url of compatibleUrls) {
+      const result = await validateFetchUrl(url);
+      expect(result).toBe(false);
+    }
+  });
+
   it("should still block standard private IPv6 addresses", async () => {
     const privateIpv6 = [
       "https://[::1]/",

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -159,6 +159,7 @@ export const CONFIG = {
     "localhost",
     "127.0.0.1",
     "::1",
+    "::",
     "localhost.localdomain",
   ],
   BLOCKED_IP_RANGES: [
@@ -177,6 +178,7 @@ export const CONFIG = {
     "224.0.0.0/4",
     "240.0.0.0/4",
     "::1/128",
+    "::/128",
     "fc00::/7",
     "fe80::/10",
     "ff00::/8",

--- a/worker/lib/security.ts
+++ b/worker/lib/security.ts
@@ -28,6 +28,7 @@ const SECURITY_CONSTANTS = {
     "localhost",
     "127.0.0.1",
     "::1",
+    "::",
     "localhost.localdomain",
   ] as const,
   BLOCKED_IP_RANGES: [
@@ -46,6 +47,7 @@ const SECURITY_CONSTANTS = {
     "224.0.0.0/4",
     "240.0.0.0/4",
     "::1/128",
+    "::/128",
     "fc00::/7",
     "fe80::/10",
     "ff00::/8",
@@ -184,7 +186,10 @@ function isIpAddress(hostname: string): boolean {
 
 function normalizeIp(ip: string): string {
   const normalized = ip.toLowerCase();
-  const mappedMatch = normalized.match(/^(?:[0:]+:ffff:)(.+)$/);
+  // Normalize IPv4-mapped (::ffff:x.x.x.x) and IPv4-compatible (::x.x.x.x) IPv6 addresses
+  const mappedMatch = normalized.match(
+    /^(?:[0:]+(?:ffff:)?)((?:\d{1,3}\.){3}\d{1,3}|[0-9a-f]{1,4}:[0-9a-f]{1,4})$/i,
+  );
   if (mappedMatch?.[1]) {
     const inner = mappedMatch[1];
     if (inner.includes(".")) return inner;


### PR DESCRIPTION
What:
Hardened SSRF protection in worker/lib/security.ts and worker/config.ts by adding :: to BLOCKED_HOSTS and ::/128 to BLOCKED_IP_RANGES, and updating normalizeIp to parse and normalize IPv4-compatible IPv6 addresses (e.g., ::127.0.0.1, ::7f00:1) into standard IPv4 dotted-decimal representations for CIDR checking. Added unit test cases in tests/unit/ssrf-bypass.test.ts.

Why:
IPv4-compatible IPv6 addresses (::x.x.x.x) and the unspecified IPv6 address (::) bypassed SSRF validation logic because normalizeIp previously only handled IPv4-mapped IPv6 addresses (::ffff:x.x.x.x).

Impact:
Eliminates SSRF bypass vectors targeting internal loopback and private IPv4 ranges via IPv4-compatible IPv6 addresses and unspecified IPv6 addresses.

Verification:
All 2,745 unit tests passed via `npm run test:unit`, including new test cases in tests/unit/ssrf-bypass.test.ts.

---
*PR created automatically by Jules for task [10873231446826559997](https://jules.google.com/task/10873231446826559997) started by @do-ops885*