### PR TITLE
chore(metrics): record plans cleanup completion

### DIFF
--- a/.agents/metrics/metrics-opencode.jsonl
+++ b/.agents/metrics/metrics-opencode.jsonl
@@ -11,3 +11,4 @@
 {"timestamp": "2026-09-03T18:05:00Z", "agent": "opencode", "task": "eliminate all quality-gate warnings and stray config drift", "status": "completed"}
 {"timestamp": "2026-09-03T18:20:00Z", "agent": "opencode", "task": "n-3 logging consolidation with spec adr-025 and goap v0.19.6", "status": "completed"}
 {"timestamp": "2026-09-05T17:10:52Z", "agent": "opencode", "task": "goap doc-sync v0.19.9 post 754 merge wave (PR 755)", "status": "completed"}
+{"timestamp": "2026-09-05T17:45:00Z", "agent": "opencode", "task": "plans folder cleanup, archive 14 stale docs (PR 757)", "status": "completed"}


### PR DESCRIPTION
What: append one completed-task entry to metrics-opencode.jsonl for the plans cleanup. Why: post-task protocol requires a metrics entry per completed task. Impact: metrics file only, zero runtime diff.