### PR TITLE
fix(dependabot): remove invalid prerelease wildcard versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,11 +56,6 @@ updates:
           - "minor"
           - "patch"
     ignore:
-      - dependency-name: "*"
-        versions:
-          - "*-alpha*"
-          - "*-beta*"
-          - "*-rc*"
       # Pinned majors until dedicated migration specs land (ADR-029, ADR-030):
       # vitest 5 conflicts with @cloudflare/vitest-pool-workers 0.22.0 (peers vitest 4).
       # zod 4 migration complete (ADR-030); ignore removed.

--- a/scripts/validate-dependabot.js
+++ b/scripts/validate-dependabot.js
@@ -108,6 +108,34 @@ try {
           );
           process.exit(1);
         }
+        // Dependabot cloud rejects glob-style prerelease versions for npm
+        // (e.g. "*-alpha*"). Versions must use the package manager's
+        // standard range syntax (e.g. ">=5", "4.x", "^1.0.0").
+        // See https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#versions-ignore
+        if (ignoreEntry.versions !== undefined) {
+          if (!Array.isArray(ignoreEntry.versions)) {
+            console.error(
+              `${prefix} Ignore entry ${i} "versions" must be a list`,
+            );
+            process.exit(1);
+          }
+          for (const v of ignoreEntry.versions) {
+            if (typeof v !== "string") {
+              console.error(
+                `${prefix} Ignore entry ${i} has non-string version`,
+              );
+              process.exit(1);
+            }
+            if (v.includes("*") && /alpha|beta|rc|pre/i.test(v)) {
+              console.error(
+                `${prefix} Ignore entry ${i} has invalid npm version requirement "${v}": ` +
+                  `glob-style prerelease patterns (e.g. "*-alpha*") are rejected by Dependabot; ` +
+                  `remove the entry (Dependabot ignores prereleases by default) or use a standard range`,
+              );
+              process.exit(1);
+            }
+          }
+        }
       });
     }
   });

--- a/tests/unit/dependabot-patterns.test.ts
+++ b/tests/unit/dependabot-patterns.test.ts
@@ -78,28 +78,24 @@ describe("Dependabot Patterns and Wildcards", () => {
   });
 
   describe("Version Ignore Wildcards", () => {
-    it("npm correctly filters pre-release tags", () => {
-      const wildcards = npmUpdate.ignore.find(
-        (i: any) => i["dependency-name"] === "*",
-      ).versions;
-
-      expect(
-        wildcards.some((w: string) =>
-          minimatch("1.0.0-alpha", w, matchOptions),
-        ),
-      ).toBe(true);
-      expect(
-        wildcards.some((w: string) =>
-          minimatch("2.1.0-beta.1", w, matchOptions),
-        ),
-      ).toBe(true);
-      expect(
-        wildcards.some((w: string) => minimatch("3.0.0-rc.5", w, matchOptions)),
-      ).toBe(true);
-
-      expect(
-        wildcards.some((w: string) => minimatch("1.0.0", w, matchOptions)),
-      ).toBe(false);
+    it("npm does not use invalid prerelease wildcard versions", () => {
+      // Dependabot cloud rejects glob-style prerelease requirements such as
+      // "*-alpha*" for npm ("invalid version requirements for a npm ignore
+      // condition"). Dependabot ignores prereleases by default for stable
+      // dependencies, so no repo-wide "*" versions ignore is needed.
+      const ignores = npmUpdate.ignore ?? [];
+      for (const entry of ignores) {
+        const versions = entry.versions ?? [];
+        for (const v of versions) {
+          expect(
+            v.includes("*") && /alpha|beta|rc|pre/i.test(v),
+            `invalid npm ignore version "${v}"`,
+          ).toBe(false);
+        }
+      }
+      expect(ignores.some((i: any) => i["dependency-name"] === "*")).toBe(
+        false,
+      );
     });
 
     it("docker ecosystem is intentionally unconfigured", () => {
@@ -110,28 +106,22 @@ describe("Dependabot Patterns and Wildcards", () => {
       expect(dockerUpdate).toBeUndefined();
     });
 
-    it("configured pre-release wildcards exclude tags but not stable versions", () => {
-      // Guards the matching semantics of the repo-wide ignore wildcards:
-      // suffixed patterns must catch prefixed/qualified pre-release forms
-      // while leaving stable versions untouched.
-      const wildcards = npmUpdate.ignore.find(
-        (i: any) => i["dependency-name"] === "*",
-      ).versions;
+    it("vitest major pins use valid ranges to prevent eresolve", () => {
+      // vitest 5 conflicts with @cloudflare/vitest-pool-workers 0.22.0
+      // (peers vitest 4). The ignore entries must use standard npm range
+      // syntax accepted by Dependabot cloud (e.g. ">=5").
+      const ignores = npmUpdate.ignore ?? [];
+      const vitest = ignores.find(
+        (i: any) => i["dependency-name"] === "vitest",
+      );
+      const vitestScoped = ignores.find(
+        (i: any) => i["dependency-name"] === "@vitest/*",
+      );
 
-      expect(
-        wildcards.some((w: string) =>
-          minimatch("v1.0.0-alpha", w, matchOptions),
-        ),
-      ).toBe(true);
-      expect(
-        wildcards.some((w: string) =>
-          minimatch("myapp:1.0.0-rc1", w, matchOptions),
-        ),
-      ).toBe(true);
-
-      expect(
-        wildcards.some((w: string) => minimatch("v1.0.0", w, matchOptions)),
-      ).toBe(false);
+      expect(vitest).toBeDefined();
+      expect(vitestScoped).toBeDefined();
+      expect(vitest.versions).toContain(">=5");
+      expect(vitestScoped.versions).toContain(">=5");
     });
   });
 


### PR DESCRIPTION
What: Remove invalid npm ignore versions *-alpha*, *-beta*, *-rc* from .github/dependabot.yml. Harden scripts/validate-dependabot.js to reject glob prerelease versions. Update tests/unit/dependabot-patterns.test.ts to assert valid config and vitest >=5 pins.

Why: Dependabot cloud reports failure on main HEAD: invalid version requirements for npm ignore condition. Historical eresolve failures already fixed by 780-783. This was the sole remaining failing check on main.

Impact: Clears Dependabot config error on main. No runtime change. Unit 2905 pass, lint and quality gate pass.