### PR TITLE
[Jules Audit] Docs: add JSDoc annotations for public expiration and circuit breaker functions

### DIFF
--- a/worker/lib/circuit-breaker.ts
+++ b/worker/lib/circuit-breaker.ts
@@ -454,6 +454,10 @@ export function resetAllMetrics(): void {
 
 /**
  * Create a new circuit breaker with the given name and options
+ * @param name Circuit breaker identifier
+ * @param options Optional configuration overrides (threshold, timeout, max calls)
+ * @param env Optional Worker environment bindings
+ * @returns Configured CircuitBreaker instance
  */
 export function createCircuitBreaker(
   name: string,
@@ -465,6 +469,11 @@ export function createCircuitBreaker(
 
 /**
  * Execute a function with circuit breaker protection
+ * @template T Return type of protected function
+ * @param circuitBreaker CircuitBreaker instance to guard execution
+ * @param fn Async operation to perform
+ * @returns Result of the operation if circuit is healthy or half-open trial succeeds
+ * @throws CircuitBreakerOpenError if circuit is open
  */
 export async function callWithCircuitBreaker<T>(
   circuitBreaker: CircuitBreaker,
@@ -475,6 +484,8 @@ export async function callWithCircuitBreaker<T>(
 
 /**
  * Get metrics for a circuit breaker
+ * @param circuitBreaker CircuitBreaker instance
+ * @returns Collected call and state change metrics
  */
 export function getCircuitBreakerMetrics(
   circuitBreaker: CircuitBreaker,
@@ -484,6 +495,7 @@ export function getCircuitBreakerMetrics(
 
 /**
  * Reset a circuit breaker to closed state
+ * @param circuitBreaker CircuitBreaker instance
  */
 export async function resetCircuitBreaker(
   circuitBreaker: CircuitBreaker,

--- a/worker/lib/expiration/mark-expired.ts
+++ b/worker/lib/expiration/mark-expired.ts
@@ -7,6 +7,11 @@ import { sendExpiredNotifications } from "./notifications";
 // Mark Expired Deals
 // ============================================================================
 
+/**
+ * Scans production snapshot for active deals past their expiration date, marks them as rejected, and dispatches notifications
+ * @param env Worker environment bindings
+ * @returns Total count of deals marked as expired
+ */
 export async function markExpiredDeals(env: Env): Promise<number> {
   const snapshot = await getProductionSnapshot(env);
   if (!snapshot) {

--- a/worker/lib/expiration/validation.ts
+++ b/worker/lib/expiration/validation.ts
@@ -9,6 +9,12 @@ import { storeValidationStats } from "./scheduling";
 // Deal Validation
 // ============================================================================
 
+/**
+ * Validates a batch of active deals for expiration, code availability, URL format, and reward bounds
+ * @param env Worker environment bindings
+ * @param batchSize Number of active deals to evaluate in this batch (default 50)
+ * @returns Summary containing count of validated and invalid deals, error log, and detailed results
+ */
 export async function validateDealsBatch(
   env: Env,
   batchSize: number = 50,
@@ -122,6 +128,11 @@ export async function validateDealsBatch(
   };
 }
 
+/**
+ * Scans active deals in the production snapshot and deactivates any invalid or expired deals
+ * @param env Worker environment bindings
+ * @returns Object summarizing total deactivated count, deactivated deal IDs, and errors encountered
+ */
 export async function deactivateInvalidDeals(env: Env): Promise<{
   deactivated: number;
   deals: string[];


### PR DESCRIPTION
## What was found
Public exported functions in `worker/lib/expiration/validation.ts`, `worker/lib/expiration/mark-expired.ts`, and `worker/lib/circuit-breaker.ts` were missing JSDoc annotations.

## What was changed
- Added JSDoc `@param`, `@returns`, and `@throws` comments to `validateDealsBatch` and `deactivateInvalidDeals` in `worker/lib/expiration/validation.ts`.
- Added JSDoc comments to `markExpiredDeals` in `worker/lib/expiration/mark-expired.ts`.
- Added JSDoc comments to `createCircuitBreaker`, `callWithCircuitBreaker`, `getCircuitBreakerMetrics`, and `resetCircuitBreaker` in `worker/lib/circuit-breaker.ts`.

## Quality Gate
Status: PASS ✅
Command used: `./scripts/quality_gate.sh` and `npm run test:unit`

## Audit files location
`plans/jules-audit/`

## Skipped / Needs Human Review
Track B (Quality) was skipped due to 0 actionable findings.

---
*PR created automatically by Jules for task [2777338672120555092](https://jules.google.com/task/2777338672120555092) started by @do-ops885*