### PR TITLE
feat(missing-impl): wire do mirrors routes filters and tests

### DIFF
--- a/plans/ADR-026-ci-npm-registry-degradation.md
+++ b/plans/ADR-026-ci-npm-registry-degradation.md
@@ -1,0 +1,64 @@
+# ADR-026: CI Blocked by npm Registry Degradation (2026-09-04)
+
+**Status**: Active (blocking all merges)
+**Created**: 2026-09-04
+**Decision Maker**: do-deal-relay Platform Team
+**Type**: External blocker
+
+---
+
+## Context
+
+During the 2026-09-04 PR triage sweep (PRs 746-750), every CI run on every
+branch failed or was cancelled, including `main` itself. Main-branch CI has
+been red since 2026-09-03 09:35 UTC with no green run since.
+
+Evidence (all conclusions verified via `gh pr checks` and `gh run list`):
+
+- `main` CI runs `33739682005`, `33742612049`, `33748103597`, `33748677587`,
+  `33792387022` (2026-09-03): `failure`; `33847175182` (2026-09-04): `cancelled`.
+- PR 748 CI runs `33840255413`, `33850885860`, `33851782991`: `cancelled`.
+- PR 749 CI runs `33848255995`, `33850890245`, `33851877151`: `cancelled`.
+- PR 750 CI runs `33851130677` (`cancelled`), `33851971705` (`failure`).
+
+Job-level root causes observed in runner logs:
+
+1. `Run npm ci` exceeds the 5-minute `timeout-minutes` budget in
+   `.github/workflows/ci.yml` (Type Check job) and is killed mid-install.
+2. PR 750 Format Check job log shows `npm error code ECONNRESET`, `syscall
+   read`, `errno -104` from the npm registry, exiting 152. This is runner
+   network degradation, not a code or format defect (the same tree passes
+   `npm run lint`, `npx tsc --noEmit`, `prettier --check`, full unit suite
+   2761/2761, and `./scripts/quality_gate.sh` locally).
+3. Killed jobs cascade: dependents report `CANCELLED`/`SKIPPED`, which the
+   merge guardrail treats as blocking (correctly).
+
+## Decision
+
+1. No merges until CI is green. The merge guardrail (AGENTS.md section 4,
+   NON-NEGOTIABLE) holds: `CANCELLED`/`FAILURE` on required checks blocks
+   merge, with no admin bypass.
+2. Do not re-trigger in a tight loop. Three retrigger rounds (fresh pushes
+   plus close/reopen cycles) reproduced identical infra failures; further
+   retries only add runner load.
+3. Local verification substitutes as merge-readiness evidence in the
+   meantime: `npx tsc --noEmit`, `npm run lint`, `npm run test:unit`,
+   `./scripts/quality_gate.sh` are green for PRs 748, 749, and 750.
+4. Retry CI once the registry recovers (single close/reopen per PR, or a
+   no-op sync push), then merge in order 748, 749, 750 after rebase on the
+   then-latest `main`.
+
+## Remediation paths (owner action)
+
+- Consider raising `timeout-minutes` on install-heavy jobs and adding npm
+  fetch retries (`fetch-retries`, `fetch-retry-mintimeout`) to
+  `.github/workflows/ci.yml`. Note: pushing workflow changes requires a
+  token with `workflow` scope, which the current automation token lacks
+  (see ADR-019). This is an owner-side change.
+- Track npm registry status externally before the next retry round.
+
+## Related
+
+- ADR-019 (deploy timeout too low, workflow-scope blocker)
+- agents-docs/KNOWN_ISSUES.md (GitHub Actions resource limits)
+- PRs 748, 749, 750 (code-complete, CI-blocked)

--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -8,6 +8,22 @@
 
 ---
 
+## 2026-09-04 PR Triage Sweep — BLOCKED on CI (ADR-026)
+
+Orchestrated via goap-agent + pr-resolver skills (4 parallel review agents).
+
+| PR | Title | Disposition | Evidence |
+|:---|:---|:---|:---|
+| #746 | JSDoc-only annotations | ✅ CLOSED — no impact per #697/#702/#706/#710 precedent | zero runtime diff, comment-only |
+| #747 | Adapt upstream workflow standards | ✅ CLOSED — guardrail regression, self-blocking CI | weakened sections 4/6, version bump vs single-source rule |
+| #748 | Aria meter attributes | 🟡 CODE-COMPLETE, merge-blocked — meter semantics hardened (finite guard, valuetext, label-in-name), 8/8 tests, tsc clean | branch `feat/deal-card-confidence-a11y-1827706011888636877` @ `288cf28` |
+| #749 | Similar-deals string allocations | 🟡 CODE-COMPLETE, merge-blocked — real shared `worker/lib/similarity.ts` helper replaced the pessimizing loops, parity tests, telemetry dropped | branch `perf/optimize-similar-deals-allocations-15641106281631573222` @ `61f5f7b` |
+| #750 | Missing-impl sweep (MI-4/OPS-R/MCP-P/EMAIL-E/MF-1) | 🟡 CODE-COMPLETE, merge-blocked — 2761/2761 unit green locally, tsc/lint/quality-gate clean | branch `feat/missing-impl-sweep`, [spec](SPEC-missing-impl-sweep.md) |
+
+Merge order once CI recovers: 748 → 749 → 750 (rebase each on latest `main`, single retrigger, verify zero non-SUCCESS before merge). No admin bypass. Blocker: [ADR-026](ADR-026-ci-npm-registry-degradation.md) — npm registry ECONNRESET + 5-min job timeouts red since 2026-09-03; `main` itself has no green run.
+
+---
+
 ## 2026-09-04 Missing-Implementation Sweep — v0.19.7
 
 Branch: `feat/missing-impl-sweep`. Spec: [SPEC-missing-impl-sweep.md](SPEC-missing-impl-sweep.md).

--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -18,7 +18,7 @@ Orchestrated via goap-agent + pr-resolver skills (4 parallel review agents).
 | #747 | Adapt upstream workflow standards | ✅ CLOSED — guardrail regression, self-blocking CI | weakened sections 4/6, version bump vs single-source rule |
 | #748 | Aria meter attributes | 🟡 CODE-COMPLETE, merge-blocked — meter semantics hardened (finite guard, valuetext, label-in-name), 8/8 tests, tsc clean | branch `feat/deal-card-confidence-a11y-1827706011888636877` @ `288cf28` |
 | #749 | Similar-deals string allocations | 🟡 CODE-COMPLETE, merge-blocked — real shared `worker/lib/similarity.ts` helper replaced the pessimizing loops, parity tests, telemetry dropped | branch `perf/optimize-similar-deals-allocations-15641106281631573222` @ `61f5f7b` |
-| #750 | Missing-impl sweep (MI-4/OPS-R/MCP-P/EMAIL-E/MF-1) | 🟡 CODE-COMPLETE, merge-blocked — 2761/2761 unit green locally, tsc/lint/quality-gate clean | branch `feat/missing-impl-sweep`, [spec](SPEC-missing-impl-sweep.md) |
+| #750 | Missing-impl sweep (MI-4/OPS-R/MCP-P/EMAIL-E/MF-1) | 🟡 CODE-COMPLETE — review round 1 resolved on branch: mirrors detached from hot path, email handler guarded, magic numbers hoisted, min_reward D1-enforced in hybrid + rejected on vector-only, do-mirror runtime guards, tests assert writes/schema; merge-blocked until re-review + full SUCCESS | branch `feat/missing-impl-sweep`, [spec](SPEC-missing-impl-sweep.md) |
 
 Merge order once CI recovers: 748 → 749 → 750 (rebase each on latest `main`, single retrigger, verify zero non-SUCCESS before merge). No admin bypass. Blocker: [ADR-026](ADR-026-ci-npm-registry-degradation.md) — npm registry ECONNRESET + 5-min job timeouts red since 2026-09-03; `main` itself has no green run.
 
@@ -34,12 +34,12 @@ Branch: `feat/missing-impl-sweep`. Spec: [SPEC-missing-impl-sweep.md](SPEC-missi
 | OPS-R | Bulk import/export + dashboard trio exported but never routed | P1 | ✅ CLOSED — `worker/router/ops-routes.ts` (`POST /api/bulk/import`, `GET /api/bulk/export` user auth; `GET /api/dashboard/*` admin-only); `legacy-routes.ts` back to 496L | ops-routes.ts, legacy-routes.ts |
 | MCP-P | Progress tool handlers never registered | P1 | ✅ CLOSED — `check_progress`/`cancel_operation`/`list_operations` in `systemTools` (15→18) | worker/lib/mcp/tools/system.ts |
 | EMAIL-E | Email Workers entrypoint missing | P2 | ✅ CLOSED — `email(message,env)` export in `worker/index.ts` delegates to `handleEmailWorker` (not a fetch route) | worker/index.ts |
-| MF-1f | Semantic-search `filters` accepted but ignored | P1 | ✅ CLOSED — `matchesSemanticFilters` applied to vector + hybrid/FTS paths, `filters_applied` reported; `min_reward` documented unsupported(vector) | worker/routes/semantic-search.ts |
+| MF-1f | Semantic-search `filters` accepted but ignored | P1 | ✅ CLOSED — `matchesSemanticFilters` applied to vector + hybrid/FTS paths, `filters_applied` reported; `min_reward` enforced from D1 `reward_value` in hybrid and rejected (400) on the vector-only path | worker/routes/semantic-search.ts |
 | MF-2d | Orchestrator docs claim real-default, code falls back to simulation | P2 | ✅ CLOSED (docs) — comments corrected to rollout-guard behavior; code unchanged (subrequest budget) | orchestrator/index.ts |
 | R-2r | 3 non-null assertions regressed in worker/ | P2 | ✅ CLOSED — guarded access in `routes/nlq/index.ts`, `routes/referrals.ts` | nlq/index.ts, referrals.ts |
-| T-5p | MCP progress + sweep wiring untested | P2 | ✅ CLOSED — `tests/unit/missing-impl-sweep.test.ts` 12 tests | missing-impl-sweep.test.ts |
+| T-5p | MCP progress + sweep wiring untested | P2 | ✅ CLOSED — `tests/unit/missing-impl-sweep.test.ts` 14 wiring tests incl. review-round assertions (storage writes, dashboard schema bodies, min_reward rejection, DO runtime guard) | missing-impl-sweep.test.ts |
 
-Verification: `npx tsc --noEmit` ✅, `prettier` ✅, `./scripts/quality_gate.sh` ✅ (no warnings), `npm run test:unit` 195 files / 2761 tests ✅.
+Verification: `npx tsc --noEmit` ✅, `prettier` ✅, quality gate ✅, full unit suite green on CI head before review round 1; review fixes re-verified locally (targeted suites 72/72, sweep file 14/14).
 
 Deferred: `extends DurableObject` migration + single-source DO cutover (ADR-017 Phase 2); exhaustive T-2/T-3/T-4 suites; `extension/popup.html` split.
 

--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -1,10 +1,31 @@
 # GOAP State: Comprehensive Improvement Inventory
 
 **Generated**: 2026-07-06
-**Last Updated**: 2026-09-03
-**Version**: 0.19.6
+**Last Updated**: 2026-09-04
+**Version**: 0.19.7
 **Status**: Active — 2026-09-03 v0.19.5 doc sync: F-8/F-10/F-12 closed via #736/#737/#738, SSRF IPv6-compatible bypass closed via #742 (`e9dd1d7`), D1 lock inclusive-expiry fix via #739, CI integration guard via #733. WS-E latent bugs #1/#2 stay closed (#741/#743). 2026-08-31 self-learning-feedback full suite COMPLETE per [SPEC-self-learning-feedback-full.md](SPEC-self-learning-feedback-full.md) + [ADR-024](ADR-024-skill-version-independence.md): 14 scripts wired (RYAN/FLASH/SYNTHESIS), skill-independent version policy, 2 lessons captured. 2026-08-25 improvement swarm COMPLETE (F-7/N-5/popup/AI/T-6-T-8) — code already on `main`, GOAP docs re-synced. 2026-08-24 improvement run also COMPLETE via PR #713.
 **Sources**: [Codebase Audit (04/04)](../reports/analysis/codebase-audit-2026-04-04.md), [Swarm Analysis (04/04)](../reports/analysis/swarm-missing-implementations-2026-04-04.md), [Feature Gap Analysis](../reports/analysis/feature-gap-analysis.md), [ADR-015](ADR-015-harness-cloudflare-2026-best-practices.md), [ADR-024](ADR-024-skill-version-independence.md)
+
+---
+
+## 2026-09-04 Missing-Implementation Sweep — v0.19.7
+
+Branch: `feat/missing-impl-sweep`. Spec: [SPEC-missing-impl-sweep.md](SPEC-missing-impl-sweep.md).
+
+| ID | Finding | Priority | Status | Evidence |
+|:---|:---|:---|:---|:---|
+| MI-4 | DealRegistry/SourceRegistry DOs have zero runtime callers | P1 | ✅ CLOSED (mirror) — `worker/lib/do-mirror.ts` best-effort mirrors wired into `pipeline/stage.ts`, `publish.ts`, `pipeline/score.ts`; KV/D1 stay canonical; base-class `extends DurableObject` migration deferred (unit pool + migrations ban) | do-mirror.ts, stage.ts, publish.ts, score.ts |
+| OPS-R | Bulk import/export + dashboard trio exported but never routed | P1 | ✅ CLOSED — `worker/router/ops-routes.ts` (`POST /api/bulk/import`, `GET /api/bulk/export` user auth; `GET /api/dashboard/*` admin-only); `legacy-routes.ts` back to 496L | ops-routes.ts, legacy-routes.ts |
+| MCP-P | Progress tool handlers never registered | P1 | ✅ CLOSED — `check_progress`/`cancel_operation`/`list_operations` in `systemTools` (15→18) | worker/lib/mcp/tools/system.ts |
+| EMAIL-E | Email Workers entrypoint missing | P2 | ✅ CLOSED — `email(message,env)` export in `worker/index.ts` delegates to `handleEmailWorker` (not a fetch route) | worker/index.ts |
+| MF-1f | Semantic-search `filters` accepted but ignored | P1 | ✅ CLOSED — `matchesSemanticFilters` applied to vector + hybrid/FTS paths, `filters_applied` reported; `min_reward` documented unsupported(vector) | worker/routes/semantic-search.ts |
+| MF-2d | Orchestrator docs claim real-default, code falls back to simulation | P2 | ✅ CLOSED (docs) — comments corrected to rollout-guard behavior; code unchanged (subrequest budget) | orchestrator/index.ts |
+| R-2r | 3 non-null assertions regressed in worker/ | P2 | ✅ CLOSED — guarded access in `routes/nlq/index.ts`, `routes/referrals.ts` | nlq/index.ts, referrals.ts |
+| T-5p | MCP progress + sweep wiring untested | P2 | ✅ CLOSED — `tests/unit/missing-impl-sweep.test.ts` 12 tests | missing-impl-sweep.test.ts |
+
+Verification: `npx tsc --noEmit` ✅, `prettier` ✅, `./scripts/quality_gate.sh` ✅ (no warnings), `npm run test:unit` 195 files / 2761 tests ✅.
+
+Deferred: `extends DurableObject` migration + single-source DO cutover (ADR-017 Phase 2); exhaustive T-2/T-3/T-4 suites; `extension/popup.html` split.
 
 ---
 

--- a/plans/SPEC-missing-impl-sweep.md
+++ b/plans/SPEC-missing-impl-sweep.md
@@ -1,0 +1,81 @@
+# PEV Spec — Missing-Implementation Sweep
+
+---
+
+## Task
+
+**Title**: Wire DO mirrors, ops routes, MCP progress tools, semantic filters
+**Author**: opencode
+**Date**: 2026-09-04
+**Priority**: high
+
+## Goal
+
+Close verified-open missing implementations without breaking deploys: DO runtime callers, unregistered handlers, ignored search filters, misleading MF-2 docs.
+
+## Approach
+
+Best-effort mirrors with KV/D1 canonical plus isolated failures; new routes behind existing auth and rate limiting; no wrangler migrations changes.
+
+## Non-Goals
+
+Explicitly state what we are NOT doing:
+
+- [ ] Not migrating DO classes to extends DurableObject (deferred: unit pool uses threads, wrangler bans migrations blocks)
+- [ ] Not cutting KV/D1 over to DO as single source of truth (deferred ADR-017 Phase 2 design)
+- [ ] Not forcing real-fetch default in dev (subrequest budget and rate-limit guard stay)
+- [ ] Not splitting extension/popup.html (low ROI, breakage risk)
+- [ ] Not writing exhaustive T-2/T-3/T-4 email/NLQ/scraper suites (focused wiring tests only)
+
+## Steps
+
+Decompose into the smallest steps that each leave the repo green:
+
+| Step | Description | Files Touched | Risk |
+|------|-------------|---------------|------|
+| 1 | Remove non-null assertions in NLQ delete and referral pagination | worker/routes/nlq/index.ts, worker/routes/referrals.ts | low |
+| 2 | Add best-effort DO mirror helper and wire stage/publish/trust | worker/lib/do-mirror.ts, worker/pipeline/stage.ts, worker/publish.ts, worker/pipeline/score.ts | medium |
+| 3 | Wire bulk/dashboard ops routes via extracted router plus email entrypoint | worker/router/ops-routes.ts, worker/router/legacy-routes.ts, worker/index.ts | medium |
+| 4 | Register MCP progress tools | worker/lib/mcp/tools/system.ts | low |
+| 5 | Apply semantic-search filters and fix MF-2 docs | worker/routes/semantic-search.ts, worker/lib/research-agent/orchestrator/index.ts | medium |
+| 6 | Add wiring tests and fix tool-count assertion | tests/unit/missing-impl-sweep.test.ts, tests/unit/mcp-tools-definitions.test.ts | low |
+
+## Acceptance Criteria
+
+Concrete, testable statements the Verify phase will check:
+
+- [ ] All 9 validation gates pass
+- [ ] Unit test coverage holds with zero regressions (2761 green)
+- [ ] No lint warnings introduced
+- [ ] No type errors introduced
+- [ ] legacy-routes.ts under 500-line limit
+- [ ] Zero non-null assertions in worker production code
+- [ ] DO mirror failures never throw into pipeline paths
+- [ ] Dashboard routes admin-only, bulk routes authenticated and rate-limited
+- [ ] Existing tests still pass (no regression)
+
+## Open Questions
+
+If ambiguous, surface here instead of guessing:
+
+- [ ] Question 1: Should DealRegistry become single source of truth in a follow-up ADR-017 Phase 2 spec? (Answered: yes, deferred.)
+- [ ] Question 2: Should min_reward filter gain a D1-backed value check? (Deferred: no vector metadata value field.)
+
+## Risk Assessment
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| DO RPC failure blocks pipeline | high | Best-effort mirrors with timeout and try/catch, canonical stores unchanged |
+| New public routes widen attack surface | high | Admin tier for dashboard, user auth plus rate limiting for bulk, body-size caps |
+| Bulk import bypasses validation gates | medium | Single-item path keeps schema plus SSRF checks; batch limits size; follow-up to route through full pipeline |
+| Deploy break from DO config change | high | No wrangler migrations changes; exports blocks untouched |
+
+## Dependencies
+
+- [ ] Cloudflare DO bindings present in runtime env (absent bindings fall back cleanly)
+
+## Out of Scope for This Spec
+
+- extends DurableObject base-class migration and DO test-harness move to workers pool
+- Full T-2/T-3/T-4 coverage suites
+- popup.html split

--- a/tests/unit/mcp-tools-definitions.test.ts
+++ b/tests/unit/mcp-tools-definitions.test.ts
@@ -138,9 +138,9 @@ async function seedReferral(env: Env, referral: ReferralInput): Promise<void> {
 // ============================================================================
 
 describe("MCP Tools - Definitions", () => {
-  it("should export 15 tools", () => {
+  it("should export 18 tools", () => {
     const tools = getTools();
-    expect(tools).toHaveLength(15);
+    expect(tools).toHaveLength(18);
   });
 
   it("should have all required tool fields", () => {
@@ -170,6 +170,9 @@ describe("MCP Tools - Definitions", () => {
     expect(toolNames).toContain("get_similar_deals");
     expect(toolNames).toContain("get_deal_highlights");
     expect(toolNames).toContain("get_logs");
+    expect(toolNames).toContain("check_progress");
+    expect(toolNames).toContain("cancel_operation");
+    expect(toolNames).toContain("list_operations");
     expect(toolNames).toContain("natural_language_query");
   });
 

--- a/tests/unit/missing-impl-sweep.test.ts
+++ b/tests/unit/missing-impl-sweep.test.ts
@@ -7,6 +7,7 @@ import {
 import {
   matchesSemanticFilters,
   describeSemanticFilters,
+  handleSemanticSearch,
 } from "../../worker/routes/semantic-search";
 import { getTools, executeTool } from "../../worker/lib/mcp/tools/index";
 import { handleBulkImport } from "../../worker/routes/bulk/import";
@@ -101,6 +102,35 @@ describe("do-mirror best-effort wiring", () => {
     expect(publishDeals).toHaveBeenCalledWith(["d1"]);
   });
 
+  it("ignores DO stubs that fail the runtime method guard", async () => {
+    const stageDeals = vi.fn().mockResolvedValue(1);
+    const env = mockEnv({
+      DEAL_REGISTRY: {
+        idFromName: vi.fn().mockReturnValue({}),
+        get: vi.fn().mockReturnValue({ stageDeals }), // validateDeals missing
+      },
+      SOURCE_REGISTRY: {
+        idFromName: vi.fn().mockReturnValue({}),
+        get: vi.fn().mockReturnValue({ evolveTrust: "not-a-function" }),
+      },
+    });
+    await expect(
+      mirrorStageToDO(env, [
+        {
+          id: "d1",
+          source: { domain: "example.com" },
+          title: "t",
+          metadata: { status: "active" },
+        },
+      ] as never),
+    ).resolves.toBeUndefined();
+    expect(stageDeals).not.toHaveBeenCalled();
+    await expect(mirrorPublishToDO(env, ["d1"])).resolves.toBeUndefined();
+    await expect(
+      mirrorTrustToDO(env, new Map([["example.com", true]])),
+    ).resolves.toBeUndefined();
+  });
+
   it("mirrors trust capped and isolated per-domain", async () => {
     const evolveTrust = vi.fn().mockResolvedValue(0.6);
     const env = mockEnv({
@@ -158,10 +188,33 @@ describe("semantic-search filters", () => {
     expect(matchesSemanticFilters(undefined, undefined)).toBe(true);
   });
 
-  it("describes applied filters", () => {
-    expect(
-      describeSemanticFilters({ domain: "x.com", min_reward: 10 }),
-    ).toContain("domain=x.com");
+  it("describes applied filters incl. the D1-backed min_reward", () => {
+    const described = describeSemanticFilters({
+      domain: "x.com",
+      min_reward: 10,
+    });
+    expect(described).toContain("domain=x.com");
+    expect(described).toContain("min_reward=10");
+    expect(described.some((d) => d.includes("unsupported"))).toBe(false);
+  });
+
+  it("rejects min_reward on the pure vector path (no D1 values)", async () => {
+    const env = mockEnv({
+      AI: { run: vi.fn() },
+      DEAL_EMBEDDINGS: {
+        query: vi.fn().mockResolvedValue({ matches: [] }),
+      },
+    });
+    const request = new Request("https://example.com/api/semantic-search", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        query: "cash bonus",
+        filters: { min_reward: 50 },
+      }),
+    });
+    const response = await handleSemanticSearch(request, env);
+    expect(response.status).toBe(400);
   });
 });
 
@@ -195,29 +248,170 @@ describe("mcp progress tools registered", () => {
 });
 
 describe("bulk + dashboard handlers wired", () => {
-  it("bulk handlers are functions", () => {
+  it("bulk import writes a validated referral through storage", async () => {
     expect(typeof handleBulkImport).toBe("function");
     expect(typeof handleBulkExport).toBe("function");
+
+    const putFn = vi.fn().mockResolvedValue(undefined);
+    const env = mockEnv({
+      DEALS_SOURCES: {
+        get: vi.fn().mockResolvedValue(null),
+        put: putFn,
+      },
+    });
+    const request = new Request("http://localhost/api/bulk/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        deals: [
+          {
+            code: "WIRE1",
+            url: "https://wire.example.com/invite/WIRE1",
+            domain: "wire.example.com",
+          },
+        ],
+      }),
+    });
+    const response = await handleBulkImport(request, env);
+    const body = (await response.json()) as {
+      success: boolean;
+      total: number;
+      imported: number;
+      failed: number;
+      skipped: number;
+      results: Array<{
+        success: boolean;
+        code: string;
+        message: string;
+        referral_id: string | null;
+        errors: string[] | null;
+      }>;
+    };
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.total).toBe(1);
+    expect(body.imported).toBe(1);
+    expect(body.failed).toBe(0);
+    expect(body.skipped).toBe(0);
+    expect(body.results[0]?.success).toBe(true);
+    expect(body.results[0]?.message).toBe("created");
+    expect(body.results[0]?.referral_id).toBeTruthy();
+
+    // Assert the actual write: a referral:input:<id> KV entry whose payload
+    // matches the normalized referral schema.
+    const inputPuts = putFn.mock.calls.filter(
+      ([key]) => typeof key === "string" && key.startsWith("referral:input:"),
+    );
+    expect(inputPuts).toHaveLength(1);
+    const written = JSON.parse(inputPuts[0]?.[1] as string) as {
+      code: string;
+      domain: string;
+      url: string;
+      status: string;
+      metadata: { title: string };
+    };
+    expect(written.code).toBe("WIRE1");
+    expect(written.domain).toBe("wire.example.com");
+    expect(written.url).toBe("https://wire.example.com/invite/WIRE1");
+    expect(written.status).toBe("quarantined");
+    expect(written.metadata?.title).toBe("wire.example.com Referral");
   });
 
-  it("dashboard handlers return responses with mocked D1", async () => {
+  it("dashboard handlers return computed schema bodies", async () => {
+    const now = Date.now();
+    const inWindow = new Date(now).toISOString();
+    const tooOld = new Date(now - 48 * 60 * 60 * 1000).toISOString();
     const env = mockEnv({
       DEALS_DB: {
         prepare: vi.fn(() => ({
-          bind: vi.fn(() => ({
-            all: vi.fn().mockResolvedValue({ results: [] }),
-            first: vi.fn().mockResolvedValue(null),
-          })),
-          all: vi.fn().mockResolvedValue({ results: [] }),
+          all: vi.fn().mockResolvedValue({
+            results: [
+              { status: "active", count: 4 },
+              { status: "quarantined", count: 1 },
+              { status: "rejected", count: 2 },
+            ],
+          }),
+          first: vi.fn().mockResolvedValue({}),
         })),
       },
+      DEALS_STAGING: { get: vi.fn() },
+      DEALS_LOG: {
+        get: vi.fn(),
+        list: vi.fn().mockResolvedValue({
+          keys: [
+            {
+              name: "run-final",
+              metadata: JSON.stringify({
+                ts: inWindow,
+                phase: "finalize",
+                candidate_count: 10,
+              }),
+            },
+            {
+              name: "run-error",
+              metadata: JSON.stringify({ ts: inWindow, status: "error" }),
+            },
+            {
+              name: "run-too-old",
+              metadata: JSON.stringify({
+                ts: tooOld,
+                phase: "finalize",
+                candidate_count: 99,
+              }),
+            },
+          ],
+          list_complete: true,
+        }),
+      },
+      DEALS_LOCK: { get: vi.fn() },
+      DEALS_SOURCES: { get: vi.fn() },
     });
-    const stats = await handleDashboardStats(env);
-    const activity = await handleDashboardRecentActivity(env);
-    const health = await handleDashboardSystemHealth(env);
-    expect(stats.status).toBe(200);
-    expect(activity.status).toBe(200);
-    expect(health.status).toBe(200);
+
+    const statsResponse = await handleDashboardStats(env);
+    expect(statsResponse.status).toBe(200);
+    const statsBody = (await statsResponse.json()) as {
+      stats: {
+        total: number;
+        active: number;
+        quarantined: number;
+        rejected: number;
+      };
+      recentActivity: { runs: number; dealsFound: number; errors: number };
+      systemHealth: { status: string; checks: Record<string, boolean> };
+      timestamp: string;
+    };
+    expect(statsBody.stats).toEqual({
+      total: 7,
+      active: 4,
+      quarantined: 1,
+      rejected: 2,
+    });
+    expect(statsBody.recentActivity).toEqual({
+      runs: 1,
+      dealsFound: 10,
+      errors: 1,
+    });
+    expect(statsBody.systemHealth.status).toBe("healthy");
+    expect(typeof statsBody.timestamp).toBe("string");
+
+    const activityResponse = await handleDashboardRecentActivity(env);
+    expect(activityResponse.status).toBe(200);
+    const activityBody = (await activityResponse.json()) as {
+      runs: number;
+      dealsFound: number;
+      errors: number;
+    };
+    expect(activityBody).toEqual({ runs: 1, dealsFound: 10, errors: 1 });
+
+    const healthResponse = await handleDashboardSystemHealth(env);
+    expect(healthResponse.status).toBe(200);
+    const healthBody = (await healthResponse.json()) as {
+      status: string;
+      checks: Record<string, boolean>;
+    };
+    expect(healthBody.status).toBe("healthy");
+    expect(healthBody.checks.d1_connection).toBe(true);
+    expect(healthBody.checks.DEALS_PROD).toBe(true);
   });
 });
 

--- a/tests/unit/missing-impl-sweep.test.ts
+++ b/tests/unit/missing-impl-sweep.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  mirrorStageToDO,
+  mirrorPublishToDO,
+  mirrorTrustToDO,
+} from "../../worker/lib/do-mirror";
+import {
+  matchesSemanticFilters,
+  describeSemanticFilters,
+} from "../../worker/routes/semantic-search";
+import { getTools, executeTool } from "../../worker/lib/mcp/tools/index";
+import { handleBulkImport } from "../../worker/routes/bulk/import";
+import { handleBulkExport } from "../../worker/routes/bulk/export";
+import {
+  handleDashboardStats,
+  handleDashboardRecentActivity,
+  handleDashboardSystemHealth,
+} from "../../worker/routes/dashboard";
+import workerDefault from "../../worker/index";
+
+function mockEnv(overrides: Record<string, unknown> = {}) {
+  return {
+    DEALS_PROD: {
+      get: vi.fn().mockResolvedValue(null),
+      put: vi.fn().mockResolvedValue(undefined),
+    },
+    DEALS_DB: {
+      exec: vi.fn().mockResolvedValue(undefined),
+      prepare: vi.fn(() => ({
+        bind: vi.fn(() => ({
+          run: vi.fn().mockResolvedValue(undefined),
+          all: vi.fn().mockResolvedValue({ results: [] }),
+        })),
+      })),
+    },
+    ...overrides,
+  } as unknown as import("../../worker/types").Env;
+}
+
+describe("do-mirror best-effort wiring", () => {
+  it("stages + validates via DealRegistry stub", async () => {
+    const stageDeals = vi.fn().mockResolvedValue(2);
+    const validateDeals = vi.fn().mockResolvedValue(1);
+    const env = mockEnv({
+      DEAL_REGISTRY: {
+        idFromName: vi.fn().mockReturnValue({}),
+        get: vi.fn().mockReturnValue({ stageDeals, validateDeals }),
+      },
+    });
+    await mirrorStageToDO(env, [
+      {
+        id: "d1",
+        source: { domain: "example.com" },
+        title: "t",
+        metadata: { status: "active" },
+      },
+      {
+        id: "d2",
+        source: { domain: "example.com" },
+        title: "t2",
+        metadata: { status: "rejected" },
+      },
+    ] as never);
+    expect(stageDeals).toHaveBeenCalledTimes(1);
+    expect(validateDeals).toHaveBeenCalledWith(["d1"]);
+  });
+
+  it("never throws when DO is missing or rejects", async () => {
+    await expect(mirrorStageToDO(mockEnv(), [])).resolves.toBeUndefined();
+    const env = mockEnv({
+      DEAL_REGISTRY: {
+        idFromName: vi.fn().mockReturnValue({}),
+        get: vi.fn().mockReturnValue({
+          stageDeals: vi.fn().mockRejectedValue(new Error("boom")),
+          validateDeals: vi.fn(),
+        }),
+      },
+    });
+    await expect(
+      mirrorStageToDO(env, [
+        {
+          id: "d",
+          source: { domain: "x" },
+          title: "t",
+          metadata: { status: "active" },
+        },
+      ] as never),
+    ).resolves.toBeUndefined();
+    await expect(mirrorPublishToDO(env, ["d"])).resolves.toBeUndefined();
+  });
+
+  it("publishes via DealRegistry stub", async () => {
+    const publishDeals = vi.fn().mockResolvedValue(1);
+    const env = mockEnv({
+      DEAL_REGISTRY: {
+        idFromName: vi.fn().mockReturnValue({}),
+        get: vi.fn().mockReturnValue({ publishDeals }),
+      },
+    });
+    await mirrorPublishToDO(env, ["d1"]);
+    expect(publishDeals).toHaveBeenCalledWith(["d1"]);
+  });
+
+  it("mirrors trust capped and isolated per-domain", async () => {
+    const evolveTrust = vi.fn().mockResolvedValue(0.6);
+    const env = mockEnv({
+      SOURCE_REGISTRY: {
+        idFromName: vi.fn().mockReturnValue({}),
+        get: vi.fn().mockReturnValue({ evolveTrust }),
+      },
+    });
+    const outcomes = new Map(
+      Array.from(
+        { length: 15 },
+        (_, i) => [`d${i}.com`, true] as [string, boolean],
+      ),
+    );
+    await mirrorTrustToDO(env, outcomes);
+    expect(evolveTrust).toHaveBeenCalledTimes(10);
+  });
+});
+
+describe("semantic-search filters", () => {
+  it("matches domain/category/status/tags", () => {
+    expect(
+      matchesSemanticFilters(
+        { domain: "Example.COM" },
+        { domain: "example.com" },
+      ),
+    ).toBe(true);
+    expect(
+      matchesSemanticFilters(
+        { domain: "other.com" },
+        { domain: "example.com" },
+      ),
+    ).toBe(false);
+    expect(
+      matchesSemanticFilters(
+        { category: ["Trading"] },
+        { category: "trading" },
+      ),
+    ).toBe(true);
+    expect(
+      matchesSemanticFilters({ status: "active" }, { status: "active" }),
+    ).toBe(true);
+    expect(
+      matchesSemanticFilters(
+        { tags: ["bonus", "invite"] },
+        { tags: ["Bonus"] },
+      ),
+    ).toBe(true);
+    expect(
+      matchesSemanticFilters(
+        { tags: ["bonus"] },
+        { tags: ["bonus", "missing"] },
+      ),
+    ).toBe(false);
+    expect(matchesSemanticFilters(undefined, undefined)).toBe(true);
+  });
+
+  it("describes applied filters", () => {
+    expect(
+      describeSemanticFilters({ domain: "x.com", min_reward: 10 }),
+    ).toContain("domain=x.com");
+  });
+});
+
+describe("mcp progress tools registered", () => {
+  it("exposes check/cancel/list tools", () => {
+    const names = getTools().map((t) => t.name);
+    expect(names).toContain("check_progress");
+    expect(names).toContain("cancel_operation");
+    expect(names).toContain("list_operations");
+  });
+
+  it("list_operations returns empty list with mocked env", async () => {
+    const result = await executeTool(
+      "list_operations",
+      {},
+      mockEnv(),
+      new Request("https://example.com/mcp"),
+    );
+    expect(result.isError).not.toBe(true);
+  });
+
+  it("check_progress without id lists operations", async () => {
+    const result = await executeTool(
+      "check_progress",
+      {},
+      mockEnv(),
+      new Request("https://example.com/mcp"),
+    );
+    expect(result.isError).not.toBe(true);
+  });
+});
+
+describe("bulk + dashboard handlers wired", () => {
+  it("bulk handlers are functions", () => {
+    expect(typeof handleBulkImport).toBe("function");
+    expect(typeof handleBulkExport).toBe("function");
+  });
+
+  it("dashboard handlers return responses with mocked D1", async () => {
+    const env = mockEnv({
+      DEALS_DB: {
+        prepare: vi.fn(() => ({
+          bind: vi.fn(() => ({
+            all: vi.fn().mockResolvedValue({ results: [] }),
+            first: vi.fn().mockResolvedValue(null),
+          })),
+          all: vi.fn().mockResolvedValue({ results: [] }),
+        })),
+      },
+    });
+    const stats = await handleDashboardStats(env);
+    const activity = await handleDashboardRecentActivity(env);
+    const health = await handleDashboardSystemHealth(env);
+    expect(stats.status).toBe(200);
+    expect(activity.status).toBe(200);
+    expect(health.status).toBe(200);
+  });
+});
+
+describe("email worker entrypoint", () => {
+  it("exposes email handler on default export", () => {
+    expect(typeof (workerDefault as unknown as { email: unknown }).email).toBe(
+      "function",
+    );
+  });
+});

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -78,4 +78,29 @@ export default {
 
     return handleScheduled(event, env);
   },
+
+  async email(
+    message: {
+      from: string;
+      to: string;
+      subject: string;
+      headers: Headers;
+      text?: string;
+      html?: string;
+      raw?: () => Promise<ReadableStream>;
+    },
+    env: Env,
+  ): Promise<void> {
+    try {
+      validateConfig(env);
+    } catch (error) {
+      logger.error("Email execution configuration error", {
+        component: "worker",
+        error_message: toError(error).message,
+      });
+      return;
+    }
+    const { handleEmailWorker } = await import("./routes/email");
+    await handleEmailWorker(message, env);
+  },
 };

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -100,7 +100,14 @@ export default {
       });
       return;
     }
-    const { handleEmailWorker } = await import("./routes/email");
-    await handleEmailWorker(message, env);
+    try {
+      const { handleEmailWorker } = await import("./routes/email");
+      await handleEmailWorker(message, env);
+    } catch (error) {
+      logger.error("Email worker execution error", {
+        component: "worker",
+        error_message: toError(error).message,
+      });
+    }
   },
 };

--- a/worker/lib/do-mirror.ts
+++ b/worker/lib/do-mirror.ts
@@ -1,0 +1,144 @@
+import type { Env, Deal } from "../types";
+import { logger } from "./global-logger";
+import { toError } from "./sanitize-error";
+
+const DO_RPC_TIMEOUT_MS = 1000;
+const MAX_MIRROR_DOMAINS = 10;
+
+interface DealRegistryStub {
+  stageDeals(
+    deals: Array<{ id: string; source: string; title: string; data: string }>,
+  ): Promise<number>;
+  validateDeals(dealIds: string[]): Promise<number>;
+  publishDeals(dealIds: string[]): Promise<number>;
+}
+
+interface SourceRegistryStub {
+  evolveTrust(source_id: string, success: boolean): Promise<number>;
+}
+
+function getDealRegistryStub(env: Env): DealRegistryStub | undefined {
+  const namespace = env.DEAL_REGISTRY;
+  if (!namespace) return undefined;
+  try {
+    const objectId = namespace.idFromName("deals");
+    return namespace.get(objectId) as unknown as DealRegistryStub;
+  } catch {
+    return undefined;
+  }
+}
+
+function getSourceRegistryStub(env: Env): SourceRegistryStub | undefined {
+  const namespace = env.SOURCE_REGISTRY;
+  if (!namespace) return undefined;
+  try {
+    const objectId = namespace.idFromName("sources");
+    return namespace.get(objectId) as unknown as SourceRegistryStub;
+  } catch {
+    return undefined;
+  }
+}
+
+function raceWithTimeout<T>(operation: Promise<T>): Promise<T> {
+  let timerId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timerId = setTimeout(() => {
+      reject(new Error(`DO mirror RPC timed out after ${DO_RPC_TIMEOUT_MS}ms`));
+    }, DO_RPC_TIMEOUT_MS);
+  });
+  timeout.catch(() => undefined);
+  operation.catch(() => undefined);
+  return Promise.race([operation, timeout]).finally(() => {
+    if (timerId !== undefined) clearTimeout(timerId);
+  });
+}
+
+/**
+ * Best-effort mirror of staged deals into DealRegistry DO.
+ * KV snapshot remains canonical; DO failures are logged and never throw.
+ */
+export async function mirrorStageToDO(env: Env, deals: Deal[]): Promise<void> {
+  const stub = getDealRegistryStub(env);
+  if (!stub || deals.length === 0) return;
+  try {
+    const inputs = deals.map((d) => ({
+      id: d.id,
+      source: d.source.domain,
+      title: d.title,
+      data: JSON.stringify(d),
+    }));
+    const staged = await raceWithTimeout(stub.stageDeals(inputs));
+    logger.debug("DealRegistry mirror staged", {
+      component: "do-mirror",
+      staged,
+      total: deals.length,
+    });
+    const validatedIds = deals
+      .filter((d) => d.metadata.status === "active")
+      .map((d) => d.id);
+    if (validatedIds.length > 0) {
+      await raceWithTimeout(stub.validateDeals(validatedIds));
+    }
+  } catch (error) {
+    logger.warn("DealRegistry stage mirror failed (non-critical)", {
+      component: "do-mirror",
+      error: toError(error).message,
+    });
+  }
+}
+
+/**
+ * Best-effort mirror of publish transition into DealRegistry DO.
+ * Never throws; publish canonical path is KV + GitHub.
+ */
+export async function mirrorPublishToDO(
+  env: Env,
+  dealIds: string[],
+): Promise<void> {
+  const stub = getDealRegistryStub(env);
+  if (!stub || dealIds.length === 0) return;
+  try {
+    const published = await raceWithTimeout(stub.publishDeals(dealIds));
+    logger.debug("DealRegistry mirror published", {
+      component: "do-mirror",
+      published,
+      total: dealIds.length,
+    });
+  } catch (error) {
+    logger.warn("DealRegistry publish mirror failed (non-critical)", {
+      component: "do-mirror",
+      error: toError(error).message,
+    });
+  }
+}
+
+/**
+ * Best-effort mirror of trust outcomes into SourceRegistry DO.
+ * D1 remains canonical; capped to respect subrequest budget.
+ */
+export async function mirrorTrustToDO(
+  env: Env,
+  outcomes: Map<string, boolean>,
+): Promise<void> {
+  const stub = getSourceRegistryStub(env);
+  if (!stub || outcomes.size === 0) return;
+  try {
+    const entries = Array.from(outcomes.entries()).slice(0, MAX_MIRROR_DOMAINS);
+    await Promise.all(
+      entries.map(([domain, success]) =>
+        raceWithTimeout(stub.evolveTrust(domain, success)).catch((error) => {
+          logger.warn("SourceRegistry mirror single-domain failed", {
+            component: "do-mirror",
+            domain,
+            error: toError(error).message,
+          });
+        }),
+      ),
+    );
+  } catch (error) {
+    logger.warn("SourceRegistry trust mirror failed (non-critical)", {
+      component: "do-mirror",
+      error: toError(error).message,
+    });
+  }
+}

--- a/worker/lib/do-mirror.ts
+++ b/worker/lib/do-mirror.ts
@@ -17,23 +17,41 @@ interface SourceRegistryStub {
   evolveTrust(source_id: string, success: boolean): Promise<number>;
 }
 
-function getDealRegistryStub(env: Env): DealRegistryStub | undefined {
+type DealRegistryRpc = keyof DealRegistryStub;
+
+type DealRegistryRpcMethods = ReadonlyArray<DealRegistryRpc>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+/**
+ * Runtime guard: the stub is only usable when every listed RPC method is a
+ * function. Replaces the previous unchecked `as unknown as` stub casts.
+ */
+function hasRpcMethods(
+  stub: unknown,
+  methods: DealRegistryRpcMethods | ReadonlyArray<keyof SourceRegistryStub>,
+): boolean {
+  if (!isRecord(stub)) return false;
+  return methods.every((method) => typeof stub[method] === "function");
+}
+
+function getDealRegistryStubObject(env: Env): unknown {
   const namespace = env.DEAL_REGISTRY;
   if (!namespace) return undefined;
   try {
-    const objectId = namespace.idFromName("deals");
-    return namespace.get(objectId) as unknown as DealRegistryStub;
+    return namespace.get(namespace.idFromName("deals"));
   } catch {
     return undefined;
   }
 }
 
-function getSourceRegistryStub(env: Env): SourceRegistryStub | undefined {
+function getSourceRegistryStubObject(env: Env): unknown {
   const namespace = env.SOURCE_REGISTRY;
   if (!namespace) return undefined;
   try {
-    const objectId = namespace.idFromName("sources");
-    return namespace.get(objectId) as unknown as SourceRegistryStub;
+    return namespace.get(namespace.idFromName("sources"));
   } catch {
     return undefined;
   }
@@ -58,8 +76,10 @@ function raceWithTimeout<T>(operation: Promise<T>): Promise<T> {
  * KV snapshot remains canonical; DO failures are logged and never throw.
  */
 export async function mirrorStageToDO(env: Env, deals: Deal[]): Promise<void> {
-  const stub = getDealRegistryStub(env);
-  if (!stub || deals.length === 0) return;
+  if (deals.length === 0) return;
+  const candidate = getDealRegistryStubObject(env);
+  if (!hasRpcMethods(candidate, ["stageDeals", "validateDeals"])) return;
+  const stub = candidate as DealRegistryStub;
   try {
     const inputs = deals.map((d) => ({
       id: d.id,
@@ -95,8 +115,10 @@ export async function mirrorPublishToDO(
   env: Env,
   dealIds: string[],
 ): Promise<void> {
-  const stub = getDealRegistryStub(env);
-  if (!stub || dealIds.length === 0) return;
+  if (dealIds.length === 0) return;
+  const candidate = getDealRegistryStubObject(env);
+  if (!hasRpcMethods(candidate, ["publishDeals"])) return;
+  const stub = candidate as DealRegistryStub;
   try {
     const published = await raceWithTimeout(stub.publishDeals(dealIds));
     logger.debug("DealRegistry mirror published", {
@@ -120,8 +142,10 @@ export async function mirrorTrustToDO(
   env: Env,
   outcomes: Map<string, boolean>,
 ): Promise<void> {
-  const stub = getSourceRegistryStub(env);
-  if (!stub || outcomes.size === 0) return;
+  if (outcomes.size === 0) return;
+  const candidate = getSourceRegistryStubObject(env);
+  if (!hasRpcMethods(candidate, ["evolveTrust"])) return;
+  const stub = candidate as SourceRegistryStub;
   try {
     const entries = Array.from(outcomes.entries()).slice(0, MAX_MIRROR_DOMAINS);
     await Promise.all(

--- a/worker/lib/mcp/tools/system.ts
+++ b/worker/lib/mcp/tools/system.ts
@@ -18,6 +18,11 @@ import {
   GetSimilarDealsInputSchema,
 } from "../handlers/discovery";
 import { handleGetLogs, GetLogsInputSchema } from "../handlers/logging";
+import {
+  handleCheckProgress,
+  handleCancelOperation,
+  handleListOperations,
+} from "../handlers/progress";
 
 export const systemTools: Tool[] = [
   {
@@ -163,6 +168,73 @@ export const systemTools: Tool[] = [
       openWorldHint: false,
     },
   },
+  {
+    name: "check_progress",
+    title: "Check Operation Progress",
+    description: "Get progress state for a long-running MCP operation",
+    inputSchema: {
+      type: "object",
+      properties: {
+        operationId: { type: "string" },
+      },
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        operationId: { type: "string" },
+        status: { type: "string" },
+      },
+    },
+    annotations: {
+      title: "Check Progress",
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  },
+  {
+    name: "cancel_operation",
+    title: "Cancel Operation",
+    description: "Cancel a running MCP operation",
+    inputSchema: {
+      type: "object",
+      properties: {
+        operationId: { type: "string" },
+      },
+      required: ["operationId"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        success: { type: "boolean" },
+      },
+    },
+    annotations: {
+      title: "Cancel Operation",
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  },
+  {
+    name: "list_operations",
+    title: "List Operations",
+    description: "List tracked MCP operations",
+    inputSchema: { type: "object", properties: {} },
+    outputSchema: {
+      type: "object",
+      properties: {
+        operations: { type: "array" },
+        count: { type: "number" },
+      },
+    },
+    annotations: {
+      title: "List Operations",
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  },
 ];
 
 export const systemToolHandlers: Record<string, ToolHandler> = {
@@ -173,4 +245,7 @@ export const systemToolHandlers: Record<string, ToolHandler> = {
     handleGetSimilarDeals(GetSimilarDealsInputSchema.parse(args), env),
   get_deal_highlights: (args, env) => handleGetDealHighlights(args, env),
   get_logs: (args, env) => handleGetLogs(GetLogsInputSchema.parse(args), env),
+  check_progress: (args, env) => handleCheckProgress(args, env),
+  cancel_operation: (args, env) => handleCancelOperation(args, env),
+  list_operations: (args, env) => handleListOperations(args, env),
 };

--- a/worker/lib/research-agent/orchestrator/index.ts
+++ b/worker/lib/research-agent/orchestrator/index.ts
@@ -51,16 +51,17 @@ function getApiKeys(env: Env) {
 /**
  * Resolve whether the research agent should perform REAL fetching.
  *
- * Real fetching is the DEFAULT (MF-2). Simulation is only used when
- * explicitly requested through the test-only `use_simulated_results`
- * option or an explicit `use_real_fetching: false` override.
+ * Real fetching is used when explicitly enabled (MF-2 rollout guard):
+ * simulation remains the fallback outside production to respect
+ * subrequest budgets and external rate limits. Simulation is also forced
+ * through the test-only `use_simulated_results` option.
  *
  * Order of precedence:
  *   1. Request level: request.options?.use_simulated_results (test-only flag)
  *   2. Request level: request.options?.use_real_fetching (explicit override)
  *   3. Feature flag: real_research_fetching (supports rolloutPercentage)
  *   4. Environment allowlist: production OR explicit RESEARCH_USE_REAL_FETCHING=true
- *   5. Default: real fetching (honest results — never fabricate codes)
+ *   5. Default: simulated discovery (safe fallback — no external calls)
  */
 async function shouldUseRealFetching(
   env: Env,
@@ -101,7 +102,7 @@ export async function executeReferralResearch(
   const registry = createDefaultScraperRegistry();
   const scraperEnv = env as unknown as ScraperEnv;
   const readySources = readySourceNames(registry, scraperEnv);
-  // Real fetching is the default (MF-2); simulation is opt-in only.
+  // MF-2 rollout guard: real fetching only when enabled (flag/env/override).
   const useRealFetching = await shouldUseRealFetching(env, request);
 
   const discoveredCodes: ReferralResearchResult["discovered_codes"] = [];

--- a/worker/pipeline/score.ts
+++ b/worker/pipeline/score.ts
@@ -231,8 +231,10 @@ export async function evolveSourceTrust(
           allValid,
         });
       }
-      // Best-effort SourceRegistry DO mirror (D1 remains canonical)
-      await mirrorTrustToDO(
+      // Best-effort SourceRegistry DO mirror (D1 remains canonical).
+      // Detached (fire-and-forget) so DO RPC timeouts never delay trust
+      // evolution or the pipeline phase that awaits it.
+      void mirrorTrustToDO(
         env,
         new Map(domains.map((domain) => [domain, allValid])),
       );

--- a/worker/pipeline/score.ts
+++ b/worker/pipeline/score.ts
@@ -2,6 +2,7 @@ import { Deal, DealMetadata, PipelineContext, Env } from "../types";
 import { CONFIG } from "../config";
 import { updateSourceTrust } from "../lib/storage";
 import { evolveTrustBatch } from "../lib/d1/trust";
+import { mirrorTrustToDO } from "../lib/do-mirror";
 import { logger } from "../lib/global-logger";
 import { toError } from "../lib/sanitize-error";
 
@@ -230,6 +231,11 @@ export async function evolveSourceTrust(
           allValid,
         });
       }
+      // Best-effort SourceRegistry DO mirror (D1 remains canonical)
+      await mirrorTrustToDO(
+        env,
+        new Map(domains.map((domain) => [domain, allValid])),
+      );
     } catch (error) {
       const err = toError(error);
       logger.error(`D1 batch trust evolution failed, falling back to KV`, {

--- a/worker/pipeline/stage.ts
+++ b/worker/pipeline/stage.ts
@@ -3,6 +3,7 @@ import { SnapshotSchema } from "../types";
 import { CONFIG } from "../config";
 import { generateSnapshotHash } from "../lib/crypto";
 import { putStagingSnapshot } from "../lib/storage";
+import { mirrorStageToDO } from "../lib/do-mirror";
 import type { Env } from "../types";
 
 // ============================================================================
@@ -69,6 +70,9 @@ export async function stage(
 
   // Write to staging — use direct put to avoid second hash (F-8)
   await putStagingSnapshot(env, snapshot);
+
+  // Best-effort DealRegistry DO mirror (KV remains canonical)
+  await mirrorStageToDO(env, deals);
 
   // Read-after-write verification (single read, no re-hash)
   const verified = await verifyStaging(env, snapshot);

--- a/worker/pipeline/stage.ts
+++ b/worker/pipeline/stage.ts
@@ -71,8 +71,9 @@ export async function stage(
   // Write to staging — use direct put to avoid second hash (F-8)
   await putStagingSnapshot(env, snapshot);
 
-  // Best-effort DealRegistry DO mirror (KV remains canonical)
-  await mirrorStageToDO(env, deals);
+  // Best-effort DealRegistry DO mirror (KV remains canonical). Detached
+  // (fire-and-forget) so DO RPC timeouts never block the staging hot path.
+  void mirrorStageToDO(env, deals);
 
   // Read-after-write verification (single read, no re-hash)
   const verified = await verifyStaging(env, snapshot);

--- a/worker/publish.ts
+++ b/worker/publish.ts
@@ -23,6 +23,7 @@ import {
   METRIC_PUBLISH_ERRORS,
 } from "./lib/metrics/names";
 import { notifyHighValueDealsWithWebhook } from "./lib/high-value-notifier";
+import { mirrorPublishToDO } from "./lib/do-mirror";
 
 // ============================================================================
 // Production Publish Flow
@@ -123,6 +124,12 @@ export async function publishSnapshot(
       status: deal.metadata.status,
     }));
     await insertReferralsBatch(env.DEALS_DB, referrals);
+
+    // Step 5a: Best-effort DealRegistry DO mirror (KV + D1 remain canonical)
+    await mirrorPublishToDO(
+      env,
+      publishedSnapshot.deals.map((deal) => deal.id),
+    );
 
     // Step 5b: High-value deal notifications (MF-N1) — best-effort, never blocks publish.
     // Reuses webhook infra (worker/lib/webhook) + push path (notify) from

--- a/worker/publish.ts
+++ b/worker/publish.ts
@@ -125,8 +125,9 @@ export async function publishSnapshot(
     }));
     await insertReferralsBatch(env.DEALS_DB, referrals);
 
-    // Step 5a: Best-effort DealRegistry DO mirror (KV + D1 remain canonical)
-    await mirrorPublishToDO(
+    // Step 5a: Best-effort DealRegistry DO mirror (KV + D1 remain canonical).
+    // Detached (fire-and-forget) so DO RPC timeouts never block publishing.
+    void mirrorPublishToDO(
       env,
       publishedSnapshot.deals.map((deal) => deal.id),
     );

--- a/worker/router/legacy-routes.ts
+++ b/worker/router/legacy-routes.ts
@@ -37,6 +37,7 @@ import {
   handleMCPInfo,
 } from "../routes/mcp";
 import { tryHandleMCPStreamRoutes } from "./mcp-stream-routes";
+import { tryHandleOpsRoutes } from "./ops-routes";
 import {
   handleValidateUrl,
   handleValidateBatch,
@@ -461,6 +462,10 @@ export async function tryHandleLegacyRoutes(
   if (path === "/api/email/help" && request.method === "GET") {
     return withAuth(request, env, undefined, () => handleEmailHelp());
   }
+
+  // Bulk + dashboard ops routes (extracted to ops-routes.ts).
+  const opsResponse = await tryHandleOpsRoutes(request, env, path);
+  if (opsResponse) return opsResponse;
 
   // Admin API Key Management
   if (path === "/api/admin/keys") {

--- a/worker/router/ops-routes.ts
+++ b/worker/router/ops-routes.ts
@@ -10,6 +10,9 @@ import {
   handleDashboardSystemHealth,
 } from "../routes/dashboard";
 
+/** Max accepted JSON body for bulk import (50 KiB). */
+const BULK_IMPORT_MAX_BODY_BYTES = 50 * 1024;
+
 /**
  * Ops routes (bulk + dashboard), extracted from legacy-routes.ts to keep
  * the legacy dispatcher under the source-size limit.
@@ -26,7 +29,7 @@ export async function tryHandleOpsRoutes(
   path: string,
 ): Promise<Response | null> {
   if (path === "/api/bulk/import" && request.method === "POST") {
-    const bodyTooLarge = checkBodySize(request, 50 * 1024);
+    const bodyTooLarge = checkBodySize(request, BULK_IMPORT_MAX_BODY_BYTES);
     if (bodyTooLarge) return bodyTooLarge;
     return withAuth(request, env, "user", (auth) => {
       const rateLimiter = createRateLimitMiddleware(

--- a/worker/router/ops-routes.ts
+++ b/worker/router/ops-routes.ts
@@ -1,0 +1,68 @@
+import type { Env } from "../types";
+import { checkBodySize } from "../middleware/body-limit";
+import { withAuth } from "../lib/auth";
+import { createRateLimitMiddleware } from "../lib/rate-limit";
+import { handleBulkImport } from "../routes/bulk/import";
+import { handleBulkExport } from "../routes/bulk/export";
+import {
+  handleDashboardStats,
+  handleDashboardRecentActivity,
+  handleDashboardSystemHealth,
+} from "../routes/dashboard";
+
+/**
+ * Ops routes (bulk + dashboard), extracted from legacy-routes.ts to keep
+ * the legacy dispatcher under the source-size limit.
+ *
+ * - POST /api/bulk/import (user auth, rate-limited)
+ * - GET /api/bulk/export (user auth, rate-limited)
+ * - GET /api/dashboard/stats|activity|health (admin-only ops surface)
+ *
+ * Returns the matching Response, or `null` if no ops route matched.
+ */
+export async function tryHandleOpsRoutes(
+  request: Request,
+  env: Env,
+  path: string,
+): Promise<Response | null> {
+  if (path === "/api/bulk/import" && request.method === "POST") {
+    const bodyTooLarge = checkBodySize(request, 50 * 1024);
+    if (bodyTooLarge) return bodyTooLarge;
+    return withAuth(request, env, "user", (auth) => {
+      const rateLimiter = createRateLimitMiddleware(
+        env,
+        "/api/bulk/import",
+        auth,
+      );
+      return rateLimiter(request, () => handleBulkImport(request, env));
+    });
+  }
+  if (path === "/api/bulk/export" && request.method === "GET") {
+    return withAuth(request, env, "user", (auth) => {
+      const rateLimiter = createRateLimitMiddleware(
+        env,
+        "/api/bulk/export",
+        auth,
+      );
+      return rateLimiter(request, () => handleBulkExport(request, env));
+    });
+  }
+
+  if (path === "/api/dashboard/stats" && request.method === "GET") {
+    return withAuth(request, env, "admin", () =>
+      handleDashboardStats(env, request),
+    );
+  }
+  if (path === "/api/dashboard/activity" && request.method === "GET") {
+    return withAuth(request, env, "admin", () =>
+      handleDashboardRecentActivity(env, request),
+    );
+  }
+  if (path === "/api/dashboard/health" && request.method === "GET") {
+    return withAuth(request, env, "admin", () =>
+      handleDashboardSystemHealth(env, request),
+    );
+  }
+
+  return null;
+}

--- a/worker/routes/nlq/index.ts
+++ b/worker/routes/nlq/index.ts
@@ -51,7 +51,19 @@ export async function handleNLQRequest(
   }
   const savedDeleteMatch = path.match(/^\/api\/nlq\/saved\/([^/]+)$/);
   if (savedDeleteMatch && request.method === "DELETE") {
-    const id = savedDeleteMatch[1]!;
+    const id = savedDeleteMatch[1];
+    if (!id) {
+      return jsonResponse(
+        {
+          error: "Not found",
+          message: "Missing saved query id",
+          code: "NOT_FOUND",
+        } as NLQError,
+        404,
+        request,
+        env,
+      );
+    }
     return handleSavedDelete(request, env, id);
   }
 

--- a/worker/routes/referrals.ts
+++ b/worker/routes/referrals.ts
@@ -59,10 +59,10 @@ export async function handleGetReferrals(
         (url.searchParams.get("source") as ReferralSearchQuery["source"]) ||
         "all",
       limit: url.searchParams.has("limit")
-        ? parseInt(url.searchParams.get("limit")!, 10)
+        ? parseInt(url.searchParams.get("limit") ?? "100", 10)
         : 100,
       offset: url.searchParams.has("offset")
-        ? parseInt(url.searchParams.get("offset")!, 10)
+        ? parseInt(url.searchParams.get("offset") ?? "0", 10)
         : 0,
     };
 

--- a/worker/routes/semantic-search.ts
+++ b/worker/routes/semantic-search.ts
@@ -33,6 +33,9 @@ import {
 /** Workers AI embedding model used for query vectorization. */
 const SEMANTIC_EMBEDDING_MODEL = "@cf/baai/bge-base-en-v1.5";
 
+/** Bucket size (5 minutes) used when synthesizing created_at vector metadata. */
+const CREATED_AT_BUCKET_MS = 5 * 60 * 1000;
+
 export function matchesSemanticFilters(
   metadata: Record<string, unknown> | undefined,
   filters: SemanticSearchFilters | undefined,
@@ -69,7 +72,9 @@ export function matchesSemanticFilters(
     );
     if (!wantsAll) return false;
   }
-  // min_reward has no vector-metadata value field; documented as FTS/hybrid-only.
+  // min_reward has no vector-metadata value field. It is enforced separately
+  // from the D1 reward_value column: hybrid search filters FTS rows against
+  // it, and the pure vector path rejects min_reward requests (no D1 values).
   return true;
 }
 
@@ -85,7 +90,7 @@ export function describeSemanticFilters(
   if (filters.tags !== undefined && filters.tags.length > 0)
     applied.push(`tags=${filters.tags.join(",")}`);
   if (filters.min_reward !== undefined)
-    applied.push("min_reward=unsupported(vector)");
+    applied.push(`min_reward=${filters.min_reward}`);
   return applied;
 }
 
@@ -120,6 +125,16 @@ export async function handleSemanticSearch(
   }
 
   const { query, limit, filters, hybrid, min_score } = parsed.data;
+
+  // min_reward is a structured D1 attribute that vector metadata does not
+  // carry. Enforcing it requires D1 rows (hybrid), so reject vector-only.
+  if (filters?.min_reward !== undefined && hybrid !== true) {
+    return errorResponse(
+      "min_reward filter requires hybrid=true; pure vector search returns no reward values",
+      400,
+    );
+  }
+
   const requestedLimit = limit ?? SEMANTIC_SEARCH_CONFIG.DEFAULT_LIMIT;
   const namespace =
     env.ENVIRONMENT === "production"
@@ -255,8 +270,21 @@ async function handleHybridSearch(
         }
       ).rows
     : [];
+  const minReward = filters?.min_reward;
+
+  // min_reward is a structured D1 attribute that vector metadata does not
+  // carry, so it is enforced from the FTS rows' D1 reward_value before fusion.
+  const rewardEligibleRows =
+    minReward !== undefined
+      ? rawFtsRows.filter(
+          (row) =>
+            typeof row.reward_value === "number" &&
+            row.reward_value >= minReward,
+        )
+      : rawFtsRows;
+
   const ftsRows = filters
-    ? rawFtsRows.filter((row) =>
+    ? rewardEligibleRows.filter((row) =>
         matchesSemanticFilters(
           {
             domain: row.domain,
@@ -267,7 +295,22 @@ async function handleHybridSearch(
           filters,
         ),
       )
-    : rawFtsRows;
+    : rewardEligibleRows;
+
+  // When a reward floor is set, only deals verified against D1 (present in the
+  // reward-eligible FTS rows) may be returned; unverifiable vector hits drop.
+  const rewardEligibleIds =
+    minReward !== undefined
+      ? new Set(rewardEligibleRows.map((row) => row.deal_id))
+      : undefined;
+  const fusionVectorHits =
+    rewardEligibleIds !== undefined
+      ? vectorHits.filter((h) => {
+          const dealId =
+            typeof h.metadata?.deal_id === "string" ? h.metadata.deal_id : h.id;
+          return rewardEligibleIds.has(dealId);
+        })
+      : vectorHits;
 
   // If both empty but one side expected to have results, fallback to whichever succeeded
   const fusionStart = Date.now();
@@ -276,7 +319,7 @@ async function handleHybridSearch(
   let totalFused = 0;
 
   if (ftsQuery && ftsRows.length > 0) {
-    const fused = fuseHybridResults(vectorHits, ftsRows, {
+    const fused = fuseHybridResults(fusionVectorHits, ftsRows, {
       limit: requestedLimit,
       minScore,
     });
@@ -289,18 +332,16 @@ async function handleHybridSearch(
         tags: [],
         status: "active",
         reward_type: "cash",
-        created_at_bucket: Math.floor(Date.now() / 300000) * 300000,
+        created_at_bucket:
+          Math.floor(Date.now() / CREATED_AT_BUCKET_MS) * CREATED_AT_BUCKET_MS,
       },
       score: f.score,
       match_type: f.match_type,
     }));
   } else {
     // No FTS results or query not FTS-able: vector only filtered
-    const filtered = vectorHits
-      .filter(
-        (h) =>
-          h.score >= minScore && matchesSemanticFilters(h.metadata, filters),
-      )
+    const filtered = fusionVectorHits
+      .filter((h) => h.score >= minScore)
       .slice(0, requestedLimit);
     totalFused = filtered.length;
     results = filtered.map((h) => ({

--- a/worker/routes/semantic-search.ts
+++ b/worker/routes/semantic-search.ts
@@ -15,6 +15,7 @@ import { jsonResponse, errorResponse } from "./utils";
 import {
   SemanticSearchRequestSchema,
   SEMANTIC_SEARCH_CONFIG,
+  type SemanticSearchFilters,
   type SemanticSearchResponse,
 } from "../lib/search/types";
 import {
@@ -31,6 +32,62 @@ import {
 
 /** Workers AI embedding model used for query vectorization. */
 const SEMANTIC_EMBEDDING_MODEL = "@cf/baai/bge-base-en-v1.5";
+
+export function matchesSemanticFilters(
+  metadata: Record<string, unknown> | undefined,
+  filters: SemanticSearchFilters | undefined,
+): boolean {
+  if (!filters) return true;
+  if (filters.domain !== undefined) {
+    const domain = typeof metadata?.domain === "string" ? metadata.domain : "";
+    if (domain.toLowerCase() !== filters.domain.toLowerCase()) return false;
+  }
+  if (filters.category !== undefined) {
+    const categories = Array.isArray(metadata?.category)
+      ? (metadata.category as unknown[])
+      : [];
+    const wanted = filters.category.toLowerCase();
+    const hasCategory = categories.some(
+      (c) => typeof c === "string" && c.toLowerCase() === wanted,
+    );
+    if (!hasCategory) return false;
+  }
+  if (filters.status !== undefined && filters.status !== "all") {
+    if (metadata?.status !== filters.status) return false;
+  }
+  if (filters.tags !== undefined && filters.tags.length > 0) {
+    const tags = Array.isArray(metadata?.tags)
+      ? (metadata.tags as unknown[])
+      : [];
+    const normalizedTags = new Set(
+      tags
+        .filter((t): t is string => typeof t === "string")
+        .map((t) => t.toLowerCase()),
+    );
+    const wantsAll = filters.tags.every((t) =>
+      normalizedTags.has(t.toLowerCase()),
+    );
+    if (!wantsAll) return false;
+  }
+  // min_reward has no vector-metadata value field; documented as FTS/hybrid-only.
+  return true;
+}
+
+export function describeSemanticFilters(
+  filters: SemanticSearchFilters | undefined,
+): string[] {
+  if (!filters) return [];
+  const applied: string[] = [];
+  if (filters.domain !== undefined) applied.push(`domain=${filters.domain}`);
+  if (filters.category !== undefined)
+    applied.push(`category=${filters.category}`);
+  if (filters.status !== undefined) applied.push(`status=${filters.status}`);
+  if (filters.tags !== undefined && filters.tags.length > 0)
+    applied.push(`tags=${filters.tags.join(",")}`);
+  if (filters.min_reward !== undefined)
+    applied.push("min_reward=unsupported(vector)");
+  return applied;
+}
 
 export async function handleSemanticSearch(
   request: Request,
@@ -62,7 +119,7 @@ export async function handleSemanticSearch(
     );
   }
 
-  const { query, limit, filters: _filters, hybrid, min_score } = parsed.data;
+  const { query, limit, filters, hybrid, min_score } = parsed.data;
   const requestedLimit = limit ?? SEMANTIC_SEARCH_CONFIG.DEFAULT_LIMIT;
   const namespace =
     env.ENVIRONMENT === "production"
@@ -79,6 +136,7 @@ export async function handleSemanticSearch(
         min_score,
         namespace,
         start,
+        filters,
       );
     }
 
@@ -90,7 +148,10 @@ export async function handleSemanticSearch(
     });
     const embeddingMs = Date.now() - embeddingStart;
     const vectorizeStart = Date.now();
-    const filtered = hits.filter((h) => h.score >= min_score);
+    const filtered = hits.filter(
+      (h) =>
+        h.score >= min_score && matchesSemanticFilters(h.metadata, filters),
+    );
     const vectorizeMs = Date.now() - vectorizeStart;
 
     // Article 12 record-keeping for the embedding + vector query. The raw
@@ -129,7 +190,10 @@ export async function handleSemanticSearch(
         vectorize_time_ms: vectorizeMs,
         model: SEMANTIC_EMBEDDING_MODEL,
         index_name: SEMANTIC_SEARCH_CONFIG.INDEX_NAME,
-        filters_applied: namespace ? [`namespace=${namespace}`] : [],
+        filters_applied: [
+          ...(namespace ? [`namespace=${namespace}`] : []),
+          ...describeSemanticFilters(filters),
+        ],
       },
     };
     return jsonResponse(response);
@@ -148,6 +212,7 @@ async function handleHybridSearch(
   minScore: number,
   namespace: string | undefined,
   start: number,
+  filters?: SemanticSearchFilters,
 ): Promise<Response> {
   const hybridStart = Date.now();
   const ftsQuery = sanitizeFtsQuery(query);
@@ -177,8 +242,12 @@ async function handleHybridSearch(
       : Promise.resolve({ ok: false as const, rows: [] as never[] }),
   ]);
 
-  const vectorHits = vectorResult.ok ? vectorResult.hits : [];
-  const ftsRows = (ftsResult as { rows?: unknown[] }).rows
+  const vectorHits = vectorResult.ok
+    ? vectorResult.hits.filter((h) =>
+        matchesSemanticFilters(h.metadata, filters),
+      )
+    : [];
+  const rawFtsRows = (ftsResult as { rows?: unknown[] }).rows
     ? (
         ftsResult as {
           ok: boolean;
@@ -186,6 +255,19 @@ async function handleHybridSearch(
         }
       ).rows
     : [];
+  const ftsRows = filters
+    ? rawFtsRows.filter((row) =>
+        matchesSemanticFilters(
+          {
+            domain: row.domain,
+            category: row.category,
+            status: row.status,
+            tags: row.tags,
+          },
+          filters,
+        ),
+      )
+    : rawFtsRows;
 
   // If both empty but one side expected to have results, fallback to whichever succeeded
   const fusionStart = Date.now();
@@ -215,7 +297,10 @@ async function handleHybridSearch(
   } else {
     // No FTS results or query not FTS-able: vector only filtered
     const filtered = vectorHits
-      .filter((h) => h.score >= minScore)
+      .filter(
+        (h) =>
+          h.score >= minScore && matchesSemanticFilters(h.metadata, filters),
+      )
       .slice(0, requestedLimit);
     totalFused = filtered.length;
     results = filtered.map((h) => ({
@@ -270,6 +355,7 @@ async function handleHybridSearch(
         ...(namespace ? [`namespace=${namespace}`] : []),
         "hybrid=rrf",
         `fts_query=${ftsQuery || "n/a"}`,
+        ...describeSemanticFilters(filters),
       ],
     },
   };


### PR DESCRIPTION
What: wires DealRegistry and SourceRegistry DOs as best-effort mirrors in stage, publish and trust paths with KV and D1 staying canonical. Registers bulk import/export behind user auth and dashboard stats, activity and health behind admin auth via a new ops router. Registers MCP check_progress, cancel_operation and list_operations tools. Applies semantic-search domain, category, status and tag filters to vector and hybrid paths. Adds an Email Workers entrypoint, fixes three non-null assertions, and corrects MF-2 rollout docs. Adds 12 wiring tests and updates the MCP tool count assertion. Why: closes verified-open missing implementations MI-4, OPS-R, MCP-P, EMAIL-E, MF-1 filters, MF-2 docs, R-2 regressions and T-5 progress coverage from the 2026-08-15 gap analysis. Impact: no behavior change on canonical stores since all DO calls are timeout-guarded and failure-isolated. 15 MCP tools become 18. Dashboard surface is admin-only. Full unit suite passes 2761 tests with typecheck, format and quality gate clean. Spec in plans/SPEC-missing-impl-sweep.md, tracking in plans/GOAP_STATE.md v0.19.7.