### PR TITLE
chore(metrics): record goap v0.19.9 sync completion

### DIFF
--- a/.agents/metrics/metrics-opencode.jsonl
+++ b/.agents/metrics/metrics-opencode.jsonl
@@ -10,3 +10,4 @@
 {"timestamp": "2026-09-03T11:44:38Z", "agent": "opencode", "task": "enable f-11 unused-symbol TypeScript enforcement", "status": "completed"}
 {"timestamp": "2026-09-03T18:05:00Z", "agent": "opencode", "task": "eliminate all quality-gate warnings and stray config drift", "status": "completed"}
 {"timestamp": "2026-09-03T18:20:00Z", "agent": "opencode", "task": "n-3 logging consolidation with spec adr-025 and goap v0.19.6", "status": "completed"}
+{"timestamp": "2026-09-05T17:10:52Z", "agent": "opencode", "task": "goap doc-sync v0.19.9 post 754 merge wave (PR 755)", "status": "completed"}


### PR DESCRIPTION
What: append one completed-task entry to metrics-opencode.jsonl for the v0.19.9 doc-sync. Why: post-task protocol requires a metrics entry per completed task. Impact: metrics file only, zero runtime diff.