### PR TITLE
Permanently retain KV fallback for 300s window rate limits

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -41,7 +41,8 @@ Every API response includes rate limit metadata in the headers:
 
 - **Default**: 100 requests per 60 seconds
 - **Deal Submission** (`/api/submit`): 10 requests per 60 seconds
-- **Manual Discovery** (`/api/discover`): 5 requests per 300 seconds
+- **Manual Discovery** (`/api/discover`): 5 requests per 300 seconds (enforced via KV path; see ADR-028 Addendum)
+- **Batch Validation** (`/api/validate/batch`): 5 requests per 300 seconds (enforced via KV path; see ADR-028 Addendum)
 - **Research** (`/api/research`): 20 requests per 60 seconds
 
 ## Endpoints

--- a/plans/ADR-028-rate-limit-binding-over-do.md
+++ b/plans/ADR-028-rate-limit-binding-over-do.md
@@ -66,9 +66,30 @@ Negative / accepted trade-offs:
   advisory (limit-1 on allow, 0 on deny) on the binding path. `Retry-After`
   keeps window-boundary arithmetic. No known client parses Remaining for
   flow control.
-- Two enforcement paths exist until the 300s endpoints are rethought
-  (either accept 60s windows with scaled limits, or keep KV permanently).
-  The selector keeps this branch in one module.
+- Two enforcement paths exist because 300s endpoints are intentionally kept
+  on the KV fallback path (see Addendum below). The selector keeps this branch
+  in one module.
+
+## Addendum (2026-09-07): Disposition of 300s Window Rate Limits
+
+### Context
+Following PR #762, two endpoints remained on the KV rate-limiting path due to
+their 300-second window requirements:
+- `POST /api/discover` (5 requests / 300 seconds)
+- `POST /api/validate/batch` (5 requests / 300 seconds)
+
+The Cloudflare Workers Rate Limiting binding natively supports only 10s and 60s
+time windows (`period: 10` or `period: 60`). A decision was required to either:
+(a) Rescale to 1 request / 60s using native Rate Limiting bindings; or
+(b) Keep KV rate limiting permanently for these two endpoints and document as intentional.
+
+### Decision
+Option (b) is selected: **Keep KV rate limiting permanently for `/api/discover` and `/api/validate/batch`**.
+
+### Rationale
+1. **Burst Dynamics vs. Pacing**: `/api/discover` (trigger manual discovery) and `/api/validate/batch` (batch validation) are heavy administrative/pipeline operations. Clients occasionally need to trigger 2–3 successive discovery runs or validation batches when debugging or executing complex workflows. Rescaling to 1 request per 60s would eliminate burst capacity and cause poor developer experience (DX).
+2. **Negligible Race Risk**: The check-then-set race condition in KV is only impactful under high-concurrency throughput. For low-limit endpoints (5 requests per 5 minutes), concurrent race attempts are extremely rare, and any minor undercount during a race condition carries minimal system impact compared to high-volume user endpoints.
+3. **Architectural Simplicity**: Retaining KV fallback logic for 300s windows requires zero runtime schema changes or new bindings, keeping worker configuration minimal while serving custom/extended rate windows cleanly.
 
 ## Verification
 

--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -63,7 +63,7 @@ Full Mode. Spec: [SPEC-rl1-rate-limit-binding.md](SPEC-rl1-rate-limit-binding.md
 
 | Item | Disposition | Evidence |
 |:---|:---|:---|
-| RL-1 KV check-then-set race | ✅ CLOSED — 60s endpoint limits now enforced by native binding (atomic colo-local counters); KV retained as fallback for 300s windows, per-key configs, and binding-less surfaces | `worker/lib/rate-limit-binding.ts`, `rate-limit.ts` binding-first path |
+| RL-1 KV check-then-set race | ✅ CLOSED — 60s endpoint limits now enforced by native binding (atomic colo-local counters); KV permanently retained as fallback for 300s windows (`/api/discover`, `/api/validate/batch` per ADR-028 Addendum), per-key configs, and binding-less surfaces | `worker/lib/rate-limit-binding.ts`, `rate-limit.ts` binding-first path |
 | DO rate-limit migration (ADR-017 scope) | ⛔ RETIRED — global DO limiter is a documented anti-pattern (Rules of Durable Objects); binding is the official primitive | ADR-028 |
 | Fail-closed policy | ✅ PRESERVED — sensitive endpoints block on binding error; non-sensitive fall back to KV | `rate-limit-binding.test.ts` error-path tests |
 | Test coverage | ✅ 13 new tests (selector matrix, key shape, allow/deny, 300s bypass, per-key bypass, absent-binding fallback, error fail-closed/fail-open) | `tests/unit/rate-limit-binding.test.ts` |

--- a/tests/unit/rate-limit-binding.test.ts
+++ b/tests/unit/rate-limit-binding.test.ts
@@ -147,7 +147,11 @@ describe("checkRateLimit binding integration", () => {
 
     vi.clearAllMocks();
 
-    const batchResult = await checkRateLimit(env, "user:1", "/api/validate/batch");
+    const batchResult = await checkRateLimit(
+      env,
+      "user:1",
+      "/api/validate/batch",
+    );
     expect(batchResult.allowed).toBe(true);
     expect(env.DEALS_LOCK.put).toHaveBeenCalled();
   });

--- a/tests/unit/rate-limit-binding.test.ts
+++ b/tests/unit/rate-limit-binding.test.ts
@@ -141,8 +141,14 @@ describe("checkRateLimit binding integration", () => {
   });
 
   it("uses KV path for 300s-window endpoints even when bindings exist", async () => {
-    const result = await checkRateLimit(env, "user:1", "/api/discover");
-    expect(result.allowed).toBe(true);
+    const discoverResult = await checkRateLimit(env, "user:1", "/api/discover");
+    expect(discoverResult.allowed).toBe(true);
+    expect(env.DEALS_LOCK.put).toHaveBeenCalled();
+
+    vi.clearAllMocks();
+
+    const batchResult = await checkRateLimit(env, "user:1", "/api/validate/batch");
+    expect(batchResult.allowed).toBe(true);
     expect(env.DEALS_LOCK.put).toHaveBeenCalled();
   });
 

--- a/worker/lib/rate-limit-binding.ts
+++ b/worker/lib/rate-limit-binding.ts
@@ -4,8 +4,8 @@
  * Maps endpoint rate-limit configs to the Workers Rate Limiting bindings
  * declared in wrangler.jsonc (`ratelimits`). The binding is the primary
  * enforcement path for standard 60-second windows; lib/rate-limit.ts falls
- * back to KV when no binding matches (300s windows, per-key overrides,
- * or deploy surfaces without the bindings).
+ * back to KV when no binding matches (intentionally preserved for 300s windows
+ * per ADR-028 Addendum, per-key overrides, or deploy surfaces without bindings).
  *
  * @module worker/lib/rate-limit-binding
  */

--- a/worker/lib/rate-limit-config.ts
+++ b/worker/lib/rate-limit-config.ts
@@ -32,11 +32,13 @@ function cfg(
 
 export const ENDPOINT_LIMITS: Record<string, RateLimitConfig> = {
   "/api/submit": cfg(10, "submit"),
+  // 300s window intentionally uses KV fallback path (ADR-028 Addendum)
   "/api/discover": cfg(5, "discover", 300),
   "/api/research": cfg(20, "research"),
   "/api/email/incoming": cfg(30, "email"),
   "/api/email/parse": cfg(20, "email-parse"),
   "/api/validate/url": cfg(20, "validate"),
+  // 300s window intentionally uses KV fallback path (ADR-028 Addendum)
   "/api/validate/batch": cfg(5, "validate-batch", 300),
   "/api/semantic-search": cfg(10, "semantic"),
   "/api/auth/register": cfg(5, "auth-register"),


### PR DESCRIPTION
Decided to permanently retain KV rate limiting fallback for 300s-window endpoints (/api/discover and /api/validate/batch at 5 requests / 300s) as Option (b) per ADR-028 Addendum. Updated documentation in docs/API.md, plans/ADR-028-rate-limit-binding-over-do.md, and plans/GOAP_STATE.md; updated code comments in worker/lib/rate-limit-binding.ts and worker/lib/rate-limit-config.ts; expanded unit tests in tests/unit/rate-limit-binding.test.ts to test both 300s endpoints.

Fixes #766

---
*PR created automatically by Jules for task [3095459481165162561](https://jules.google.com/task/3095459481165162561) started by @do-ops885*