### PR TITLE
chore(metrics): record v0.19.14 ci unblock completion

### DIFF
--- a/.agents/metrics/metrics-opencode.jsonl
+++ b/.agents/metrics/metrics-opencode.jsonl
@@ -13,3 +13,4 @@
 {"timestamp": "2026-09-05T17:10:52Z", "agent": "opencode", "task": "goap doc-sync v0.19.9 post 754 merge wave (PR 755)", "status": "completed"}
 {"timestamp": "2026-09-05T17:45:00Z", "agent": "opencode", "task": "plans folder cleanup, archive 14 stale docs (PR 757)", "status": "completed"}
 {"timestamp": "2026-09-05T18:10:00Z", "agent": "opencode", "task": "close t-2 t-3 t-4 test gaps, 95 tests (PR 759)", "status": "completed"}
+{"timestamp": "2026-09-07T11:05:00Z", "agent": "opencode", "task": "ci unblock eresolve full hygiene sweep pr780", "status": "completed"}

--- a/.github/ci-status/ci-status.json
+++ b/.github/ci-status/ci-status.json
@@ -1,6 +1,6 @@
 {
   "status": "passing",
-  "last_run": "2026-09-05T16:52:06Z",
+  "last_run": "2026-09-07T11:02:40Z",
   "failing_jobs": [],
-  "workflow_url": "https://github.com/do-ops885/do-deal-relay/actions/runs/33979017192"
+  "workflow_url": "https://github.com/do-ops885/do-deal-relay/actions/runs/34114205939"
 }


### PR DESCRIPTION
What: record PR 780 metrics entry and refresh ci-status artifact to green main b37c1f1. No code change.

Why: metrics-opencode entry was uncommitted post-merge. ci-status file was stale from 2026-09-05.

Impact: docs and status only. CI expected green.