### PR TITLE
test(gaps): close deferred t-2 t-3 t-4 suites with 95 unit tests

### DIFF
--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -2,9 +2,25 @@
 
 **Generated**: 2026-07-06
 **Last Updated**: 2026-09-05
-**Version**: 0.19.9
-**Status**: Active — 2026-09-05 merge wave COMPLETE: #748/#749/#750/#751/#752/#753/#754 all MERGED to main @ 872d411, main push CI 5/5 SUCCESS, queue empty (0 open PRs/issues). ADR-026 (npm registry) and ADR-027 (ruleset mismatch) RESOLVED. Prior 2026-09-05 state: v0.19.8 fix-forward #754 blocked; 2026-09-03 v0.19.5 doc sync F-8/F-10/F-12 closed via #736/#737/#738, SSRF IPv6 bypass closed via #742, D1 lock fix via #739, CI guard via #733; 2026-08-31 self-learning-feedback COMPLETE per ADR-024; 2026-08-25/24 improvement runs COMPLETE.
+**Version**: 0.19.10
+**Status**: Active — 2026-09-05 test gaps T-2/T-3/T-4 CLOSED (95 new unit tests, 2872/2872 green, zero prod change). Prior: v0.19.9 merge wave COMPLETE (#748-#754 MERGED, queue empty, ADR-026/027 RESOLVED).
 **Sources**: [Codebase Audit (04/04)](../reports/analysis/codebase-audit-2026-04-04.md), [Swarm Analysis (04/04)](../reports/analysis/swarm-missing-implementations-2026-04-04.md), [Feature Gap Analysis](../reports/analysis/feature-gap-analysis.md), [ADR-015](ADR-015-harness-cloudflare-2026-best-practices.md), [ADR-024](ADR-024-skill-version-independence.md)
+
+---
+
+## 2026-09-05 Test-Gap Closure (T-2/T-3/T-4) — v0.19.10
+
+Branch: `chore/test-gaps-t2-t3-t4`. Spec: [SPEC-test-gaps-t2-t3-t4.md](SPEC-test-gaps-t2-t3-t4.md). No ADR (zero prod change). No new deps, creds, or bindings.
+
+| ID | Finding | Priority | Status | Evidence |
+|:---|:---|:---|:---|:---|
+| T-2 | Email HTTP handlers + route layer untested | P2 | ✅ CLOSED — `tests/unit/routes/email.test.ts` 12 route tests (real HMAC, missing-secret 500, sig 401s, field 400s, recipient split, worker delegation) + `tests/unit/email/handlers.test.ts` 17 dispatch tests (security gate, ADD/DEACTIVATE/SEARCH/DIGEST/HELP/FORWARDED, duplicates, low-confidence, exception, header mapping) | routes/email.test.ts, email/handlers.test.ts |
+| T-3 | NLQ AI enhancer + hybrid classifier untested | P2 | ✅ CLOSED — `tests/unit/nlq/ai-enhancer.test.ts` 15 tests (shouldUseAI matrix, empty/fast/AI paths, rejection + invalid-JSON fallbacks, confidence clamping, cache hit, truncation, batch, helpers) + `rule-classifier.test.ts` 16 pure-table tests + `hybrid-classifier.test.ts` 14 dispatch tests (routing, ai-null fallback, order restoration, stats) | nlq/ai-enhancer.test.ts, rule-classifier.test.ts, hybrid-classifier.test.ts |
+| T-4 | Validation scraper internals untested | P2 | ✅ CLOSED — `tests/unit/change-detector.test.ts` 13 tests (compare matrix, rounding, string normalization, severity incl. critical) + `tests/unit/batch-processor.test.ts` 8 tests (grouping, change attach, failure passthrough, catch row, stats) | change-detector.test.ts, batch-processor.test.ts |
+
+Verification: `npm run test:unit` 2872/2872 ✅ (2777 + 95 new), `npx tsc --noEmit` ✅, `prettier` ✅, `markdownlint` ✅, quality gate exit 0 ✅. All new files under 500 lines.
+
+Remaining: RL-1 (KV rate-limit race → DO migration) open per ADR-017; REDDIT-5 in progress; CI-1 blocked per ADR-023.
 
 ---
 
@@ -24,7 +40,7 @@ PRs 748/749/750/751/752/753/754 all MERGED to main @ 872d411. Main push CI 5/5 S
 | ADR-027 ruleset mismatch | ✅ RESOLVED — #754 merged, merges no longer blocked | [ADR-027](ADR-027-ruleset-required-check-mismatch.md) |
 | `sync/pr749`, `pr-747`, stale locals | ⛔ DO NOT MERGE — would revert #748/#749/#750; delete locals | merge-order audit 2026-09-05 |
 
-Next: RL-1 DO migration, T-2/T-3/T-4 gaps, REDDIT-5/6, CI-1 secrets (all Full Mode, need spec + ADR).
+Next: RL-1 DO migration, REDDIT-5/6, CI-1 secrets (Full Mode). T-2/T-3/T-4 CLOSED in v0.19.10 above.
 
 ---
 
@@ -76,7 +92,7 @@ Branch: `feat/missing-impl-sweep`. Spec: [SPEC-missing-impl-sweep.md](SPEC-missi
 
 Verification: `npx tsc --noEmit` ✅, `prettier` ✅, quality gate ✅, full unit suite green on CI head before review round 1; review fixes re-verified locally (targeted suites 72/72, sweep file 14/14).
 
-Deferred: `extends DurableObject` migration + single-source DO cutover (ADR-017 Phase 2); exhaustive T-2/T-3/T-4 suites; `extension/popup.html` split.
+Deferred: `extends DurableObject` migration + single-source DO cutover (ADR-017 Phase 2); `extension/popup.html` split.
 
 ---
 

--- a/plans/SPEC-test-gaps-t2-t3-t4.md
+++ b/plans/SPEC-test-gaps-t2-t3-t4.md
@@ -1,0 +1,70 @@
+# PEV Spec — T-2/T-3/T-4 Test Gaps
+
+## Task
+
+**Title**: Close deferred unit-test gaps T-2, T-3, T-4
+**Author**: opencode
+**Date**: 2026-09-05
+**Priority**: high
+
+## Goal
+
+Add focused unit suites for the three untested orchestration layers
+(email routes/handlers, NLQ AI enhancer + hybrid classifier, validation
+scraper internals) without touching production code.
+
+## Approach
+
+Pure test additions using established seams (vi.mock referral-storage,
+validateSecurity, validatedFetch; injected Ai stub; Map-backed KV).
+Real parseCommand, templates, extraction, and crypto stay unmocked so
+dispatch paths are genuinely exercised.
+
+## Non-Goals
+
+- [ ] Not touching any file under `worker/` (tests + spec + GOAP only)
+- [ ] Not rewriting existing test files (only extend where the 500-line
+  limit allows; otherwise new files)
+- [ ] Not adding production features, bindings, or migrations
+- [ ] Not covering REDDIT-5, RL-1, or CI-1 (separate tracks)
+
+## Steps
+
+| Step | Description | Files Touched | Risk |
+|------|-------------|---------------|------|
+| 1 | T-2: email route + handler orchestration suites | `tests/unit/routes/email.test.ts`, `tests/unit/email/handlers.test.ts` | low |
+| 2 | T-3: NLQ AI enhancer + rule/hybrid classifier suites | `tests/unit/nlq/ai-enhancer.test.ts`, `rule-classifier.test.ts`, `hybrid-classifier.test.ts` | low |
+| 3 | T-4: change-detector + batch-processor suites | `tests/unit/change-detector.test.ts`, `batch-processor.test.ts` | low |
+| 4 | Full verify + GOAP flip T-2/T-3/T-4 to CLOSED | `plans/GOAP_STATE.md` | low |
+
+## Acceptance Criteria
+
+- [ ] `npm run test:unit` fully green (no regressions, new suites pass)
+- [ ] `npx tsc --noEmit` clean (no `any` leaks; banned patterns hold)
+- [ ] `prettier --check` and `markdownlint` clean
+- [ ] `./scripts/quality_gate.sh` exit 0
+- [ ] Every new test file under 500 lines (`MAX_LINES_PER_SOURCE_FILE`)
+- [ ] No network, AI, Vectorize, or KV credentials required by new tests
+- [ ] Existing tests still pass (no regression)
+
+## Open Questions
+
+- [ ] None. Scoping (2026-09-05) confirmed seams and file layout.
+
+## Risk Assessment
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Flaky timing (`Date.now` codes, 1s batch delay) | low | Single-deal batches; avoid wall-clock asserts |
+| Mock drift from production signatures | low | Mock at module seams already used by bulk tests |
+| File-limit breach on extension approach | low | New files per item; never extend near-limit files |
+
+## Dependencies
+
+- [ ] None. No prod code, infra, secrets, or other tracks required.
+
+## Out of Scope for This Spec
+
+- REDDIT-5 coverage (separate track, own spec if needed)
+- RL-1 DO migration (needs ADR + staging probe)
+- No ADR for this spec: zero production or architectural change.

--- a/tests/unit/batch-processor.test.ts
+++ b/tests/unit/batch-processor.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Batch Processor Tests (T-4)
+ *
+ * Covers worker/lib/validation/scrapers/batch-processor.ts: domain
+ * grouping, change attachment, scrape-failure passthrough, the exception
+ * catch row, getDealsWithRewardChanges filtering, and getScrapingStats
+ * aggregation. scrapeCurrentRewards is mocked; no network access occurs.
+ * Single-deal batches keep the per-deal politeness delay cheap.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Deal, Reward } from "../../worker/types";
+import {
+  batchScrapeRewards,
+  getDealsWithRewardChanges,
+  getScrapingStats,
+} from "../../worker/lib/validation/scrapers/batch-processor";
+import type { RewardScrapeResult } from "../../worker/lib/validation/scrapers/types";
+
+vi.mock("../../worker/lib/global-logger", () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("../../worker/lib/validation/scrapers/reward-scraper-core", () => ({
+  scrapeCurrentRewards: vi.fn(),
+  extractDomain: vi.fn((url: string) => {
+    try {
+      return new URL(url).hostname;
+    } catch {
+      return "unknown";
+    }
+  }),
+}));
+
+async function mockScrape(
+  impl: (url: string) => Promise<RewardScrapeResult>,
+): Promise<ReturnType<typeof vi.fn>> {
+  const { scrapeCurrentRewards } =
+    await import("../../worker/lib/validation/scrapers/reward-scraper-core");
+  const mocked = vi.mocked(scrapeCurrentRewards);
+  mocked.mockImplementation(impl);
+  return mocked;
+}
+
+function deal(id: string, url: string, value: number | string): Deal {
+  return {
+    id,
+    url,
+    reward: { type: "cash", value } as Reward,
+  } as unknown as Deal;
+}
+
+function successResult(url: string, value: number): RewardScrapeResult {
+  return {
+    url,
+    success: true,
+    currentReward: { type: "cash", value } as Reward,
+    rewardChanged: false,
+    scrapedAt: new Date().toISOString(),
+  };
+}
+
+describe("batchScrapeRewards", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("attaches change details when the reward moved", async () => {
+    const scrape = await mockScrape(async (url) => successResult(url, 100));
+
+    const results = await batchScrapeRewards([
+      deal("d1", "https://a.com/x", 50),
+    ]);
+
+    expect(scrape).toHaveBeenCalledTimes(1);
+    expect(results).toHaveLength(1);
+    expect(results[0]?.rewardChanged).toBe(true);
+    expect(results[0]?.previousReward).toEqual({ type: "cash", value: 50 });
+    expect(results[0]?.changeDetails).toMatchObject({
+      typeChanged: false,
+      valueChanged: true,
+      oldValue: 50,
+      newValue: 100,
+    });
+  });
+
+  it("omits change details when the reward is unchanged", async () => {
+    await mockScrape(async (url) => successResult(url, 50));
+
+    const results = await batchScrapeRewards([
+      deal("d1", "https://a.com/x", 50),
+    ]);
+
+    expect(results[0]?.rewardChanged).toBe(false);
+    expect(results[0]?.previousReward).toBeUndefined();
+    expect(results[0]?.changeDetails).toBeUndefined();
+  });
+
+  it("passes scrape failures through untouched", async () => {
+    await mockScrape(async (url) => ({
+      url,
+      success: false,
+      rewardChanged: false,
+      scrapedAt: new Date().toISOString(),
+      error: "HTTP 500: boom",
+    }));
+
+    const results = await batchScrapeRewards([
+      deal("d1", "https://a.com/x", 50),
+    ]);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.success).toBe(false);
+    expect(results[0]?.error).toBe("HTTP 500: boom");
+  });
+
+  it("records a catch row when scraping throws", async () => {
+    await mockScrape(async () => {
+      throw new Error("socket hang up");
+    });
+
+    const results = await batchScrapeRewards([
+      deal("d1", "https://a.com/x", 50),
+    ]);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.success).toBe(false);
+    expect(results[0]?.rewardChanged).toBe(false);
+    expect(results[0]?.error).toBe("socket hang up");
+  });
+
+  it("scrapes every deal across domain groups", async () => {
+    const scrape = await mockScrape(async (url) => successResult(url, 10));
+
+    const results = await batchScrapeRewards([
+      deal("d1", "https://a.com/x", 10),
+      deal("d2", "https://b.com/y", 10),
+    ]);
+
+    expect(scrape).toHaveBeenCalledTimes(2);
+    expect(results).toHaveLength(2);
+    expect(results.every((r) => r.success)).toBe(true);
+  });
+});
+
+describe("getDealsWithRewardChanges", () => {
+  it("keeps only successful changed results with a reward", () => {
+    const changed = successResult("https://a.com/1", 100);
+    changed.rewardChanged = true;
+    const unchanged = successResult("https://a.com/2", 50);
+    const failed: RewardScrapeResult = {
+      url: "https://a.com/3",
+      success: false,
+      rewardChanged: false,
+      scrapedAt: new Date().toISOString(),
+    };
+
+    expect(getDealsWithRewardChanges([changed, unchanged, failed])).toEqual([
+      changed,
+    ]);
+  });
+});
+
+describe("getScrapingStats", () => {
+  function changedResult(
+    url: string,
+    oldValue: number,
+    newValue: number,
+    typeChanged = false,
+  ): RewardScrapeResult {
+    return {
+      url,
+      success: true,
+      currentReward: { type: "cash", value: newValue } as Reward,
+      rewardChanged: true,
+      previousReward: { type: "cash", value: oldValue } as Reward,
+      changeDetails: {
+        typeChanged,
+        valueChanged: true,
+        oldValue,
+        newValue,
+      },
+      scrapedAt: new Date().toISOString(),
+    };
+  }
+
+  it("aggregates totals, failures, and change direction", () => {
+    const stats = getScrapingStats([
+      changedResult("https://a.com/1", 50, 100),
+      changedResult("https://a.com/2", 100, 25),
+      successResult("https://a.com/3", 10),
+      {
+        url: "https://a.com/4",
+        success: false,
+        rewardChanged: false,
+        scrapedAt: new Date().toISOString(),
+      },
+    ]);
+
+    expect(stats.total).toBe(4);
+    expect(stats.successful).toBe(3);
+    expect(stats.failed).toBe(1);
+    expect(stats.withChanges).toBe(2);
+    expect(stats.increased).toBe(1);
+    expect(stats.decreased).toBe(1);
+    expect(stats.typeChanged).toBe(0);
+  });
+
+  it("counts type changes", () => {
+    const stats = getScrapingStats([
+      changedResult("https://a.com/1", 50, 50, true),
+    ]);
+
+    expect(stats.typeChanged).toBe(1);
+    expect(stats.withChanges).toBe(1);
+  });
+});

--- a/tests/unit/change-detector.test.ts
+++ b/tests/unit/change-detector.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Change Detector Tests (T-4)
+ *
+ * Covers worker/lib/validation/scrapers/change-detector.ts: the pure
+ * compareRewards matrix (type/value direction, string normalization,
+ * float rounding) and detectRewardChanges orchestration (scrape failure,
+ * no-change, increase/decrease/type-change, critical threshold).
+ * scrapeCurrentRewards is mocked; no network access occurs.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Deal, Reward } from "../../worker/types";
+import {
+  compareRewards,
+  detectRewardChanges,
+} from "../../worker/lib/validation/scrapers/change-detector";
+
+vi.mock("../../worker/lib/global-logger", () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("../../worker/lib/validation/scrapers/reward-scraper-core", () => ({
+  scrapeCurrentRewards: vi.fn(),
+  extractDomain: vi.fn((url: string) => {
+    try {
+      return new URL(url).hostname;
+    } catch {
+      return "unknown";
+    }
+  }),
+}));
+
+function reward(type: Reward["type"], value: number | string): Reward {
+  return { type, value };
+}
+
+function deal(rewardValue: Reward): Deal {
+  return {
+    id: "deal-1",
+    url: "https://example.com/deal",
+    reward: rewardValue,
+  } as unknown as Deal;
+}
+
+async function mockScrape(
+  currentReward: Reward | null,
+  success = true,
+): Promise<void> {
+  const { scrapeCurrentRewards } =
+    await import("../../worker/lib/validation/scrapers/reward-scraper-core");
+  vi.mocked(scrapeCurrentRewards).mockResolvedValue({
+    url: "https://example.com/deal",
+    success,
+    currentReward: currentReward ?? undefined,
+    rewardChanged: false,
+    scrapedAt: new Date().toISOString(),
+  });
+}
+
+describe("compareRewards", () => {
+  it("reports no change for identical rewards", () => {
+    const result = compareRewards(reward("cash", 50), reward("cash", 50));
+
+    expect(result.changed).toBe(false);
+    expect(result.typeChanged).toBe(false);
+    expect(result.valueChanged).toBe(false);
+    expect(result.valueIncreased).toBe(false);
+    expect(result.valueDecreased).toBe(false);
+  });
+
+  it("detects value increases and decreases", () => {
+    const up = compareRewards(reward("cash", 50), reward("cash", 100));
+    expect(up.changed).toBe(true);
+    expect(up.valueChanged).toBe(true);
+    expect(up.valueIncreased).toBe(true);
+    expect(up.valueDecreased).toBe(false);
+    expect(up.oldValue).toBe(50);
+    expect(up.newValue).toBe(100);
+
+    const down = compareRewards(reward("cash", 100), reward("cash", 50));
+    expect(down.valueDecreased).toBe(true);
+    expect(down.valueIncreased).toBe(false);
+  });
+
+  it("detects type changes", () => {
+    const result = compareRewards(reward("cash", 50), reward("percent", 50));
+
+    expect(result.changed).toBe(true);
+    expect(result.typeChanged).toBe(true);
+    expect(result.valueChanged).toBe(false);
+  });
+
+  it("normalizes strings case-insensitively with trimming", () => {
+    const result = compareRewards(
+      reward("item", "Gold"),
+      reward("item", "  gold "),
+    );
+
+    expect(result.changed).toBe(false);
+    expect(result.oldValue).toBe("gold");
+    expect(result.newValue).toBe("gold");
+  });
+
+  it("rounds floats to cents before comparing", () => {
+    const same = compareRewards(reward("cash", 10.001), reward("cash", 10.002));
+    expect(same.valueChanged).toBe(false);
+
+    const different = compareRewards(
+      reward("cash", 10.004),
+      reward("cash", 10.006),
+    );
+    expect(different.valueChanged).toBe(true);
+  });
+
+  it("never flags direction for string values", () => {
+    const result = compareRewards(reward("item", "a"), reward("item", "b"));
+
+    expect(result.valueChanged).toBe(true);
+    expect(result.valueIncreased).toBe(false);
+    expect(result.valueDecreased).toBe(false);
+  });
+
+  it("treats mixed number/string values as changed without direction", () => {
+    const result = compareRewards(reward("cash", 50), reward("cash", "fifty"));
+
+    expect(result.valueChanged).toBe(true);
+    expect(result.valueIncreased).toBe(false);
+    expect(result.valueDecreased).toBe(false);
+  });
+});
+
+describe("detectRewardChanges", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns null when scraping fails", async () => {
+    await mockScrape(null, false);
+
+    const result = await detectRewardChanges(deal(reward("cash", 50)));
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the reward is unchanged", async () => {
+    await mockScrape(reward("cash", 50));
+
+    const result = await detectRewardChanges(deal(reward("cash", 50)));
+
+    expect(result).toBeNull();
+  });
+
+  it("reports increased rewards with info severity", async () => {
+    await mockScrape(reward("cash", 100));
+
+    const result = await detectRewardChanges(deal(reward("cash", 50)));
+
+    expect(result?.changeType).toBe("increased");
+    expect(result?.severity).toBe("info");
+    expect(result?.previousReward).toEqual(reward("cash", 50));
+    expect(result?.currentReward).toEqual(reward("cash", 100));
+    expect(typeof result?.detectedAt).toBe("string");
+  });
+
+  it("reports decreased rewards with warning severity", async () => {
+    await mockScrape(reward("cash", 25));
+
+    const result = await detectRewardChanges(deal(reward("cash", 50)));
+
+    expect(result?.changeType).toBe("decreased");
+    expect(result?.severity).toBe("warning");
+  });
+
+  it("reports type changes with warning severity", async () => {
+    await mockScrape(reward("percent", 20));
+
+    const result = await detectRewardChanges(deal(reward("cash", 20)));
+
+    expect(result?.changeType).toBe("type_changed");
+    expect(result?.severity).toBe("warning");
+  });
+
+  it("escalates huge jumps to critical severity", async () => {
+    await mockScrape(reward("cash", 5000));
+
+    const result = await detectRewardChanges(deal(reward("cash", 50)));
+
+    expect(result?.changeType).toBe("increased");
+    expect(result?.severity).toBe("critical");
+  });
+});

--- a/tests/unit/email/handlers.test.ts
+++ b/tests/unit/email/handlers.test.ts
@@ -1,0 +1,443 @@
+/**
+ * Email Handler Tests (T-2)
+ *
+ * Covers worker/email/handlers orchestration: processEmail security gate,
+ * ADD/DEACTIVATE/SEARCH/DIGEST/HELP/FORWARDED dispatch, duplicate and
+ * low-confidence branches, the exception path, and emailWorkerHandler
+ * header/recipient mapping. validateSecurity and referral-storage are
+ * mocked; parseCommand, templates, extraction, and crypto stay real.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Env, ReferralInput } from "../../../worker/types";
+import type { ParsedEmail } from "../../../worker/email/types";
+
+vi.mock("../../../worker/email/security", () => ({
+  validateSecurity: vi.fn(),
+}));
+
+vi.mock("../../../worker/lib/referral-storage", () => ({
+  storeReferralInput: vi.fn(),
+  getReferralByCode: vi.fn(),
+  searchReferrals: vi.fn(),
+  deactivateReferral: vi.fn(),
+}));
+
+vi.mock("../../../worker/lib/global-logger", () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+function makeEnv(): Env {
+  return {
+    DEALS_SOURCES: {
+      get: vi.fn(),
+      put: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn(),
+      list: vi.fn(),
+    },
+    ENVIRONMENT: "test",
+  } as unknown as Env;
+}
+
+function makeEmail(overrides: Partial<ParsedEmail> = {}): ParsedEmail {
+  return {
+    from: "user@x.com",
+    to: ["inbox@x.com"],
+    subject: "hello",
+    text: "",
+    ...overrides,
+  };
+}
+
+function makeReferral(overrides: Partial<ReferralInput> = {}): ReferralInput {
+  return {
+    id: "ref-1",
+    code: "WISE123",
+    url: "https://wise.com/invite/abc",
+    domain: "wise",
+    status: "active",
+    ...overrides,
+  } as unknown as ReferralInput;
+}
+
+async function loadMocks(): Promise<{
+  validateSecurity: ReturnType<typeof vi.fn>;
+  storeReferralInput: ReturnType<typeof vi.fn>;
+  getReferralByCode: ReturnType<typeof vi.fn>;
+  searchReferrals: ReturnType<typeof vi.fn>;
+  deactivateReferral: ReturnType<typeof vi.fn>;
+}> {
+  const { validateSecurity } = await import("../../../worker/email/security");
+  const storage = await import("../../../worker/lib/referral-storage");
+  return {
+    validateSecurity: vi.mocked(validateSecurity),
+    storeReferralInput: vi.mocked(storage.storeReferralInput),
+    getReferralByCode: vi.mocked(storage.getReferralByCode),
+    searchReferrals: vi.mocked(storage.searchReferrals),
+    deactivateReferral: vi.mocked(storage.deactivateReferral),
+  };
+}
+
+describe("processEmail dispatch", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const mocks = await loadMocks();
+    mocks.validateSecurity.mockResolvedValue({ valid: true });
+    mocks.getReferralByCode.mockResolvedValue(null);
+    mocks.searchReferrals.mockResolvedValue({ referrals: [], total: 0 });
+    mocks.deactivateReferral.mockResolvedValue(null);
+    mocks.storeReferralInput.mockImplementation(
+      async (_env: Env, referral: ReferralInput) => referral,
+    );
+  });
+
+  it("rejects when the security check fails", async () => {
+    const { processEmail } =
+      await import("../../../worker/email/handlers/incoming");
+    const mocks = await loadMocks();
+    mocks.validateSecurity.mockResolvedValue({
+      valid: false,
+      reason: "spam detected",
+    });
+
+    const result = await processEmail(
+      makeEmail({ to: ["add@x.com"], subject: "add" }),
+      makeEnv(),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("spam detected");
+    expect(result.confirmationSent).toBe(false);
+    expect(mocks.storeReferralInput).not.toHaveBeenCalled();
+  });
+
+  it("adds a referral through the ADD command", async () => {
+    const { processEmail } =
+      await import("../../../worker/email/handlers/incoming");
+    const mocks = await loadMocks();
+    const env = makeEnv();
+
+    const result = await processEmail(
+      makeEmail({
+        to: ["add@x.com"],
+        subject: "add",
+        text: "service: Wise\ncode: WISE123\nreward: $20 bonus",
+      }),
+      env,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.message).toBe("Referral added successfully");
+    expect(typeof result.referralId).toBe("string");
+    expect(result.confirmationSent).toBe(true);
+    expect(mocks.storeReferralInput).toHaveBeenCalledOnce();
+    const stored = mocks.storeReferralInput.mock.calls[0]?.[1];
+    expect(stored?.status).toBe("quarantined");
+    expect(stored?.submitted_by).toBe("user@x.com");
+    expect(stored?.code).toBe("wise123");
+    expect(env.DEALS_SOURCES.put).toHaveBeenCalled();
+  });
+
+  it("replies with help when ADD has no service", async () => {
+    const { processEmail } =
+      await import("../../../worker/email/handlers/incoming");
+    const mocks = await loadMocks();
+
+    const result = await processEmail(
+      makeEmail({ to: ["add@x.com"], subject: "add:", text: "" }),
+      makeEnv(),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.message).toBe("Missing required field: service");
+    expect(result.confirmationSent).toBe(true);
+    expect(mocks.storeReferralInput).not.toHaveBeenCalled();
+  });
+
+  it("replies with help when ADD has neither code nor URL", async () => {
+    const { processEmail } =
+      await import("../../../worker/email/handlers/incoming");
+
+    const result = await processEmail(
+      makeEmail({
+        to: ["add@x.com"],
+        subject: "add",
+        text: "service: Wise",
+      }),
+      makeEnv(),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.message).toBe("Missing required field: code or referral URL");
+    expect(result.confirmationSent).toBe(true);
+  });
+
+  it("rejects duplicate codes on ADD without storing", async () => {
+    const { processEmail } =
+      await import("../../../worker/email/handlers/incoming");
+    const mocks = await loadMocks();
+    mocks.getReferralByCode.mockResolvedValue(makeReferral());
+
+    const result = await processEmail(
+      makeEmail({
+        to: ["add@x.com"],
+        subject: "add",
+        text: "service: Wise\ncode: WISE123",
+      }),
+      makeEnv(),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.message).toBe("Referral code already exists");
+    expect(result.confirmationSent).toBe(false);
+    expect(mocks.storeReferralInput).not.toHaveBeenCalled();
+  });
+
+  it("requires a code for DEACTIVATE", async () => {
+    const { processEmail } =
+      await import("../../../worker/email/handlers/incoming");
+
+    const result = await processEmail(
+      makeEmail({ to: ["deactivate@x.com"], subject: "deactivate" }),
+      makeEnv(),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.message).toBe("Missing required field: code");
+  });
+
+  it("reports unknown codes on DEACTIVATE", async () => {
+    const { processEmail } =
+      await import("../../../worker/email/handlers/incoming");
+
+    const result = await processEmail(
+      makeEmail({
+        to: ["deactivate@x.com"],
+        subject: "deactivate wise NOPE123",
+      }),
+      makeEnv(),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.message).toBe("Referral not found");
+  });
+
+  it("deactivates known codes and confirms", async () => {
+    const { processEmail } =
+      await import("../../../worker/email/handlers/incoming");
+    const mocks = await loadMocks();
+    mocks.getReferralByCode.mockResolvedValue(makeReferral());
+    const env = makeEnv();
+
+    const result = await processEmail(
+      makeEmail({
+        to: ["deactivate@x.com"],
+        subject: "deactivate wise WISE123",
+      }),
+      env,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.message).toBe("Referral deactivated successfully");
+    expect(result.confirmationSent).toBe(true);
+    expect(mocks.deactivateReferral).toHaveBeenCalledWith(
+      env,
+      "wise123",
+      "user_request",
+      undefined,
+      undefined,
+    );
+  });
+
+  it("requires a query for SEARCH", async () => {
+    const { processEmail } =
+      await import("../../../worker/email/handlers/incoming");
+
+    const result = await processEmail(
+      makeEmail({ to: ["search@x.com"], subject: "" }),
+      makeEnv(),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.message).toBe("Missing search query");
+  });
+
+  it("returns formatted results for SEARCH", async () => {
+    const { processEmail } =
+      await import("../../../worker/email/handlers/incoming");
+    const mocks = await loadMocks();
+    mocks.searchReferrals.mockResolvedValue({
+      referrals: [
+        makeReferral({ id: "r1", code: "AAA" }),
+        makeReferral({ id: "r2", code: "BBB" }),
+      ],
+      total: 2,
+    });
+
+    const result = await processEmail(
+      makeEmail({ to: ["search@x.com"], subject: "wise" }),
+      makeEnv(),
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.message).toBe("Found 2 referral(s)");
+    expect(result.confirmationSent).toBe(true);
+  });
+
+  it("sends a monthly DIGEST with reward lines", async () => {
+    const { processEmail } =
+      await import("../../../worker/email/handlers/incoming");
+    const mocks = await loadMocks();
+    mocks.searchReferrals.mockResolvedValue({
+      referrals: [makeReferral({ metadata: { reward_value: "$20" } })],
+      total: 1,
+    });
+
+    const result = await processEmail(
+      makeEmail({ to: ["digest@x.com"], subject: "monthly" }),
+      makeEnv(),
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.message).toBe("Digest sent with 1 referrals");
+    expect(result.confirmationSent).toBe(true);
+  });
+
+  it("sends help for HELP", async () => {
+    const { processEmail } =
+      await import("../../../worker/email/handlers/incoming");
+    const env = makeEnv();
+
+    const result = await processEmail(
+      makeEmail({ to: ["help@x.com"], subject: "anything" }),
+      env,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.message).toBe("Help email sent");
+    expect(result.confirmationSent).toBe(true);
+    expect(env.DEALS_SOURCES.put).toHaveBeenCalled();
+  });
+
+  it("requests manual input when extraction confidence is zero", async () => {
+    const { processEmail } =
+      await import("../../../worker/email/handlers/incoming");
+    const mocks = await loadMocks();
+
+    const result = await processEmail(
+      makeEmail({ subject: "hello there", text: "just saying hi" }),
+      makeEnv(),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.message).toBe(
+      "Could not automatically extract referral code",
+    );
+    expect(result.confirmationSent).toBe(true);
+    expect(mocks.storeReferralInput).not.toHaveBeenCalled();
+  });
+
+  it("rejects duplicate codes on FORWARDED with confirmation", async () => {
+    const { processEmail } =
+      await import("../../../worker/email/handlers/incoming");
+    const mocks = await loadMocks();
+    mocks.getReferralByCode.mockResolvedValue(makeReferral({ id: "ref-9" }));
+
+    const result = await processEmail(
+      makeEmail({
+        subject: "Fwd: invite",
+        text: "get started here https://example.com/join?ref=SAVE20NOW today",
+      }),
+      makeEnv(),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.message).toBe("Referral code already exists");
+    expect(result.confirmationSent).toBe(true);
+    expect(mocks.storeReferralInput).not.toHaveBeenCalled();
+  });
+
+  it("stores auto-extracted referrals on FORWARDED", async () => {
+    const { processEmail } =
+      await import("../../../worker/email/handlers/incoming");
+    const mocks = await loadMocks();
+
+    const result = await processEmail(
+      makeEmail({
+        subject: "Fwd: invite",
+        text: "get started here https://example.com/join?ref=SAVE20NOW today",
+      }),
+      makeEnv(),
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.message).toBe("Referral extracted and stored successfully");
+    expect(typeof result.referralId).toBe("string");
+    expect(result.extracted?.confidence).toBeGreaterThan(0);
+    expect(result.confirmationSent).toBe(true);
+    expect(mocks.storeReferralInput).toHaveBeenCalledOnce();
+    const stored = mocks.storeReferralInput.mock.calls[0]?.[1];
+    expect(stored?.code).toBe("SAVE20NOW");
+    expect(stored?.domain).toBe("example.com");
+  });
+
+  it("returns an internal error when validation throws", async () => {
+    const { processEmail } =
+      await import("../../../worker/email/handlers/incoming");
+    const mocks = await loadMocks();
+    mocks.validateSecurity.mockRejectedValueOnce(new Error("db boom"));
+
+    const result = await processEmail(makeEmail(), makeEnv());
+
+    expect(result.success).toBe(false);
+    expect(result.message).toBe("Internal processing error");
+    expect(result.confirmationSent).toBe(false);
+    expect(result.error).toBe("db boom");
+  });
+});
+
+describe("emailWorkerHandler mapping", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const mocks = await loadMocks();
+    mocks.validateSecurity.mockResolvedValue({ valid: true });
+    mocks.getReferralByCode.mockResolvedValue(null);
+    mocks.searchReferrals.mockResolvedValue({ referrals: [], total: 0 });
+    mocks.deactivateReferral.mockResolvedValue(null);
+    mocks.storeReferralInput.mockImplementation(
+      async (_env: Env, referral: ReferralInput) => referral,
+    );
+  });
+
+  it("maps headers and splits/trims recipients", async () => {
+    const { emailWorkerHandler } =
+      await import("../../../worker/email/handlers/incoming");
+    const mocks = await loadMocks();
+    let captured: ParsedEmail | undefined;
+    mocks.validateSecurity.mockImplementationOnce(
+      async (email: ParsedEmail) => {
+        captured = email;
+        return { valid: false, reason: "stop" };
+      },
+    );
+
+    await emailWorkerHandler(
+      {
+        from: "user@x.com",
+        to: "a@x.com,  b@y.com ",
+        subject: "hello",
+        headers: new Headers({ "x-dkim-valid": "true" }),
+        text: "hi",
+      },
+      makeEnv(),
+    );
+
+    expect(captured?.to).toEqual(["a@x.com", "b@y.com"]);
+    expect(captured?.dkimValid).toBe(true);
+    expect(captured?.spfValid).toBe(false);
+  });
+});

--- a/tests/unit/nlq/ai-enhancer.test.ts
+++ b/tests/unit/nlq/ai-enhancer.test.ts
@@ -1,0 +1,301 @@
+/**
+ * NLQ AI Enhancer Tests (T-3)
+ *
+ * Covers worker/lib/nlq/ai: shouldUseAI matrix, enhance empty/fast/AI
+ * paths, failure and invalid-JSON fallbacks, confidence clamping,
+ * cache hit/miss, batch chunking, and the isComplexQuery helper.
+ * The Ai binding is an injected stub; no gateway, KV credentials,
+ * or network access is required.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Env } from "../../../worker/types";
+import {
+  AIQueryEnhancer,
+  enhanceQuery,
+  enhanceQueriesBatch,
+  isComplexQuery,
+} from "../../../worker/lib/nlq/ai/index";
+
+vi.mock("../../../worker/lib/global-logger", () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+function makeKvStore(): {
+  store: Map<string, unknown>;
+  kv: {
+    get: ReturnType<typeof vi.fn>;
+    put: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+    list: ReturnType<typeof vi.fn>;
+  };
+} {
+  const store = new Map<string, unknown>();
+  return {
+    store,
+    kv: {
+      get: vi.fn(async (key: string) => store.get(key) ?? null),
+      put: vi.fn(async (key: string, value: string) => {
+        store.set(key, JSON.parse(value) as unknown);
+      }),
+      delete: vi.fn(),
+      list: vi.fn(),
+    },
+  };
+}
+
+function makeEnv(
+  kv: ReturnType<typeof makeKvStore>["kv"] | undefined = undefined,
+): Env {
+  return {
+    ENVIRONMENT: "test",
+    TRUST_THRESHOLD: "0.2",
+    ...(kv === undefined ? {} : { DEALS_SOURCES: kv }),
+  } as unknown as Env;
+}
+
+function makeAiStub(): { run: ReturnType<typeof vi.fn> } {
+  return {
+    run: vi.fn(async (_model: string, input: unknown) => {
+      const prompt = (input as { prompt: string }).prompt;
+      if (prompt.includes("Classify the search intent")) {
+        return {
+          response: JSON.stringify({ intent: "rank", confidence: 0.9 }),
+        };
+      }
+      if (prompt.includes("Extract entities")) {
+        return {
+          response: JSON.stringify({
+            entities: [{ type: "domain", value: "Coinbase", confidence: 0.9 }],
+          }),
+        };
+      }
+      if (prompt.includes("Expand this search query")) {
+        return { response: JSON.stringify(["coinbase alternatives"]) };
+      }
+      return { response: "" };
+    }),
+  };
+}
+
+describe("shouldUseAI", () => {
+  it("flags comparison and recommendation queries as complex", () => {
+    const enhancer = new AIQueryEnhancer({} as unknown as Ai, makeEnv(), {
+      useCache: false,
+    });
+    expect(enhancer.shouldUseAI("best crypto deals")).toBe(true);
+    expect(enhancer.shouldUseAI("how do referrals work")).toBe(true);
+    expect(enhancer.shouldUseAI("is this a scam")).toBe(true);
+    expect(enhancer.shouldUseAI("wise vs revolut")).toBe(true);
+  });
+
+  it("treats simple and empty queries as non-complex", () => {
+    const enhancer = new AIQueryEnhancer({} as unknown as Ai, makeEnv(), {
+      useCache: false,
+    });
+    expect(enhancer.shouldUseAI("wise")).toBe(false);
+    expect(enhancer.shouldUseAI("")).toBe(false);
+    expect(enhancer.shouldUseAI("   ")).toBe(false);
+  });
+});
+
+describe("enhance", () => {
+  it("returns an empty shape for blank queries without calling AI", async () => {
+    const ai = makeAiStub();
+    const enhancer = new AIQueryEnhancer(ai as unknown as Ai, makeEnv(), {
+      useCache: false,
+    });
+
+    const result = await enhancer.enhance("   ");
+
+    expect(result.entities).toEqual([]);
+    expect(result.intent).toEqual({ primary: "search", confidence: 0.5 });
+    expect(result.aiConfidence).toBe(0.5);
+    expect(ai.run).not.toHaveBeenCalled();
+  });
+
+  it("uses rule entities and intent-only AI for simple queries", async () => {
+    const ai = makeAiStub();
+    const enhancer = new AIQueryEnhancer(ai as unknown as Ai, makeEnv(), {
+      useCache: false,
+    });
+
+    const result = await enhancer.enhance("wise crypto deals");
+
+    expect(result.normalized).toBe("wise crypto deals");
+    expect(result.entities.map((e) => e.type)).toContain("category");
+    // Only the intent call reaches the model; entities/expansion stay local
+    expect(ai.run).toHaveBeenCalledOnce();
+    expect(result.expansion.expanded.length).toBeGreaterThan(0);
+    expect(result.expansion.expanded).not.toContain("coinbase alternatives");
+  });
+
+  it("merges AI entities, intent, and expansions for complex queries", async () => {
+    const ai = makeAiStub();
+    const enhancer = new AIQueryEnhancer(ai as unknown as Ai, makeEnv(), {
+      useCache: false,
+    });
+
+    const result = await enhancer.enhance("best crypto deals");
+
+    expect(result.intent.primary).toBe("rank");
+    expect(result.entities.map((e) => e.type)).toEqual(
+      expect.arrayContaining(["sentiment", "category", "domain"]),
+    );
+    expect(result.filters.domains).toContain("coinbase");
+    expect(result.filters.categories).toContain("crypto");
+    expect(result.expansion.expanded).toContain("coinbase alternatives");
+    expect(ai.run).toHaveBeenCalledTimes(3);
+  });
+
+  it("falls back gracefully when the model rejects", async () => {
+    const ai = { run: vi.fn().mockRejectedValue(new Error("boom")) };
+    const enhancer = new AIQueryEnhancer(ai as unknown as Ai, makeEnv(), {
+      useCache: false,
+    });
+
+    const result = await enhancer.enhance("best crypto deals");
+
+    expect(result.intent).toEqual({ primary: "search", confidence: 0.5 });
+    expect(result.entities.length).toBeGreaterThan(0);
+    expect(result.entities.map((e) => e.type)).not.toContain("domain");
+    expect(result.expansion.expanded).not.toContain("coinbase alternatives");
+  });
+
+  it("falls back gracefully on invalid model JSON", async () => {
+    const ai = { run: vi.fn().mockResolvedValue({ response: "not json {{{" }) };
+    const enhancer = new AIQueryEnhancer(ai as unknown as Ai, makeEnv(), {
+      useCache: false,
+    });
+
+    const result = await enhancer.enhance("best crypto deals");
+
+    expect(result.intent).toEqual({ primary: "search", confidence: 0.5 });
+    expect(result.entities.map((e) => e.type)).toEqual(
+      expect.arrayContaining(["sentiment", "category"]),
+    );
+  });
+
+  it("clamps out-of-range model confidences", async () => {
+    const ai = {
+      run: vi.fn(async (_model: string, input: unknown) => {
+        const prompt = (input as { prompt: string }).prompt;
+        if (prompt.includes("Classify the search intent")) {
+          return {
+            response: JSON.stringify({ intent: "rank", confidence: -2 }),
+          };
+        }
+        if (prompt.includes("Extract entities")) {
+          return {
+            response: JSON.stringify({
+              entities: [{ type: "domain", value: "Kraken", confidence: 5 }],
+            }),
+          };
+        }
+        return { response: JSON.stringify([]) };
+      }),
+    };
+    const enhancer = new AIQueryEnhancer(ai as unknown as Ai, makeEnv(), {
+      useCache: false,
+    });
+
+    const result = await enhancer.enhance("kraken deals");
+
+    expect(result.intent.confidence).toBe(0);
+    for (const entity of result.entities) {
+      expect(entity.confidence).toBeGreaterThanOrEqual(0);
+      expect(entity.confidence).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it("applies the env trust threshold for negative sentiment", async () => {
+    const ai = {
+      run: vi.fn(async () => ({
+        response: JSON.stringify({ intent: "search", confidence: 0.5 }),
+      })),
+    };
+    const enhancer = new AIQueryEnhancer(ai as unknown as Ai, makeEnv(), {
+      useCache: false,
+    });
+
+    const result = await enhancer.enhance("avoid this scam broker");
+
+    expect(result.filters.sentimentFilter).toBe("negative");
+    expect(result.filters.minTrustScore).toBe(0.2);
+  });
+
+  it("serves the second identical query from cache", async () => {
+    const ai = makeAiStub();
+    const { kv } = makeKvStore();
+    const enhancer = new AIQueryEnhancer(ai as unknown as Ai, makeEnv(kv), {
+      minConfidenceThreshold: 0.1,
+    });
+
+    const first = await enhancer.enhance("best crypto deals");
+    const callsAfterFirst = ai.run.mock.calls.length;
+    expect(callsAfterFirst).toBeGreaterThan(0);
+
+    const second = await enhancer.enhance("best crypto deals");
+
+    expect(ai.run.mock.calls.length).toBe(callsAfterFirst);
+    expect(second.intent).toEqual(first.intent);
+    expect(second.entities).toEqual(first.entities);
+  });
+
+  it("truncates queries to maxQueryLength", async () => {
+    const ai = makeAiStub();
+    const enhancer = new AIQueryEnhancer(ai as unknown as Ai, makeEnv(), {
+      useCache: false,
+      maxQueryLength: 10,
+    });
+
+    const result = await enhancer.enhance("best crypto deals for trading");
+
+    expect(result.normalized).toBe("best crypt");
+  });
+});
+
+describe("convenience functions", () => {
+  it("enhanceQuery enhances through a shared path", async () => {
+    const ai = makeAiStub();
+
+    const result = await enhanceQuery("wise", ai as unknown as Ai, makeEnv(), {
+      useCache: false,
+    });
+
+    expect(result.normalized).toBe("wise");
+    expect(result.intent.primary).toBe("rank");
+  });
+
+  it("enhanceQueriesBatch handles more than one chunk", async () => {
+    const ai = makeAiStub();
+    const queries = [
+      "wise",
+      "revolut",
+      "coinbase",
+      "kraken",
+      "etoro",
+      "freetrade",
+    ];
+
+    const results = await enhanceQueriesBatch(
+      queries,
+      ai as unknown as Ai,
+      makeEnv(),
+      { useCache: false },
+    );
+
+    expect(results).toHaveLength(6);
+    expect(results.map((r) => r.normalized)).toEqual(queries);
+  });
+
+  it("isComplexQuery mirrors shouldUseAI", () => {
+    expect(isComplexQuery("best crypto")).toBe(true);
+    expect(isComplexQuery("wise")).toBe(false);
+  });
+});

--- a/tests/unit/nlq/ai-enhancer.test.ts
+++ b/tests/unit/nlq/ai-enhancer.test.ts
@@ -8,7 +8,7 @@
  * or network access is required.
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import type { Env } from "../../../worker/types";
 import {
   AIQueryEnhancer,

--- a/tests/unit/nlq/hybrid-classifier.test.ts
+++ b/tests/unit/nlq/hybrid-classifier.test.ts
@@ -1,0 +1,211 @@
+/**
+ * NLQ Hybrid Classifier Tests (T-3)
+ *
+ * Covers worker/lib/nlq/hybrid: selectMethod routing, the shouldUseAI
+ * helper, rule/AI dispatch with and without a model, batch order
+ * restoration, stats, and convenience constructors. The Ai binding is an
+ * injected stub backed by a Map KV; no gateway or network is required.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Env } from "../../../worker/types";
+import {
+  HybridClassifier,
+  classifyQuery,
+  classifyQueriesBatch,
+  createClassifier,
+} from "../../../worker/lib/nlq/hybrid/index";
+import {
+  selectMethod,
+  shouldUseAI,
+  DEFAULT_CLASSIFIER_OPTIONS,
+} from "../../../worker/lib/nlq/hybrid/ai-decision";
+
+vi.mock("../../../worker/lib/global-logger", () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+function makeEnv(): Env {
+  const store = new Map<string, unknown>();
+  return {
+    ENVIRONMENT: "test",
+    TRUST_THRESHOLD: "0.2",
+    DEALS_SOURCES: {
+      get: vi.fn(async (key: string) => store.get(key) ?? null),
+      put: vi.fn(async (key: string, value: string) => {
+        store.set(key, JSON.parse(value) as unknown);
+      }),
+      delete: vi.fn(),
+      list: vi.fn(),
+    },
+  } as unknown as Env;
+}
+
+function makeAiStub(): { run: ReturnType<typeof vi.fn> } {
+  return {
+    run: vi.fn(async (_model: string, input: unknown) => {
+      const prompt = (input as { prompt: string }).prompt;
+      if (prompt.includes("Classify the search intent")) {
+        return {
+          response: JSON.stringify({ intent: "compare", confidence: 0.85 }),
+        };
+      }
+      if (prompt.includes("Extract entities")) {
+        return {
+          response: JSON.stringify({
+            entities: [{ type: "domain", value: "Revolut", confidence: 0.9 }],
+          }),
+        };
+      }
+      if (prompt.includes("Expand this search query")) {
+        return { response: JSON.stringify(["revolut rivals"]) };
+      }
+      return { response: "" };
+    }),
+  };
+}
+
+const LONG_QUERY = "find the very best trading deals with cash bonuses!!";
+const COMPLEX_QUERY = "what is the best broker for crypto trading today?";
+
+describe("selectMethod", () => {
+  it("routes short queries to rules", () => {
+    expect(selectMethod("wise", DEFAULT_CLASSIFIER_OPTIONS)).toBe("rule");
+  });
+
+  it("routes overlong queries to AI", () => {
+    expect(selectMethod(LONG_QUERY, DEFAULT_CLASSIFIER_OPTIONS)).toBe("ai");
+    expect(LONG_QUERY.length).toBeGreaterThan(
+      DEFAULT_CLASSIFIER_OPTIONS.longQueryThreshold,
+    );
+  });
+
+  it("routes mid-length complex queries to AI", () => {
+    expect(COMPLEX_QUERY.length).toBeGreaterThan(
+      DEFAULT_CLASSIFIER_OPTIONS.maxRuleQueryLength,
+    );
+    expect(COMPLEX_QUERY.length).toBeLessThanOrEqual(
+      DEFAULT_CLASSIFIER_OPTIONS.longQueryThreshold,
+    );
+    expect(selectMethod(COMPLEX_QUERY, DEFAULT_CLASSIFIER_OPTIONS)).toBe("ai");
+  });
+
+  it("routes mid-length plain queries to rules", () => {
+    const plain = "find trading deals with cash bonuses today!!";
+    expect(plain.length).toBeGreaterThan(
+      DEFAULT_CLASSIFIER_OPTIONS.maxRuleQueryLength,
+    );
+    expect(selectMethod(plain, DEFAULT_CLASSIFIER_OPTIONS)).toBe("rule");
+  });
+});
+
+describe("shouldUseAI", () => {
+  it("mirrors the length and complexity gates", () => {
+    expect(shouldUseAI("wise")).toBe(false);
+    expect(shouldUseAI("wise", { maxRuleQueryLength: 2 })).toBe(true);
+    expect(shouldUseAI("best broker?")).toBe(true);
+    expect(shouldUseAI("best broker?", { enableAIForComplex: false })).toBe(
+      false,
+    );
+  });
+});
+
+describe("HybridClassifier", () => {
+  let env: Env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    env = makeEnv();
+  });
+
+  it("uses rules for short queries without touching the model", async () => {
+    const ai = makeAiStub();
+    const classifier = new HybridClassifier(ai as unknown as Ai, env);
+
+    const result = await classifier.classify("wise");
+
+    expect(result.method).toBe("rule");
+    expect(result.query.intent.primary).toBe("search");
+    expect(ai.run).not.toHaveBeenCalled();
+    expect(result.appliedFilters).toEqual(result.query.filters);
+  });
+
+  it("falls back to rules when AI is unavailable", async () => {
+    const classifier = new HybridClassifier(null, env);
+
+    const result = await classifier.classify(COMPLEX_QUERY);
+
+    expect(result.method).toBe("ai");
+    expect(result.query.intent.primary).toBeDefined();
+    expect(typeof result.confidence).toBe("number");
+  });
+
+  it("uses the model for long queries", async () => {
+    const ai = makeAiStub();
+    const classifier = new HybridClassifier(ai as unknown as Ai, env);
+
+    const result = await classifier.classify(LONG_QUERY);
+
+    expect(result.method).toBe("ai");
+    expect(ai.run).toHaveBeenCalled();
+    expect(result.query.intent.primary).toBe("compare");
+    expect(result.query.filters.domains).toContain("revolut");
+  });
+
+  it("restores original order across mixed batches", async () => {
+    const ai = makeAiStub();
+    const classifier = new HybridClassifier(ai as unknown as Ai, env);
+
+    const results = await classifier.classifyBatch(["wise", LONG_QUERY]);
+
+    expect(results).toHaveLength(2);
+    expect(results[0]?.query.original).toBe("wise");
+    expect(results[0]?.method).toBe("rule");
+    expect(results[1]?.query.original).toBe(LONG_QUERY);
+    expect(results[1]?.method).toBe("ai");
+  });
+
+  it("reports availability stats", () => {
+    const withAi = new HybridClassifier({} as unknown as Ai, env);
+    expect(withAi.getStats().aiAvailable).toBe(true);
+    expect(withAi.getStats().cacheEnabled).toBe(true);
+
+    const withoutAi = new HybridClassifier(null, env);
+    expect(withoutAi.getStats().aiAvailable).toBe(false);
+    expect(withoutAi.getStats().cacheEnabled).toBe(false);
+  });
+});
+
+describe("convenience functions", () => {
+  it("classifyQuery classifies a single query", async () => {
+    const result = await classifyQuery("wise", null, makeEnv());
+
+    expect(result.method).toBe("rule");
+    expect(result.query.normalized).toBe("wise");
+  });
+
+  it("classifyQueriesBatch classifies several queries", async () => {
+    const results = await classifyQueriesBatch(
+      ["wise", "revolut"],
+      null,
+      makeEnv(),
+    );
+
+    expect(results).toHaveLength(2);
+    expect(results.map((r) => r.method)).toEqual(["rule", "rule"]);
+  });
+
+  it("createClassifier builds a classifier with options", async () => {
+    const classifier = createClassifier(null, makeEnv(), {
+      maxRuleQueryLength: 100,
+    });
+
+    const result = await classifier.classify(COMPLEX_QUERY);
+    expect(result.method).toBe("rule");
+  });
+});

--- a/tests/unit/nlq/rule-classifier.test.ts
+++ b/tests/unit/nlq/rule-classifier.test.ts
@@ -1,0 +1,221 @@
+/**
+ * NLQ Rule Classifier Tests (T-3)
+ *
+ * Covers worker/lib/nlq/hybrid/rule-classifier.ts: intent detection,
+ * rule entity extraction, expansions, filter building, confidence math,
+ * normalization, and the classifyWithRules fast path. Fully synchronous
+ * with no mocks required.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { Env } from "../../../worker/types";
+import {
+  classifyWithRules,
+  normalizeQuery,
+  detectIntent,
+  extractEntitiesWithRules,
+  buildExpansions,
+  buildFiltersFromEntities,
+  calculateRuleConfidence,
+} from "../../../worker/lib/nlq/hybrid/rule-classifier";
+import type { Entity, ExtractedIntent } from "../../../worker/lib/nlq/ai/types";
+
+const mockEnv = {
+  ENVIRONMENT: "test",
+  TRUST_THRESHOLD: "0.2",
+} as unknown as Env;
+
+function intent(
+  primary: ExtractedIntent["primary"],
+  confidence: number,
+): ExtractedIntent {
+  return { primary, confidence };
+}
+
+describe("detectIntent", () => {
+  it("detects rank for best/top queries", () => {
+    expect(detectIntent("best crypto deals").primary).toBe("rank");
+    expect(detectIntent("top trading apps").primary).toBe("rank");
+  });
+
+  it("detects compare for versus queries", () => {
+    expect(detectIntent("compare wise versus revolut").primary).toBe("compare");
+    expect(detectIntent("alternatives to coinbase").primary).toBe("compare");
+  });
+
+  it("detects filter for cash-only queries", () => {
+    expect(detectIntent("cash only deals").primary).toBe("filter");
+  });
+
+  it("detects discover for listing queries", () => {
+    expect(detectIntent("show all deals").primary).toBe("discover");
+  });
+
+  it("defaults single words and empty input to search", () => {
+    expect(detectIntent("wise")).toEqual({
+      primary: "search",
+      confidence: 0.7,
+    });
+    expect(detectIntent("")).toEqual({ primary: "search", confidence: 0.5 });
+  });
+});
+
+describe("extractEntitiesWithRules", () => {
+  it("extracts categories and reward types", () => {
+    const entities = extractEntitiesWithRules("crypto wallet with cash bonus");
+
+    expect(entities).toContainEqual(
+      expect.objectContaining({ type: "category", value: "crypto" }),
+    );
+    expect(entities).toContainEqual(
+      expect.objectContaining({ type: "reward_type", value: "cash" }),
+    );
+  });
+
+  it("extracts positive and negative sentiment with impact", () => {
+    const positive = extractEntitiesWithRules("best broker");
+    expect(positive).toContainEqual(
+      expect.objectContaining({
+        type: "sentiment",
+        value: "positive",
+        metadata: { impact: 0.3 },
+      }),
+    );
+
+    const negative = extractEntitiesWithRules("avoid this scam");
+    expect(negative).toContainEqual(
+      expect.objectContaining({
+        type: "sentiment",
+        value: "negative",
+        metadata: { impact: -0.5 },
+      }),
+    );
+  });
+
+  it("extracts domains with high confidence", () => {
+    const entities = extractEntitiesWithRules("deals on coinbase.com today");
+
+    expect(entities).toContainEqual({
+      type: "domain",
+      value: "coinbase.com",
+      confidence: 0.85,
+    });
+  });
+
+  it("returns no entities for plain queries", () => {
+    expect(extractEntitiesWithRules("hello there")).toEqual([]);
+  });
+});
+
+describe("buildExpansions", () => {
+  it("expands category synonyms into query variants", () => {
+    const entities: Entity[] = [
+      { type: "category", value: "crypto", confidence: 0.8 },
+    ];
+
+    const expansion = buildExpansions("crypto deals", entities);
+
+    expect(expansion.expanded).toHaveLength(3);
+    expect(expansion.expanded).toContain("cryptocurrency deals");
+    expect(expansion.synonyms.get("crypto")).toEqual([
+      "cryptocurrency",
+      "digital assets",
+      "crypto exchange",
+    ]);
+  });
+
+  it("returns empty expansions without a category", () => {
+    const expansion = buildExpansions("wise deals", []);
+
+    expect(expansion.expanded).toEqual([]);
+    expect(expansion.synonyms.size).toBe(0);
+  });
+});
+
+describe("buildFiltersFromEntities", () => {
+  it("ranks up positive sentiment", () => {
+    const filters = buildFiltersFromEntities(
+      [
+        {
+          type: "sentiment",
+          value: "positive",
+          confidence: 0.7,
+          metadata: { impact: 0.3 },
+        },
+      ],
+      mockEnv,
+    );
+
+    expect(filters.minTrustScore).toBe(0.8);
+    expect(filters.minRanking).toBe(0.8);
+  });
+
+  it("uses the default threshold for negative sentiment without env", () => {
+    const filters = buildFiltersFromEntities([
+      {
+        type: "sentiment",
+        value: "negative",
+        confidence: 0.7,
+        metadata: { impact: -0.5 },
+      },
+    ]);
+
+    expect(filters.sentimentFilter).toBe("negative");
+    expect(filters.minTrustScore).toBe(0.3);
+  });
+
+  it("accumulates categories, rewards, and domains", () => {
+    const filters = buildFiltersFromEntities(
+      [
+        { type: "category", value: "crypto", confidence: 0.8 },
+        { type: "reward_type", value: "cash", confidence: 0.75 },
+        { type: "domain", value: "wise.com", confidence: 0.85 },
+      ],
+      mockEnv,
+    );
+
+    expect(filters.categories).toEqual(["crypto"]);
+    expect(filters.rewardTypes).toEqual(["cash"]);
+    expect(filters.domains).toEqual(["wise.com"]);
+  });
+});
+
+describe("calculateRuleConfidence", () => {
+  it("derives confidence from intent alone without entities", () => {
+    expect(calculateRuleConfidence([], intent("search", 0.5))).toBeCloseTo(0.3);
+  });
+
+  it("boosts non-search intents and caps at 0.95", () => {
+    const confidence = calculateRuleConfidence(
+      [{ type: "domain", value: "wise.com", confidence: 0.85 }],
+      intent("rank", 0.9),
+    );
+    expect(confidence).toBeCloseTo(0.895, 5);
+    expect(confidence).toBeLessThanOrEqual(0.95);
+
+    const capped = calculateRuleConfidence(
+      [{ type: "domain", value: "wise.com", confidence: 1 }],
+      intent("rank", 0.9),
+    );
+    expect(capped).toBeLessThanOrEqual(0.95);
+  });
+});
+
+describe("normalizeQuery", () => {
+  it("trims, lowercases, and collapses whitespace", () => {
+    expect(normalizeQuery("  BEST   Crypto  ")).toBe("best crypto");
+  });
+});
+
+describe("classifyWithRules", () => {
+  it("classifies end to end with filters and timing", () => {
+    const result = classifyWithRules("best crypto", Date.now(), mockEnv);
+
+    expect(result.original).toBe("best crypto");
+    expect(result.normalized).toBe("best crypto");
+    expect(result.intent.primary).toBe("rank");
+    expect(result.filters.minRanking).toBe(0.8);
+    expect(result.aiConfidence).toBeGreaterThan(0);
+    expect(typeof result.processingTimeMs).toBe("number");
+  });
+});

--- a/tests/unit/routes/email.test.ts
+++ b/tests/unit/routes/email.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Email Route Tests (T-2)
+ *
+ * Covers worker/routes/email.ts orchestration: HMAC webhook verification,
+ * required-field and from-format validation, parse/help shapes, and the
+ * Email Worker delegation entrypoint. processEmail/emailWorkerHandler are
+ * mocked at the ../email/handler seam; HMAC stays real.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Env } from "../../../worker/types";
+import { generateWebhookHeaders } from "../../../worker/lib/hmac";
+import type { EmailProcessingResult } from "../../../worker/email/types";
+
+type MockKVNamespace = {
+  get: ReturnType<typeof vi.fn>;
+  put: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+  list: ReturnType<typeof vi.fn>;
+};
+
+vi.mock("../../../worker/email/handler", () => ({
+  processEmail: vi.fn(),
+  emailWorkerHandler: vi.fn(),
+}));
+
+vi.mock("../../../worker/lib/global-logger", () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+const SECRET = "test-email-webhook-secret";
+
+function makeEnv(withSecret = true): Env {
+  const kv = {
+    get: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+    list: vi.fn(),
+  };
+  return {
+    DEALS_SOURCES: kv as unknown as MockKVNamespace,
+    ENVIRONMENT: "test",
+    ...(withSecret ? { EMAIL_WEBHOOK_SECRET: SECRET } : {}),
+  } as unknown as Env;
+}
+
+async function signedRequest(
+  body: Record<string, unknown>,
+  secret: string = SECRET,
+): Promise<Request> {
+  const payload = JSON.stringify(body);
+  const headers = await generateWebhookHeaders(
+    payload,
+    secret,
+    "evt-1",
+    "email.incoming",
+  );
+  return new Request("http://localhost/api/email/incoming", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    body: payload,
+  });
+}
+
+describe("handleEmailIncoming", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 500 when EMAIL_WEBHOOK_SECRET is not configured", async () => {
+    const { handleEmailIncoming } =
+      await import("../../../worker/routes/email");
+    const request = new Request("http://localhost/api/email/incoming", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ from: "a@x.com", to: "b@y.com", subject: "hi" }),
+    });
+
+    const res = await handleEmailIncoming(request, makeEnv(false));
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Failed to process email");
+  });
+
+  it("returns 401 when signature headers are missing", async () => {
+    const { handleEmailIncoming } =
+      await import("../../../worker/routes/email");
+    const request = new Request("http://localhost/api/email/incoming", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ from: "a@x.com", to: "b@y.com", subject: "hi" }),
+    });
+
+    const res = await handleEmailIncoming(request, makeEnv());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when the signature header format is invalid", async () => {
+    const { handleEmailIncoming } =
+      await import("../../../worker/routes/email");
+    const request = new Request("http://localhost/api/email/incoming", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-webhook-signature": "not-a-valid-header",
+        "x-webhook-timestamp": String(Math.floor(Date.now() / 1000)),
+      },
+      body: JSON.stringify({ from: "a@x.com", to: "b@y.com", subject: "hi" }),
+    });
+
+    const res = await handleEmailIncoming(request, makeEnv());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when the signature does not match", async () => {
+    const { handleEmailIncoming } =
+      await import("../../../worker/routes/email");
+    const request = await signedRequest(
+      { from: "a@x.com", to: "b@y.com", subject: "hi" },
+      "wrong-secret",
+    );
+
+    const res = await handleEmailIncoming(request, makeEnv());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when required fields are missing", async () => {
+    const { handleEmailIncoming } =
+      await import("../../../worker/routes/email");
+    const request = await signedRequest({ from: "a@x.com" });
+
+    const res = await handleEmailIncoming(request, makeEnv());
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Missing required fields: from, to, subject");
+  });
+
+  it("returns 400 when the from address is not an email", async () => {
+    const { handleEmailIncoming } =
+      await import("../../../worker/routes/email");
+    const request = await signedRequest({
+      from: "not-an-email",
+      to: "add@x.com",
+      subject: "add",
+    });
+
+    const res = await handleEmailIncoming(request, makeEnv());
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Invalid from email format");
+  });
+
+  it("returns 200 and splits/trims recipients on success", async () => {
+    const { handleEmailIncoming } =
+      await import("../../../worker/routes/email");
+    const { processEmail } = await import("../../../worker/email/handler");
+    const result: EmailProcessingResult = {
+      success: true,
+      message: "Referral added successfully",
+      referralId: "deal-1",
+      confirmationSent: true,
+    };
+    vi.mocked(processEmail).mockResolvedValue(result);
+
+    const request = await signedRequest({
+      from: "user@x.com",
+      to: "add@x.com,  help@x.com ",
+      subject: "add",
+      text: "service: Wise",
+    });
+    const env = makeEnv();
+
+    const res = await handleEmailIncoming(request, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      success: boolean;
+      referralId: string;
+      confirmationSent: boolean;
+    };
+    expect(body.success).toBe(true);
+    expect(body.referralId).toBe("deal-1");
+    expect(body.confirmationSent).toBe(true);
+    expect(vi.mocked(processEmail)).toHaveBeenCalledOnce();
+    const [emailArg] = vi.mocked(processEmail).mock.calls[0] ?? [];
+    expect(emailArg?.to).toEqual(["add@x.com", "help@x.com"]);
+  });
+
+  it("returns 400 when processing reports failure", async () => {
+    const { handleEmailIncoming } =
+      await import("../../../worker/routes/email");
+    const { processEmail } = await import("../../../worker/email/handler");
+    vi.mocked(processEmail).mockResolvedValue({
+      success: false,
+      message: "Security check failed: spam",
+      confirmationSent: false,
+      error: "spam",
+    });
+
+    const request = await signedRequest({
+      from: "spammer@x.com",
+      to: "add@x.com",
+      subject: "add",
+    });
+
+    const res = await handleEmailIncoming(request, makeEnv());
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { success: boolean; message: string };
+    expect(body.success).toBe(false);
+  });
+});
+
+describe("handleEmailParse", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 400 when from or subject is missing", async () => {
+    const { handleEmailParse } = await import("../../../worker/routes/email");
+    const request = new Request("http://localhost/api/email/parse", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ from: "a@x.com" }),
+    });
+
+    const res = await handleEmailParse(request, makeEnv());
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 200 with extraction and command shapes", async () => {
+    const { handleEmailParse } = await import("../../../worker/routes/email");
+    const request = new Request("http://localhost/api/email/parse", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        from: "user@x.com",
+        to: "add@x.com",
+        subject: "add",
+        text: "service: Wise\ncode: WISE123",
+      }),
+    });
+
+    const res = await handleEmailParse(request, makeEnv());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      extraction: { service: string };
+      command: { type: string };
+      email: { from: string; hasText: boolean; hasHtml: boolean };
+    };
+    expect(body.command.type).toBe("ADD");
+    expect(body.extraction.service).toBeDefined();
+    expect(body.email.from).toBe("user@x.com");
+    expect(body.email.hasText).toBe(true);
+    expect(body.email.hasHtml).toBe(false);
+  });
+});
+
+describe("handleEmailHelp", () => {
+  it("returns 200 with subject, text, and html template", async () => {
+    const { handleEmailHelp } = await import("../../../worker/routes/email");
+
+    const res = await handleEmailHelp(undefined, makeEnv());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      subject: string;
+      text: string;
+      html: string;
+    };
+    expect(typeof body.subject).toBe("string");
+    expect(body.text.length).toBeGreaterThan(0);
+    expect(body.html.length).toBeGreaterThan(0);
+  });
+});
+
+describe("handleEmailWorker", () => {
+  it("delegates the message and env to emailWorkerHandler", async () => {
+    const { handleEmailWorker } = await import("../../../worker/routes/email");
+    const { emailWorkerHandler } =
+      await import("../../../worker/email/handler");
+    const message = {
+      from: "user@x.com",
+      to: "add@x.com",
+      subject: "add",
+      headers: new Headers(),
+      text: "service: Wise",
+    };
+    const env = makeEnv();
+
+    await handleEmailWorker(message, env);
+
+    expect(vi.mocked(emailWorkerHandler)).toHaveBeenCalledOnce();
+    expect(vi.mocked(emailWorkerHandler)).toHaveBeenCalledWith(message, env);
+  });
+});

--- a/tests/unit/routes/email.test.ts
+++ b/tests/unit/routes/email.test.ts
@@ -9,7 +9,10 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { Env } from "../../../worker/types";
-import { generateWebhookHeaders } from "../../../worker/lib/hmac";
+import {
+  generateWebhookHeaders,
+  generateWebhookSecret,
+} from "../../../worker/lib/hmac";
 import type { EmailProcessingResult } from "../../../worker/email/types";
 
 type MockKVNamespace = {
@@ -32,7 +35,7 @@ vi.mock("../../../worker/lib/global-logger", () => ({
   },
 }));
 
-const SECRET = "test-email-webhook-secret";
+const SECRET = generateWebhookSecret();
 
 function makeEnv(withSecret = true): Env {
   const kv = {


### PR DESCRIPTION
What: add 95 unit tests closing deferred gaps T-2 email routes and handlers, T-3 NLQ AI enhancer plus rule and hybrid classifiers, T-4 scraper change detection plus batch stats. Includes the PEV spec and a GOAP_STATE bump to v0.19.10. Why: these three orchestration layers had zero direct coverage and were the last deferred test items from the August gap analysis. Impact: tests only, zero production diff, full suite 2872 of 2872 green. Verified with tsc, prettier, markdownlint, and quality gate exit 0.