### PR TITLE
refactor(rate-limit): extract endpoint config table to own module

### DIFF
--- a/.agents/metrics/metrics-opencode.jsonl
+++ b/.agents/metrics/metrics-opencode.jsonl
@@ -14,3 +14,4 @@
 {"timestamp": "2026-09-05T17:45:00Z", "agent": "opencode", "task": "plans folder cleanup, archive 14 stale docs (PR 757)", "status": "completed"}
 {"timestamp": "2026-09-05T18:10:00Z", "agent": "opencode", "task": "close t-2 t-3 t-4 test gaps, 95 tests (PR 759)", "status": "completed"}
 {"timestamp": "2026-09-07T11:05:00Z", "agent": "opencode", "task": "ci unblock eresolve full hygiene sweep pr780", "status": "completed"}
+{"timestamp": "2026-09-07T11:20:00Z", "agent": "opencode", "task": "metrics v0.19.14 sync pr781", "status": "completed"}

--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -2,7 +2,7 @@
 
 **Generated**: 2026-07-06
 **Last Updated**: 2026-09-07
-**Version**: 0.19.14
+**Version**: 0.19.15
 **Status**: Active — 2026-09-07 CI unblock + full hygiene ( vitest/zod pins, webhook hermeticity, CI scripts, circuit-breaker split). Prior: v0.19.13 deep re-verification.
 **Note**: GOAP Version tracks this register only. System version is solely `VERSION` (0.1.8) per AGENTS.md single-source rule.
 **Sources**: [Codebase Audit (04/04)](../reports/analysis/codebase-audit-2026-04-04.md), [Swarm Analysis (04/04)](../reports/analysis/swarm-missing-implementations-2026-04-04.md), [Feature Gap Analysis](../reports/analysis/feature-gap-analysis.md), [ADR-015](ADR-015-harness-cloudflare-2026-best-practices.md), [ADR-024](ADR-024-skill-version-independence.md)
@@ -21,7 +21,7 @@ Branch: `fix/ci-unblock-eresolve-full-hygiene`. Spec: [SPEC-ci-unblock-full-hygi
 | CI-SCRIPTS | check/update-ci-status missed main (limit 5, CI-only, any-branch) | P2 | ✅ CLOSED — branch main, limit 20, newest-commit rollup across workflows | scripts/check-ci-status.sh, update-ci-status.sh |
 | DEP-MAJORS | dependabot majors can re-break main | P2 | ✅ CLOSED — ignore vitest>=5, @vitest/*>=5, zod>=4 | .github/dependabot.yml, ADR-029 |
 | LOC-504 | worker/lib/circuit-breaker.ts 504/500 quality-gate warning | P2 | ✅ CLOSED — extract metrics to circuit-breaker-metrics.ts (431 + 75) | worker/lib/circuit-breaker.ts, circuit-breaker-metrics.ts |
-| LOC-496 | worker/lib/rate-limit.ts 496/500 fragile | P3 | ⬜ DEFERRED — passes gate, split only if growth resumes | ADR-029 |
+| LOC-496 | worker/lib/rate-limit.ts 496/500 fragile | P3 | ✅ CLOSED — endpoint-limit table extracted to rate-limit-config.ts (445 + 79); public API re-exported, zero importer changes | worker/lib/rate-limit.ts, rate-limit-config.ts |
 
 Verification: `npm ci` clean, `npx tsc --noEmit` clean, `npm run test:unit`, `npm run validate`, `npm run build`, `./scripts/quality_gate.sh` exit 0. Full-hygiene scope per operator 2026-09-07.
 

--- a/worker/lib/rate-limit-config.ts
+++ b/worker/lib/rate-limit-config.ts
@@ -1,0 +1,79 @@
+/**
+ * Rate Limit Configuration
+ *
+ * Endpoint limit table and per-key config helpers extracted from
+ * `worker/lib/rate-limit.ts` to keep both modules under the
+ * `MAX_LINES_PER_SOURCE_FILE=500` limit. Zero behavior change.
+ *
+ * @module worker/lib/rate-limit-config
+ */
+
+import type { AuthResult } from "./auth";
+
+export interface RateLimitConfig {
+  maxRequests: number;
+  windowSeconds: number;
+  keyPrefix: string;
+}
+
+export const DEFAULT_CONFIG: RateLimitConfig = {
+  maxRequests: 100,
+  windowSeconds: 60,
+  keyPrefix: "ratelimit",
+};
+
+function cfg(
+  maxRequests: number,
+  keySuffix: string,
+  windowSeconds = 60,
+): RateLimitConfig {
+  return { maxRequests, windowSeconds, keyPrefix: "ratelimit:" + keySuffix };
+}
+
+export const ENDPOINT_LIMITS: Record<string, RateLimitConfig> = {
+  "/api/submit": cfg(10, "submit"),
+  "/api/discover": cfg(5, "discover", 300),
+  "/api/research": cfg(20, "research"),
+  "/api/email/incoming": cfg(30, "email"),
+  "/api/email/parse": cfg(20, "email-parse"),
+  "/api/validate/url": cfg(20, "validate"),
+  "/api/validate/batch": cfg(5, "validate-batch", 300),
+  "/api/semantic-search": cfg(10, "semantic"),
+  "/api/auth/register": cfg(5, "auth-register"),
+  "/api/auth/login": cfg(10, "auth-login"),
+  "/api/auth/refresh": cfg(20, "auth-refresh"),
+  "/api/nlq": cfg(10, "nlq"),
+  "/api/experience": cfg(20, "experience"),
+  "/deals": cfg(60, "deals"),
+  "/webhooks/incoming": cfg(50, "webhook"),
+  default: DEFAULT_CONFIG,
+};
+
+export const SENSITIVE_ENDPOINTS = new Set([
+  "/api/auth/register",
+  "/api/auth/login",
+  "/api/auth/refresh",
+  "/api/submit",
+  "/api/email/incoming",
+  "/api/email/parse",
+  "/api/validate/url",
+  "/api/validate/batch",
+  "/webhooks/incoming",
+]);
+
+/** Parse per-key rate limit config from AuthResult metadata. */
+export function getPerKeyRateLimitConfig(
+  auth: AuthResult,
+): RateLimitConfig | undefined {
+  if (!auth.requestsPerMinute && !auth.requestsPerHour) return undefined;
+  return {
+    maxRequests: auth.requestsPerMinute ?? DEFAULT_CONFIG.maxRequests,
+    windowSeconds: 60,
+    keyPrefix: "ratelimit:user",
+  };
+}
+
+/** Get rate limit configuration for an endpoint. */
+export function getRateLimitConfig(endpoint: string): RateLimitConfig {
+  return ENDPOINT_LIMITS[endpoint] ?? DEFAULT_CONFIG;
+}

--- a/worker/lib/rate-limit.ts
+++ b/worker/lib/rate-limit.ts
@@ -13,12 +13,22 @@ import { logger } from "./global-logger";
 import { toErrMessage } from "./errors";
 import { checkRateLimitViaBinding } from "./rate-limit-binding";
 import { listAllKvKeys } from "./kv-pagination";
+import {
+  DEFAULT_CONFIG,
+  ENDPOINT_LIMITS,
+  SENSITIVE_ENDPOINTS,
+  getPerKeyRateLimitConfig,
+} from "./rate-limit-config";
+import type { RateLimitConfig } from "./rate-limit-config";
 
-export interface RateLimitConfig {
-  maxRequests: number;
-  windowSeconds: number;
-  keyPrefix: string;
-}
+export type { RateLimitConfig } from "./rate-limit-config";
+export {
+  DEFAULT_CONFIG,
+  ENDPOINT_LIMITS,
+  SENSITIVE_ENDPOINTS,
+  getPerKeyRateLimitConfig,
+  getRateLimitConfig,
+} from "./rate-limit-config";
 
 export interface RateLimitResult {
   allowed: boolean;
@@ -56,53 +66,9 @@ interface RateLimitState {
   windowStart: number;
 }
 
-const DEFAULT_CONFIG: RateLimitConfig = {
-  maxRequests: 100,
-  windowSeconds: 60,
-  keyPrefix: "ratelimit",
-};
 const DEFAULT_KV_MAX_REQUESTS = 100;
 const DEFAULT_KV_WINDOW_SECONDS = 60;
 const KV_KEY_PREFIX = "rl:kv";
-
-function cfg(
-  maxRequests: number,
-  keySuffix: string,
-  windowSeconds = 60,
-): RateLimitConfig {
-  return { maxRequests, windowSeconds, keyPrefix: "ratelimit:" + keySuffix };
-}
-
-const ENDPOINT_LIMITS: Record<string, RateLimitConfig> = {
-  "/api/submit": cfg(10, "submit"),
-  "/api/discover": cfg(5, "discover", 300),
-  "/api/research": cfg(20, "research"),
-  "/api/email/incoming": cfg(30, "email"),
-  "/api/email/parse": cfg(20, "email-parse"),
-  "/api/validate/url": cfg(20, "validate"),
-  "/api/validate/batch": cfg(5, "validate-batch", 300),
-  "/api/semantic-search": cfg(10, "semantic"),
-  "/api/auth/register": cfg(5, "auth-register"),
-  "/api/auth/login": cfg(10, "auth-login"),
-  "/api/auth/refresh": cfg(20, "auth-refresh"),
-  "/api/nlq": cfg(10, "nlq"),
-  "/api/experience": cfg(20, "experience"),
-  "/deals": cfg(60, "deals"),
-  "/webhooks/incoming": cfg(50, "webhook"),
-  default: DEFAULT_CONFIG,
-};
-
-const SENSITIVE_ENDPOINTS = new Set([
-  "/api/auth/register",
-  "/api/auth/login",
-  "/api/auth/refresh",
-  "/api/submit",
-  "/api/email/incoming",
-  "/api/email/parse",
-  "/api/validate/url",
-  "/api/validate/batch",
-  "/webhooks/incoming",
-]);
 
 /** Check rate limit via binding (primary) or KV (fallback). */
 export async function checkRateLimit(
@@ -461,23 +427,6 @@ export function createRateLimitKVMiddleware(
     response.headers.set("X-RateLimit-Reset", result.resetAt.toISOString());
     return response;
   };
-}
-
-/** Parse per-key rate limit config from AuthResult metadata. */
-export function getPerKeyRateLimitConfig(
-  auth: AuthResult,
-): RateLimitConfig | undefined {
-  if (!auth.requestsPerMinute && !auth.requestsPerHour) return undefined;
-  return {
-    maxRequests: auth.requestsPerMinute ?? DEFAULT_CONFIG.maxRequests,
-    windowSeconds: 60,
-    keyPrefix: "ratelimit:user",
-  };
-}
-
-/** Get rate limit configuration for an endpoint. */
-export function getRateLimitConfig(endpoint: string): RateLimitConfig {
-  return ENDPOINT_LIMITS[endpoint] ?? DEFAULT_CONFIG;
 }
 
 /** Reset rate limit state for a client and endpoint. */


### PR DESCRIPTION
What: extract endpoint limit table, sensitive set, and per-key config helpers from worker lib rate-limit to new rate-limit-config module. Re-export public API so all importers stay unchanged. Rate-limit goes 496 to 445 lines, config is 79 lines.

Why: closes LOC-496 deferred item from GOAP 0.19.14. File sat 4 lines under the 500 quality gate limit with zero growth margin.

Impact: zero behavior change. tsc clean, 2905 unit tests pass, validate 0 errors, quality gate exit 0.