### PR TITLE
fix(d1): reject failed writes instead of resolving envelope

### DIFF
--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -2,9 +2,23 @@
 
 **Generated**: 2026-07-06
 **Last Updated**: 2026-09-03
-**Version**: 0.19.3
-**Status**: Active — 2026-09-03 webhook hardening + atomic rate limit + trust batch fix (branch `fix/webhook-scoping-rate-limit-trust`): WS-E latent bug #1 closed, DO atomic rate limits, user-scoped webhook ownership. 2026-08-31 self-learning-feedback full suite COMPLETE per [SPEC-self-learning-feedback-full.md](SPEC-self-learning-feedback-full.md) + [ADR-024](ADR-024-skill-version-independence.md): 14 scripts wired (RYAN/FLASH/SYNTHESIS), skill-independent version policy, 2 lessons captured. 2026-08-25 improvement swarm COMPLETE (F-7/N-5/popup/AI/T-6-T-8) — code already on `main` (commits `ebe9323`, `b14380a`, `61dbc87`, `3465d06`, `b89d69d`, `1b251b4`), GOAP docs re-synced. 2026-08-24 improvement run also COMPLETE via PR #713.
+**Version**: 0.19.4
+**Status**: Active — 2026-09-03 WS-E latent bug #2 closed (branch `fix/d1-write-reject`): D1 writes reject instead of resolving `{error}` envelopes. 2026-09-03 webhook hardening + trust batch fix merged as `fb0c6e5` (PR #741): WS-E latent bug #1 closed, JWT hardening, user-scoped webhook ownership; DO rate-limit attempt reverted (deferred per ADR-017). 2026-08-31 self-learning-feedback full suite COMPLETE per [SPEC-self-learning-feedback-full.md](SPEC-self-learning-feedback-full.md) + [ADR-024](ADR-024-skill-version-independence.md): 14 scripts wired (RYAN/FLASH/SYNTHESIS), skill-independent version policy, 2 lessons captured. 2026-08-25 improvement swarm COMPLETE (F-7/N-5/popup/AI/T-6-T-8) — code already on `main`, GOAP docs re-synced. 2026-08-24 improvement run also COMPLETE via PR #713.
 **Sources**: [Codebase Audit (04/04)](../reports/analysis/codebase-audit-2026-04-04.md), [Swarm Analysis (04/04)](../reports/analysis/swarm-missing-implementations-2026-04-04.md), [Feature Gap Analysis](../reports/analysis/feature-gap-analysis.md), [ADR-015](ADR-015-harness-cloudflare-2026-best-practices.md), [ADR-024](ADR-024-skill-version-independence.md)
+
+---
+
+## 2026-09-03 D1 Write Rejection (WS-E-2) — v0.19.4
+
+Branch: `fix/d1-write-reject`.
+
+| ID | Finding | Priority | Status | Evidence |
+|:---|:---|:---|:---|:---|
+| WS-E-2 | `executeWithRetry` resolved `{error}` instead of rejecting, masking permanent write failures (dual-write divergence, trust loss) | P1 | ✅ CLOSED — writes throw after logging; reads keep envelope (pinned by tests). Boundaries map to `{success:false}`: mutations `executeWrite`, experience `executeWrite` + aggregation short-circuit, `batchInsert` catch, `evolveTrust` warn-and-continue. Dual-write/migration catches now actually fire | worker/lib/d1/client.ts, worker/lib/d1/mutations.ts, worker/lib/d1/experience.ts, worker/lib/d1/trust.ts |
+
+Verification: `npx tsc --noEmit` ✅, `npm run lint` ✅, `npm run test:unit` 2748/2748 ✅ (4 new rejection/mapping tests, zero contract changes).
+
+Remaining: F-11/N-3 deferred; RL-1 deferred per ADR-017.
 
 ---
 
@@ -21,7 +35,7 @@ Branch: `fix/webhook-scoping-rate-limit-trust` (3 atomic commits).
 
 Verification: `npx tsc --noEmit` ✅, `npm run lint` ✅, `npm run validate` 0 errors, `npm run build` ✅, `npm run test:unit` 2749/2749 ✅.
 
-Remaining: WS-E latent bug #2 (`d1/client.ts` `executeWithRetry` resolves `{error}`) still open; F-11/N-3 deferred.
+Remaining at the time: WS-E latent bug #2 — now CLOSED above in v0.19.4; F-11/N-3 deferred.
 
 ---
 

--- a/tests/unit/d1/client.core.test.ts
+++ b/tests/unit/d1/client.core.test.ts
@@ -273,6 +273,18 @@ describe("d1/client", () => {
       expect(result.lastRowId).toBe(42);
       expect(result.changes).toBe(1);
     });
+
+    it("rejects instead of resolving an error envelope when the write fails", async () => {
+      const { db, mocks } = buildMockDb();
+      (mocks.run as Mock).mockRejectedValueOnce(
+        new Error("constraint failed: UNIQUE"),
+      );
+      const client = new D1Client(db);
+
+      await expect(
+        client.execute("INSERT INTO deals (id) VALUES (?)", [1]),
+      ).rejects.toThrow("constraint failed");
+    });
   });
 
   describe("raw()", () => {
@@ -310,6 +322,16 @@ describe("d1/client", () => {
       expect(result.success).toBe(true);
       expect(mocks.exec).not.toHaveBeenCalled();
     });
+
+    it("rejects when the underlying exec fails", async () => {
+      const { db, mocks } = buildMockDb();
+      (mocks.exec as Mock).mockRejectedValueOnce(new Error("disk I/O error"));
+      const client = new D1Client(db);
+
+      await expect(
+        client.raw("CREATE TABLE foo (id INTEGER);"),
+      ).rejects.toThrow("disk I/O error");
+    });
   });
 
   // ============================================================================
@@ -336,6 +358,20 @@ describe("d1/client", () => {
       expect(result.results[0]?.data).toEqual([{ id: 1 }]);
       expect(result.results[1]?.data).toEqual([{ id: 2 }]);
       expect(mocks.batch).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects when the underlying batch fails", async () => {
+      const { db, mocks } = buildMockDb();
+      (mocks.batch as Mock).mockRejectedValueOnce(
+        new Error("too many statements"),
+      );
+      const client = new D1Client(db);
+
+      await expect(
+        client.batch([
+          { sql: "INSERT INTO deals (id) VALUES (?)", params: [1] },
+        ]),
+      ).rejects.toThrow("too many statements");
     });
   });
 

--- a/tests/unit/experience-d1.test.ts
+++ b/tests/unit/experience-d1.test.ts
@@ -204,5 +204,28 @@ describe("Experience D1 Queries", () => {
       expect(result.dealsProcessed).toBe(0);
       expect(result.eventsProcessed).toBe(0);
     });
+
+    it("should return an error envelope when an aggregate write fails", async () => {
+      currentMockStatement.run
+        .mockResolvedValueOnce({
+          results: [{ deal_code: "DEAL1" }],
+          success: true,
+          meta: { rows_read: 1, rows_written: 0 },
+        })
+        .mockRejectedValueOnce(new Error("D1 write failed"));
+
+      currentMockStatement.first.mockResolvedValueOnce({
+        total: 5,
+        positive: 3,
+        negative: 1,
+        avg: 40,
+      });
+
+      const result = await runAggregation(mockDb as unknown as D1Database);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("D1 write failed");
+      expect(result.dealsProcessed).toBe(0);
+    });
   });
 });

--- a/worker/lib/d1/client.ts
+++ b/worker/lib/d1/client.ts
@@ -279,7 +279,15 @@ export class D1Client {
       params: columns.map((col) => row[col]),
     }));
 
-    const result = await this.batch<unknown>(queries);
+    let result;
+    try {
+      result = await this.batch<unknown>(queries);
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
 
     if (!result.success || result.error) {
       return { success: false, error: result.error };
@@ -513,9 +521,14 @@ export class D1Client {
       maxAttempts,
     });
 
-    // Return error envelope instead of throwing so callers can
-    // return graceful fallbacks (empty arrays / success:false) — matches
-    // historical behavior expected by unit tests and analytics queries.
+    // Writes reject so permanent failures (e.g. dual-write divergence,
+    // migration bookkeeping) surface to callers instead of resolving
+    // into a silent envelope. Reads keep the historical error envelope
+    // so analytics paths can return graceful fallbacks.
+    if (options.isWrite === true) {
+      throw lastError instanceof Error ? lastError : new Error(errorMessage);
+    }
+
     return { error: errorMessage } as R & { error?: string };
   }
 

--- a/worker/lib/d1/client.ts
+++ b/worker/lib/d1/client.ts
@@ -279,7 +279,11 @@ export class D1Client {
       params: columns.map((col) => row[col]),
     }));
 
-    let result;
+    let result: {
+      success: boolean;
+      results: Array<QueryResult<unknown>>;
+      error?: string;
+    };
     try {
       result = await this.batch<unknown>(queries);
     } catch (error) {

--- a/worker/lib/d1/experience.ts
+++ b/worker/lib/d1/experience.ts
@@ -22,6 +22,31 @@ export interface AggregationResult {
   error?: string;
 }
 
+type WriteClient = ReturnType<typeof createD1Client>;
+
+/**
+ * Execute a write and map a rejection to a failure envelope.
+ *
+ * D1Client.execute rejects on write failure so silent divergence is
+ * impossible; experience helpers translate that into their historical
+ * {success, error} contract.
+ */
+async function executeWrite(
+  client: WriteClient,
+  sql: string,
+  params: unknown[],
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const result = await client.execute(sql, params);
+    return { success: result.success, error: result.error };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
 export async function submitExperienceEvent(
   db: D1Database,
   event: {
@@ -35,7 +60,8 @@ export async function submitExperienceEvent(
 ): Promise<ExperienceEventResult> {
   const client = createD1Client(db);
 
-  const result = await client.execute(
+  const result = await executeWrite(
+    client,
     `INSERT INTO experience_events (id, deal_code, event_type, agent_id, score, metadata, created_at)
      VALUES (?, ?, ?, ?, ?, ?, ?)`,
     [
@@ -135,7 +161,8 @@ export async function runAggregation(
     const stats = statsResult.data;
     const now = Math.floor(Date.now() / 1000);
 
-    await client.execute(
+    const writeResult = await executeWrite(
+      client,
       `INSERT INTO experience_aggregates (deal_code, total_events, positive_events, negative_events, avg_score, last_updated)
        VALUES (?, ?, ?, ?, ?, ?)
        ON CONFLICT(deal_code) DO UPDATE SET
@@ -153,6 +180,15 @@ export async function runAggregation(
         now,
       ],
     );
+
+    if (!writeResult.success) {
+      return {
+        success: false,
+        dealsProcessed,
+        eventsProcessed,
+        error: writeResult.error || "Failed to write aggregate",
+      };
+    }
 
     dealsProcessed++;
     eventsProcessed += stats.total || 0;

--- a/worker/lib/d1/mutations.ts
+++ b/worker/lib/d1/mutations.ts
@@ -6,6 +6,30 @@ import type { D1Database } from "@cloudflare/workers-types";
 import { createD1Client } from "./client";
 import type { Deal, ReferralInput } from "../../types";
 
+type WriteClient = ReturnType<typeof createD1Client>;
+
+/**
+ * Execute a write and map a rejection to a failure envelope.
+ *
+ * D1Client.execute rejects on write failure so silent divergence is
+ * impossible; mutation helpers translate that into their historical
+ * {success, error} contract.
+ */
+async function executeWrite(
+  client: WriteClient,
+  sql: string,
+  params: unknown[],
+): Promise<{ success: boolean; lastRowId?: number; error?: string }> {
+  try {
+    return await client.execute(sql, params);
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
 /**
  * Insert a new deal with conflict handling
  */
@@ -22,7 +46,8 @@ export async function insertDeal(
 
   const now = Math.floor(Date.now() / 1000);
 
-  const result = await client.execute(
+  const result = await executeWrite(
+    client,
     `INSERT INTO deals (
       deal_id, title, description, code, url, domain, 
       source_url, source_trust_score,
@@ -106,7 +131,8 @@ export async function insertReferralCode(
 
   const now = Math.floor(Date.now() / 1000);
 
-  const result = await client.execute(
+  const result = await executeWrite(
+    client,
     `INSERT INTO referral_codes (
       code, deal_id, user_id, submitted_by,
       max_uses, current_uses, use_count,

--- a/worker/lib/d1/trust.ts
+++ b/worker/lib/d1/trust.ts
@@ -10,6 +10,7 @@
 
 import type { D1Database } from "@cloudflare/workers-types";
 import { createD1Client } from "./client";
+import { logger } from "../global-logger";
 
 // ============================================================================
 // Types
@@ -97,33 +98,41 @@ export async function evolveTrust(
   );
   // Use finalScore classification so that params[3] matches expected new_score (test checks write param); new domain case also uses finalScore which equals initialScore
   const initialClassification = classifyTrust(finalScoreForExisting);
-  await client.execute(
-    `INSERT INTO trust_scores (domain, trust_score, total_deals, successful_deals, classification, last_seen_at, created_at, updated_at)
-     VALUES (?, ?, 1, ?, ?, ?, datetime('now'), datetime('now'))
-     ON CONFLICT(domain) DO UPDATE SET
-       trust_score = MAX(0, MIN(1, trust_score + ?)),
-       total_deals = total_deals + 1,
-       successful_deals = successful_deals + ?,
-       classification = CASE
-         WHEN MAX(0, MIN(1, trust_score + ?)) >= 0.7 THEN 'trusted'
-         WHEN MAX(0, MIN(1, trust_score + ?)) >= 0.4 THEN 'probationary'
-         ELSE 'unverified'
-       END,
-       last_seen_at = ?,
-       updated_at = datetime('now')`,
-    [
+  try {
+    await client.execute(
+      `INSERT INTO trust_scores (domain, trust_score, total_deals, successful_deals, classification, last_seen_at, created_at, updated_at)
+      VALUES (?, ?, 1, ?, ?, ?, datetime('now'), datetime('now'))
+      ON CONFLICT(domain) DO UPDATE SET
+        trust_score = MAX(0, MIN(1, trust_score + ?)),
+        total_deals = total_deals + 1,
+        successful_deals = successful_deals + ?,
+        classification = CASE
+          WHEN MAX(0, MIN(1, trust_score + ?)) >= 0.7 THEN 'trusted'
+          WHEN MAX(0, MIN(1, trust_score + ?)) >= 0.4 THEN 'probationary'
+          ELSE 'unverified'
+        END,
+        last_seen_at = ?,
+        updated_at = datetime('now')`,
+      [
+        domain,
+        initialScore,
+        success ? 1 : 0,
+        initialClassification,
+        now,
+        adjustment,
+        success ? 1 : 0,
+        adjustment,
+        adjustment,
+        now,
+      ],
+    );
+  } catch (error) {
+    logger.warn("Trust evolution write failed", {
+      component: "d1-trust",
       domain,
-      initialScore,
-      success ? 1 : 0,
-      initialClassification,
-      now,
-      adjustment,
-      success ? 1 : 0,
-      adjustment,
-      adjustment,
-      now,
-    ],
-  );
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
 
   // Step 3: Fetch updated row for accurate new_score (respects clamping)
   const updatedResult = await client.query<TrustScoreRow>(


### PR DESCRIPTION
What: d1 executewithretry now throws on write exhaustion instead of resolving an error envelope, reads keep the envelope. Mutation, experience, batchinsert and trust boundaries map rejections to failure envelopes, dual-write and migration catches now fire on real failures. 3 commits plus goap v0.19.4 closing ws-e-2, 4 new tests. Why: permanent write failures were silently masked as resolved envelopes, hiding dual-write divergence and trust loss. Impact: write callers without try-catch now see rejections, all pinned read and mutation contracts unchanged, 2748 unit tests pass with lint typecheck and quality gate green.