### PR TITLE
[Jules Audit] Docs: add JSDoc annotations for public lib functions

### DIFF
--- a/worker/lib/config-utils.ts
+++ b/worker/lib/config-utils.ts
@@ -51,9 +51,9 @@ export function getTrustThreshold(env: Env): number {
 }
 
 /**
- * Validate the trust threshold configuration
+ * Validate the required environment configuration and budget parameters
  * @param env Worker environment
- * @throws Error if the threshold is invalid (non-numeric or out of range)
+ * @throws Error if any required environment variable is missing or invalid
  */
 export function validateConfig(env: Env): void {
   const required = [

--- a/worker/lib/source-expiry.ts
+++ b/worker/lib/source-expiry.ts
@@ -45,6 +45,11 @@ async function readBoundedText(response: Response): Promise<string> {
   return text + decoder.decode();
 }
 
+/**
+ * Checks if a deal source URL content indicates that the deal or offer has expired.
+ * @param sourceUrl Target source URL to check, or null
+ * @returns Promise resolving to true if expired phrases are detected, false otherwise
+ */
 export async function sourceSaysExpired(
   sourceUrl: string | null,
 ): Promise<boolean> {

--- a/worker/lib/utils.ts
+++ b/worker/lib/utils.ts
@@ -1,6 +1,11 @@
 import { CONFIG } from "../config";
 import { logger } from "./global-logger";
 
+/**
+ * Creates an AbortSignal that automatically aborts after a specified timeout duration.
+ * @param ms Timeout duration in milliseconds
+ * @returns An object containing the AbortSignal and a cleanup function to clear the timer
+ */
 export function createTimeoutSignal(ms: number): {
   signal: AbortSignal;
   cleanup: () => void;


### PR DESCRIPTION
## What was found
Added/updated JSDoc annotations (@param, @returns, @throws) for public functions in worker/lib/config-utils.ts, worker/lib/utils.ts, and worker/lib/source-expiry.ts.

## What was changed
- worker/lib/config-utils.ts: Updated JSDoc for validateConfig
- worker/lib/utils.ts: Added JSDoc for createTimeoutSignal
- worker/lib/source-expiry.ts: Added JSDoc for sourceSaysExpired

## Quality Gate
Status: PASS ✅
Command used: bash scripts/quality_gate.sh

## Audit files location
plans/jules-audit/

## Skipped / Needs Human Review
Track B (Quality) skipped due to zero actionable findings.

---
*PR created automatically by Jules for task [7954952999194483229](https://jules.google.com/task/7954952999194483229) started by @do-ops885*